### PR TITLE
Release v1.1.2 — AI/Prompt Layer, recipe tools & intent expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ app_data
 .mcpregistry_github_token
 
 *.tgz
+
+# Local maintenance scripts (not published)
+scripts/add-copyright-headers.ts

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ app_data
 
 *.tgz
 
+# Local planning docs (not published)
+docs/plans/
+
 # Local maintenance scripts (not published)
 scripts/add-copyright-headers.ts

--- a/README.md
+++ b/README.md
@@ -63,6 +63,34 @@ photoshop-mcp-ui [--port 5174] [--host 127.0.0.1] [--no-open]
 
 ---
 
+## AI/Prompt Layer for Photoshop
+
+On top of 55 atomic `photoshop_*` tools, the server ships an opinionated AI/prompt
+layer that helps host LLMs (Cursor, Claude Desktop, etc.) translate vague user
+requests into reliable Photoshop actions:
+
+- **Server `instructions`** — workflow contract advertised on MCP `initialize`
+  (ping once, state-before-action, prefer recipes, error recovery). See
+  [`src/prompts/instructions.ts`](src/prompts/instructions.ts).
+- **MCP `prompts` primitive** — 8 pre-engineered templates (`ps.enhance_portrait`,
+  `ps.remove_background`, `ps.prepare_for_web`, …) via `prompts/list` and
+  `prompts/get`.
+- **Recipe tools** — 7 outcome-oriented `photoshop_recipe_*` tools (remove
+  background, enhance portrait, prepare for web, export social variants, color
+  grade, batch mockup, organize layers). Each wraps steps in a single Photoshop
+  history state (one Undo reverts all).
+- **State & preview** — `photoshop_get_state` (cheap snapshot),
+  `photoshop_get_preview` (base64 JPEG for vision verification),
+  `photoshop_get_capabilities` (version-aware feature flags).
+- **Structured errors** — failures return JSON envelopes with `code` and
+  `suggested_next_tool` for self-correction.
+
+Full reference: [`docs/prompt-layer.md`](docs/prompt-layer.md).
+
+Verify parity: `npm run verify:photoshop-prompts`
+
+---
+
 ## Example Prompts
 
 Below are example prompts you can use with AI assistants (Claude, Cursor, etc.) when this MCP server is configured:

--- a/README.md
+++ b/README.md
@@ -75,13 +75,14 @@ requests into reliable Photoshop actions:
 - **Server `instructions`** — workflow contract advertised on MCP `initialize`
   (ping once, state-before-action, prefer recipes, error recovery). See
   [`src/prompts/instructions.ts`](src/prompts/instructions.ts).
-- **MCP `prompts` primitive** — 8 pre-engineered templates (`ps.enhance_portrait`,
-  `ps.remove_background`, `ps.prepare_for_web`, …) via `prompts/list` and
-  `prompts/get`.
-- **Recipe tools** — 8 outcome-oriented `photoshop_recipe_*` tools (remove
+- **MCP `prompts` primitive** — 16 pre-engineered templates (12 recipe + 4 guide:
+  `ps.enhance_portrait`, `ps.remove_background`, `ps.gradient_fade`, `ps.sky_blend`, …)
+  via `prompts/list` and `prompts/get`.
+- **Recipe tools** — 12 outcome-oriented `photoshop_recipe_*` tools (remove
   background, enhance portrait, prepare for web, export social variants, color
-  grade, frequency separation, batch mockup, organize layers). Each wraps steps
-  in a single Photoshop history state (one Undo reverts all).
+  grade, frequency separation, batch mockup, organize layers, gradient fade,
+  sky blend, dodge & burn, remove distraction). Each wraps steps in a single
+  Photoshop history state (one Undo reverts all).
 - **State & preview** — `photoshop_get_state` (cheap snapshot),
   `photoshop_get_preview` (base64 JPEG for vision verification),
   `photoshop_get_capabilities` (version-aware feature flags).
@@ -101,8 +102,8 @@ Local MCP integration tests run against a live Photoshop instance over stdio
 | Suite | Command | Result |
 |-------|---------|--------|
 | Full tool + recipe sweep | `npm run test:mcp-all` | **94 pass**, **0 fail**, **3 skip** (97 total) |
-| Prompt-layer smoke | `npm run test:mcp-local` | 8/8 prompt templates + core recipes |
-| Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 8↔8 strict match |
+| Prompt-layer smoke | `npm run test:mcp-local` | 16 prompt templates + core recipes |
+| Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 12↔12 strict match + 4 guides |
 
 **Tool coverage:** 66/66 atomic + recipe `photoshop_*` tools exercised sequentially.
 
@@ -423,7 +424,7 @@ Never guess — read get_state after a failure and propose the next single step.
 - ✅ **ExtendScript API**: Universal compatibility via AppleScript/COM automation
 - ✅ **Auto-Detection**: Automatically finds Photoshop installation on your system
 - ✅ **66+ Tools**: Atomic `photoshop_*` tools plus 8 recipe tools for comprehensive automation
-- ✅ **AI/Prompt Layer**: 8 MCP prompt templates, server instructions, state/preview/capabilities tools
+- ✅ **AI/Prompt Layer**: 16 MCP prompt templates (12 recipe + 4 guide), server instructions, state/preview/capabilities tools
 - ✅ **Document Management**: Create, open, save, close, crop documents
 - ✅ **Layer Operations**: Create, delete, duplicate, merge, transform layers
 - ✅ **Layer Properties**: Opacity, blend modes, visibility, locking

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Photoshop MCP Server
+
+*v1.1+ — recipe workflows, fewer round-trips, snappier sessions.*
+
 > **Note:** This is an unofficial, community-maintained project and is not affiliated with or endorsed by Adobe Inc.
 
 [![npm version](https://img.shields.io/npm/v/@alisaitteke/photoshop-mcp.svg)](https://www.npmjs.com/package/@alisaitteke/photoshop-mcp)
@@ -65,7 +68,7 @@ photoshop-mcp-ui [--port 5174] [--host 127.0.0.1] [--no-open]
 
 ## AI/Prompt Layer for Photoshop
 
-On top of 55 atomic `photoshop_*` tools, the server ships an opinionated AI/prompt
+On top of atomic `photoshop_*` tools, the server ships an opinionated AI/prompt
 layer that helps host LLMs (Cursor, Claude Desktop, etc.) translate vague user
 requests into reliable Photoshop actions:
 
@@ -75,10 +78,10 @@ requests into reliable Photoshop actions:
 - **MCP `prompts` primitive** — 8 pre-engineered templates (`ps.enhance_portrait`,
   `ps.remove_background`, `ps.prepare_for_web`, …) via `prompts/list` and
   `prompts/get`.
-- **Recipe tools** — 7 outcome-oriented `photoshop_recipe_*` tools (remove
+- **Recipe tools** — 8 outcome-oriented `photoshop_recipe_*` tools (remove
   background, enhance portrait, prepare for web, export social variants, color
-  grade, batch mockup, organize layers). Each wraps steps in a single Photoshop
-  history state (one Undo reverts all).
+  grade, frequency separation, batch mockup, organize layers). Each wraps steps
+  in a single Photoshop history state (one Undo reverts all).
 - **State & preview** — `photoshop_get_state` (cheap snapshot),
   `photoshop_get_preview` (base64 JPEG for vision verification),
   `photoshop_get_capabilities` (version-aware feature flags).
@@ -89,11 +92,144 @@ Full reference: [`docs/prompt-layer.md`](docs/prompt-layer.md).
 
 Verify parity: `npm run verify:photoshop-prompts`
 
+### Integration test results
+
+Local MCP integration tests run against a live Photoshop instance over stdio
+(same path as Cursor / Claude Desktop). Last verified on **Photoshop 26.5.0**
+(macOS).
+
+| Suite | Command | Result |
+|-------|---------|--------|
+| Full tool + recipe sweep | `npm run test:mcp-all` | **94 pass**, **0 fail**, **3 skip** (97 total) |
+| Prompt-layer smoke | `npm run test:mcp-local` | 8/8 prompt templates + core recipes |
+| Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 8↔8 strict match |
+
+**Tool coverage:** 66/66 atomic + recipe `photoshop_*` tools exercised sequentially.
+
+**Intentional skips** (environment-dependent, not regressions):
+
+| Tool | Reason |
+|------|--------|
+| `photoshop_play_action` | Requires a real Actions palette entry on the machine |
+| `photoshop_recipe_remove_background` | Synthetic test canvas has no recognizable subject for Select Subject |
+| `photoshop_recipe_batch_mockup_replace` | Requires a Smart Object mockup PSD |
+
+**PS 26 compatibility notes** (ExtendScript): layer masks use `stringID make`;
+mask apply uses `delete` + `apply: true`; hue/saturation uses `Hst2` descriptors;
+frequency separation uses `applyImageEvent` calculation descriptors. See
+[`src/api/extendscript.ts`](src/api/extendscript.ts) and
+[`src/tools/recipes/_shared.ts`](src/tools/recipes/_shared.ts).
+
+Prerequisites: Photoshop installed and scriptable; run from the repo root after
+`npm run build:server`.
+
 ---
 
 ## Example Prompts
 
-Below are example prompts you can use with AI assistants (Claude, Cursor, etc.) when this MCP server is configured:
+Below are example prompts you can use with AI assistants (Claude, Cursor, etc.)
+when this MCP server is configured. Prefer **recipe tools** (`photoshop_recipe_*`)
+for multi-step outcomes — each recipe is a single undo step. Use atomic
+`photoshop_*` tools only for fine-grained edits no recipe covers.
+
+<details>
+<summary>🧠 State-aware session (recommended first step)</summary>
+
+```
+Ping Photoshop and read capabilities for my installed version.
+Get the current document state before changing anything.
+Open portrait.jpg, get a downscaled preview so you can verify the subject.
+After each major recipe, get another preview to confirm the result.
+```
+
+</details>
+
+<details>
+<summary>👤 Portrait retouch (recipe)</summary>
+
+```
+Enhance the portrait on the active layer at medium intensity with skin smoothing.
+Use the enhance-portrait recipe — I want frequency separation + auto-tone in one undoable step.
+If the active layer is text or a Smart Object, rasterize first or pick a raster layer.
+Show me a preview when done.
+```
+
+Equivalent MCP prompt template: `ps.enhance_portrait` with `{ intensity: "medium", skin_smoothing: "true" }`.
+
+</details>
+
+<details>
+<summary>✂️ Background removal (recipe)</summary>
+
+```
+Remove the background from the active portrait layer.
+Use Select Subject + a layer mask with a 2px feather. Keep the original pixels behind the mask.
+The subject must be on the active layer — not a flat color fill.
+```
+
+Equivalent MCP prompt template: `ps.remove_background` with `{ feather_px: "2", keep_shadow: "false" }`.
+
+</details>
+
+<details>
+<summary>🎨 Color grade (recipe)</summary>
+
+```
+Apply a warm film color grade to the open document as non-destructive adjustment layers.
+Use the apply-color-grade recipe with preset warm_film.
+Preview the result when finished.
+```
+
+</details>
+
+<details>
+<summary>🔬 Frequency separation setup (recipe)</summary>
+
+```
+Set up frequency separation on the active raster layer with a 6px blur radius.
+I will paint on the Low and High layers myself — do not apply extra smoothing.
+Tell me which layers to edit when the stack is ready.
+```
+
+Equivalent MCP prompt template: `ps.frequency_separation` with `{ radius_px: "6" }`.
+
+</details>
+
+<details>
+<summary>🌐 Prepare for web + social export (recipes)</summary>
+
+```
+Prepare the active document for web: sRGB, downscale, sharpen, export one optimized JPEG to ~/.photoshop-mcp/exports.
+Then export Instagram post and X post variants as separate JPEGs from the same document.
+List the output paths in a table.
+```
+
+Equivalent templates: `ps.prepare_for_web`, `ps.export_social_variants`.
+
+</details>
+
+<details>
+<summary>📦 Batch mockup replace (recipe)</summary>
+
+```
+I have a mockup PSD open with a Smart Object layer named "Screen".
+Replace it with every PNG/JPG in ~/assets/mockups/ and export one JPEG per asset.
+Do not place flat layers — swap the Smart Object so perspective is preserved.
+```
+
+Equivalent MCP prompt template: `ps.batch_mockup_replace`.
+
+</details>
+
+<details>
+<summary>🗂️ Organize layers (recipe)</summary>
+
+```
+Organize the layer stack: rename by kind, auto-group related layers, preserve originals.
+Run the organize-layers recipe, then list layers so I can review the new structure.
+```
+
+</details>
 
 <details>
 <summary>🎨 Basic Design Creation</summary>
@@ -128,10 +264,9 @@ Save as adventure.jpg with quality 10.
 
 ```
 Open photo.jpg from my Desktop in Photoshop.
-Apply auto levels and auto contrast.
-Apply unsharp mask with amount 120%, radius 1.5, threshold 0.
-Increase saturation by 15.
-Crop to remove 100px from each edge.
+Get state, then run the enhance-portrait recipe at low intensity.
+If I only need quick tone fixes, apply auto levels, auto contrast, and unsharp mask (120%, 1.5, 0) on the active layer instead.
+Adjust hue +15 and saturation +15, or use prepare-for-web when I'm ready to export.
 Save as enhanced-photo.jpg with quality 12.
 ```
 
@@ -269,8 +404,17 @@ Redo 1 step to bring back one operation.
 ```
 
 </details>
----
-> **🎨 50+ Tools** | **🖥️ Cross-Platform** | **📦 NPX Ready** | **🔧 ExtendScript API** | **⏮️ Undo/Redo**
+
+<details>
+<summary>🔁 Error recovery (structured envelopes)</summary>
+
+```
+If a recipe returns version_unsupported or generative_unavailable, call get_capabilities and tell me which Photoshop feature is missing.
+If a tool fails with suggested_next_tool, follow that hint (e.g. rasterize_layer before a raster-only recipe).
+Never guess — read get_state after a failure and propose the next single step.
+```
+
+</details>
 
 ## Features
 
@@ -278,7 +422,8 @@ Redo 1 step to bring back one operation.
 - ✅ **Supports Photoshop 2012-2025+**
 - ✅ **ExtendScript API**: Universal compatibility via AppleScript/COM automation
 - ✅ **Auto-Detection**: Automatically finds Photoshop installation on your system
-- ✅ **50+ Tools**: Comprehensive Photoshop automation
+- ✅ **66+ Tools**: Atomic `photoshop_*` tools plus 8 recipe tools for comprehensive automation
+- ✅ **AI/Prompt Layer**: 8 MCP prompt templates, server instructions, state/preview/capabilities tools
 - ✅ **Document Management**: Create, open, save, close, crop documents
 - ✅ **Layer Operations**: Create, delete, duplicate, merge, transform layers
 - ✅ **Layer Properties**: Opacity, blend modes, visibility, locking
@@ -1313,6 +1458,15 @@ npm run lint
 npm run format
 ```
 
+### Integration tests (requires running Photoshop)
+
+```bash
+npm run build:server
+npm run test:mcp-local    # prompt-layer smoke
+npm run test:mcp-all      # full sequential tool sweep
+npm run verify:photoshop-prompts
+```
+
 ## Quick Start Examples
 
 ### 💡 Common Use Cases
@@ -1327,6 +1481,12 @@ npm run format
 | **Text Styling** | "Change text to Helvetica 64pt, color red, center aligned" |
 | **Batch Work** | "Resize to 1080x1080, auto contrast, save as square.jpg, close" |
 | **Masks** | "Select rectangle 100,100 to 500,500, create layer mask" |
+| **Portrait recipe** | "Enhance portrait at medium intensity with skin smoothing, then preview" |
+| **Background removal** | "Remove background from active layer, 2px feather, non-destructive mask" |
+| **Web export** | "Prepare for web + export Instagram and X post variants to exports folder" |
+| **Color grade** | "Apply warm_film color grade as adjustment layers" |
+| **Frequency separation** | "Build FS stack at 6px — I'll paint the Low/High layers myself" |
+| **State check** | "Ping Photoshop, get capabilities, then get_state before editing" |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ requests into reliable Photoshop actions:
   background, enhance portrait, prepare for web, export social variants, color
   grade, frequency separation, batch mockup, organize layers, gradient fade,
   sky blend, dodge & burn, remove distraction). Each wraps steps in a single
-  Photoshop history state (one Undo reverts all).
+  Photoshop history state (one Undo reverts all). **78 tools total** (66 atomic
+  + 12 recipe).
 - **State & preview** — `photoshop_get_state` (cheap snapshot),
   `photoshop_get_preview` (base64 JPEG for vision verification),
   `photoshop_get_capabilities` (version-aware feature flags).
@@ -99,13 +100,17 @@ Local MCP integration tests run against a live Photoshop instance over stdio
 (same path as Cursor / Claude Desktop). Last verified on **Photoshop 26.5.0**
 (macOS).
 
+*Recorded on PS 26.5.0 before the intent-expansion tools landed; counts predate
+the 4 new atomics + 4 new recipes — re-run `npm run test:mcp-all` to refresh.*
+
 | Suite | Command | Result |
 |-------|---------|--------|
 | Full tool + recipe sweep | `npm run test:mcp-all` | **94 pass**, **0 fail**, **3 skip** (97 total) |
 | Prompt-layer smoke | `npm run test:mcp-local` | 16 prompt templates + core recipes |
 | Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 12↔12 strict match + 4 guides |
 
-**Tool coverage:** 66/66 atomic + recipe `photoshop_*` tools exercised sequentially.
+**Tool coverage:** 78 total tools (66 atomic `photoshop_*` + 12 recipe
+`photoshop_recipe_*`) — re-run `npm run test:mcp-all` for a fresh pass count.
 
 **Intentional skips** (environment-dependent, not regressions):
 
@@ -423,7 +428,7 @@ Never guess — read get_state after a failure and propose the next single step.
 - ✅ **Supports Photoshop 2012-2025+**
 - ✅ **ExtendScript API**: Universal compatibility via AppleScript/COM automation
 - ✅ **Auto-Detection**: Automatically finds Photoshop installation on your system
-- ✅ **66+ Tools**: Atomic `photoshop_*` tools plus 8 recipe tools for comprehensive automation
+- ✅ **78 Tools**: 66 atomic `photoshop_*` + 12 recipe `photoshop_recipe_*`
 - ✅ **AI/Prompt Layer**: 16 MCP prompt templates (12 recipe + 4 guide), server instructions, state/preview/capabilities tools
 - ✅ **Document Management**: Create, open, save, close, crop documents
 - ✅ **Layer Operations**: Create, delete, duplicate, merge, transform layers
@@ -431,8 +436,8 @@ Never guess — read get_state after a failure and propose the next single step.
 - ✅ **Text Formatting**: Font, size, color, alignment controls
 - ✅ **Image Placement**: Place images, open files, fit to document
 - ✅ **Filters**: Gaussian Blur, Sharpen, Noise, Motion Blur
-- ✅ **Color Adjustments**: Brightness/Contrast, Hue/Saturation, Auto Levels/Contrast
-- ✅ **Selections & Masks**: Rectangular selections, layer masks
+- ✅ **Color Adjustments**: Brightness/Contrast, Hue/Saturation, Curves, Auto Levels/Contrast
+- ✅ **Selections & Masks**: Rectangular selections, select subject, content-aware fill, gradient mask, layer masks
 - ✅ **History Control**: Undo/Redo operations, view history states
 - ✅ **Actions**: Play recorded actions, execute custom scripts
 - ✅ **Auto-Rasterize**: Automatically converts layers when needed for filters
@@ -952,6 +957,17 @@ Apply auto contrast adjustment.
 photoshop_auto_contrast()
 ```
 
+#### `photoshop_adjust_curves`
+Create a Curves adjustment layer on the active document.
+
+**Parameters:**
+- `preset` (string, optional): `auto_tone` (S-curve) or `neutral` (identity curve); default `auto_tone`
+
+```javascript
+// Example: Auto-tone S-curve
+photoshop_adjust_curves({ preset: 'auto_tone' })
+```
+
 #### `photoshop_desaturate`
 Desaturate the layer (convert to grayscale).
 
@@ -1088,6 +1104,43 @@ Apply (merge) the layer mask to the layer.
 ```javascript
 // Example: Apply mask
 photoshop_apply_layer_mask()
+```
+
+#### `photoshop_select_subject`
+Run Select Subject on the active layer (pixel selection only, no mask). Requires Photoshop 23+.
+
+**Parameters:**
+- `sample_all_layers` (boolean, optional): Sample all layers for autoCutout fallback; default `false`
+
+```javascript
+// Example: Select the main subject
+photoshop_select_subject()
+```
+
+#### `photoshop_content_aware_fill`
+Fill the current pixel selection using Content-Aware Fill. Requires an active selection.
+
+```javascript
+// Example: Remove selected distraction
+photoshop_content_aware_fill()
+```
+
+#### `photoshop_apply_gradient_mask`
+Apply a linear black-to-white gradient on the active layer mask (fade/blend).
+
+**Parameters:**
+- `direction` (string, optional): Fade direction — `bottom_to_top`, `top_to_bottom`, `left_to_right`, `right_to_left`; default `bottom_to_top`
+- `start_pct` (number, optional): Gradient start along fade axis (0–100); default `0`
+- `end_pct` (number, optional): Gradient end along fade axis (0–100); default `100`
+- `angle_deg` (number, optional): Override gradient angle in degrees
+
+```javascript
+// Example: Fade subject into background from bottom
+photoshop_apply_gradient_mask({
+  direction: 'bottom_to_top',
+  start_pct: 0,
+  end_pct: 100
+})
 ```
 
 ### History & Undo/Redo
@@ -1511,7 +1564,7 @@ photoshop-mcp/
 │   │   ├── photoshop-api.ts    # API factory
 │   │   ├── batch-play.ts       # UXP batchPlay helpers (legacy)
 │   │   └── extendscript.ts     # ExtendScript snippets library
-│   ├── tools/            # MCP tool implementations (42+ tools)
+│   ├── tools/            # MCP tool implementations (78 tools: 66 atomic + 12 recipe)
 │   │   ├── document-tools.ts        # Document operations
 │   │   ├── layer-tools.ts           # Layer creation/deletion
 │   │   ├── layer-properties-tools.ts # Opacity, blend modes, etc.
@@ -1521,8 +1574,11 @@ photoshop-mcp/
 │   │   ├── filter-tools.ts          # Blur, sharpen, noise
 │   │   ├── adjustment-tools.ts      # Color adjustments
 │   │   ├── text-tools.ts            # Text formatting
-│   │   ├── selection-tools.ts       # Selections & masks
-│   │   └── action-tools.ts          # Actions & custom scripts
+│   │   ├── selection-tools.ts       # Selections & subject isolation
+│   │   ├── mask-tools.ts            # Gradient mask blending
+│   │   ├── state-tools.ts           # State, preview, capabilities
+│   │   ├── action-tools.ts          # Actions & custom scripts
+│   │   └── recipes/                 # 12 outcome-oriented recipe tools
 │   └── utils/            # Utilities
 │       └── logger.ts     # Logging system (stderr-based)
 └── examples/             # Configuration examples

--- a/docs/plans/prompt-intent-expansion/README.md
+++ b/docs/plans/prompt-intent-expansion/README.md
@@ -2,16 +2,30 @@
 
 Expand the Photoshop MCP prompt layer so host LLMs map colloquial user language (blogs, Reddit, natural chat) to the correct `photoshop_recipe_*` / `photoshop_*` tools. Full stack: intent glossary, guide prompts, ExtendScript primitives, new recipes, verification.
 
+## Baseline → target
+
+| Layer | Baseline (today) | After Phase 5 | Anchor |
+|-------|------------------|---------------|--------|
+| Atomic tools | 55 | **59** (+4 core) | `src/core/server.ts:106-121` |
+| Recipe tools | 8 | 12 | `src/tools/recipes/index.ts:25-34` |
+| Recipe prompts | 8 | 12 | `src/prompts/registry.ts:12-21` |
+| Guide prompts | 0 | 4 | Phase 1 (`ps.gradient_blend`, etc.) |
+| Instructions | bootstrap + recipe list | + glossary, degrade paths, disambiguation | `src/prompts/instructions.ts:5-64` |
+| ExtendScript snippets | none for Tier A gaps | curves, gradient mask, select subject, content-aware (+ generative if spike OK) | `src/api/extendscript.ts:86+` |
+| Verify linter | strict 8↔8 recipe parity | 12↔12 recipes + separate guide list | `scripts/verify-photoshop-prompt-coverage.ts:44-80` |
+
+**Next step:** Phase 5 complete — see [phase-5-handoff.md](./phase-5-handoff.md).
+
 ## Phases
 
 | Phase | File | Layer | Status |
 |-------|------|-------|--------|
-| 0 | [phase-0-research.md](./phase-0-research.md) | research / spike | Ready to implement |
-| 1 | [phase-1-prompt-layer.md](./phase-1-prompt-layer.md) | prompt-layer | Blocked on Phase 0 (taxonomy); glossary text can draft in parallel |
-| 2 | [phase-2-extendscript.md](./phase-2-extendscript.md) | extendscript API | Blocked on Phase 0 spike |
-| 3 | [phase-3-atomic-tools.md](./phase-3-atomic-tools.md) | mcp-tools | Blocked on Phase 2 |
-| 4 | [phase-4-recipes.md](./phase-4-recipes.md) | recipes | Blocked on Phase 3 |
-| 5 | [phase-5-prompts-verify.md](./phase-5-prompts-verify.md) | prompts + verify + docs | Blocked on Phases 1 and 4 |
+| 0 | [phase-0-research.md](./phase-0-research.md) | research / spike | **Done** — [handoff](./phase-0-handoff.md) |
+| 1 | [phase-1-prompt-layer.md](./phase-1-prompt-layer.md) | prompt-layer | **Done** — [handoff](./phase-1-handoff.md) |
+| 2 | [phase-2-extendscript.md](./phase-2-extendscript.md) | extendscript API | **Done** — [handoff](./phase-2-handoff.md) |
+| 3 | [phase-3-atomic-tools.md](./phase-3-atomic-tools.md) | mcp-tools | **Done** — [handoff](./phase-3-handoff.md) |
+| 4 | [phase-4-recipes.md](./phase-4-recipes.md) | recipes | **Done** — [handoff](./phase-4-handoff.md) |
+| 5 | [phase-5-prompts-verify.md](./phase-5-prompts-verify.md) | prompts + verify + docs | **Done** — [handoff](./phase-5-handoff.md) |
 
 Handoff docs (`phase-N-handoff.md`) are written by the implementing agent after each phase completes.
 

--- a/docs/plans/prompt-intent-expansion/README.md
+++ b/docs/plans/prompt-intent-expansion/README.md
@@ -1,0 +1,49 @@
+# Prompt Intent Expansion
+
+Expand the Photoshop MCP prompt layer so host LLMs map colloquial user language (blogs, Reddit, natural chat) to the correct `photoshop_recipe_*` / `photoshop_*` tools. Full stack: intent glossary, guide prompts, ExtendScript primitives, new recipes, verification.
+
+## Phases
+
+| Phase | File | Layer | Status |
+|-------|------|-------|--------|
+| 0 | [phase-0-research.md](./phase-0-research.md) | research / spike | Ready to implement |
+| 1 | [phase-1-prompt-layer.md](./phase-1-prompt-layer.md) | prompt-layer | Blocked on Phase 0 (taxonomy); glossary text can draft in parallel |
+| 2 | [phase-2-extendscript.md](./phase-2-extendscript.md) | extendscript API | Blocked on Phase 0 spike |
+| 3 | [phase-3-atomic-tools.md](./phase-3-atomic-tools.md) | mcp-tools | Blocked on Phase 2 |
+| 4 | [phase-4-recipes.md](./phase-4-recipes.md) | recipes | Blocked on Phase 3 |
+| 5 | [phase-5-prompts-verify.md](./phase-5-prompts-verify.md) | prompts + verify + docs | Blocked on Phases 1 and 4 |
+
+Handoff docs (`phase-N-handoff.md`) are written by the implementing agent after each phase completes.
+
+## Confirmed decisions
+
+| Decision | Value |
+|----------|-------|
+| Backward compatibility | **No** strict compat on prompt/instruction/description **text** — may rewrite aggressively. Existing 55 atomic + 8 recipe **tool names and input schemas** stay unchanged. New tools/recipes are **additive**. |
+| Scope | **Full stack** — prompts + ExtendScript + atomics + recipes + verification. |
+| Dev platform | **macOS** (ExtendScript spike runs on user's machine). |
+| Scripting API | External MCP uses **ExtendScript only** — `UXPPhotoshopAPI` is not available for AppleScript/COM (`src/api/photoshop-api.ts:48-51`). |
+| Prompt parity model | **Recipe prompts** stay 1:1 with `photoshop_recipe_*`. **Guide prompts** (`ps.gradient_blend`, etc.) are registered separately — not in `RECIPE_TO_PROMPT`. |
+| Generative AI tools | **Gated on Phase 0 spike** — include only if `executeAction` descriptors work; else content-aware fallback + user handoff. |
+
+## Dependency order
+
+```mermaid
+flowchart LR
+  P0[Phase0_research] --> P1[Phase1_prompt_layer]
+  P0 --> P2[Phase2_extendscript]
+  P2 --> P3[Phase3_atomic_tools]
+  P3 --> P4[Phase4_recipes]
+  P1 --> P5[Phase5_prompts_verify]
+  P4 --> P5
+```
+
+## Popular topics (research summary)
+
+Tier A gaps (implement first): gradient mask blending, sky replacement, object/distraction removal, portrait/dodge-burn vocabulary, curves adjustment.
+
+See [intent-taxonomy.md](./intent-taxonomy.md) (produced in Phase 0) for phrase → tool mapping.
+
+## Reference plans in this repo
+
+No `docs/plans/session-status-timeline/` exists yet in this repo; this folder establishes the convention for photoshop-mcp.

--- a/docs/plans/prompt-intent-expansion/README.md
+++ b/docs/plans/prompt-intent-expansion/README.md
@@ -2,19 +2,20 @@
 
 Expand the Photoshop MCP prompt layer so host LLMs map colloquial user language (blogs, Reddit, natural chat) to the correct `photoshop_recipe_*` / `photoshop_*` tools. Full stack: intent glossary, guide prompts, ExtendScript primitives, new recipes, verification.
 
-## Baseline → target
+## Baseline → delivered
 
-| Layer | Baseline (today) | After Phase 5 | Anchor |
-|-------|------------------|---------------|--------|
-| Atomic tools | 55 | **59** (+4 core) | `src/core/server.ts:106-121` |
-| Recipe tools | 8 | 12 | `src/tools/recipes/index.ts:25-34` |
-| Recipe prompts | 8 | 12 | `src/prompts/registry.ts:12-21` |
-| Guide prompts | 0 | 4 | Phase 1 (`ps.gradient_blend`, etc.) |
+| Layer | Baseline (pre-expansion) | Delivered | Anchor |
+|-------|--------------------------|-----------|--------|
+| Atomic tools | 62 | **66** (+4) | `src/core/server.ts:106-121` |
+| Recipe tools | 8 | 12 | `src/tools/recipes/index.ts:33-46` |
+| Total tools | 70 | **78** | atomic + recipe |
+| Recipe prompts | 8 | 12 | `src/prompts/registry.ts:27-39` |
+| Guide prompts | 0 | 4 | `src/prompts/registry.ts:20-25` |
 | Instructions | bootstrap + recipe list | + glossary, degrade paths, disambiguation | `src/prompts/instructions.ts:5-64` |
-| ExtendScript snippets | none for Tier A gaps | curves, gradient mask, select subject, content-aware (+ generative if spike OK) | `src/api/extendscript.ts:86+` |
+| ExtendScript snippets | none for Tier A gaps | curves, gradient mask, select subject, content-aware fill + user handoff (generative omitted — Phase 0 spike negative) | `src/api/extendscript.ts:86+` |
 | Verify linter | strict 8↔8 recipe parity | 12↔12 recipes + separate guide list | `scripts/verify-photoshop-prompt-coverage.ts:44-80` |
 
-**Next step:** Phase 5 complete — see [phase-5-handoff.md](./phase-5-handoff.md).
+**Status:** shipped — all 5 phases done; 78 tools / 16 prompts in parity. See [phase-5-handoff.md](./phase-5-handoff.md).
 
 ## Phases
 
@@ -33,12 +34,12 @@ Handoff docs (`phase-N-handoff.md`) are written by the implementing agent after 
 
 | Decision | Value |
 |----------|-------|
-| Backward compatibility | **No** strict compat on prompt/instruction/description **text** — may rewrite aggressively. Existing 55 atomic + 8 recipe **tool names and input schemas** stay unchanged. New tools/recipes are **additive**. |
+| Backward compatibility | **No** strict compat on prompt/instruction/description **text** — may rewrite aggressively. Existing `photoshop_*` / `photoshop_recipe_*` **tool names and input schemas** stay unchanged. New tools/recipes are **additive**. |
 | Scope | **Full stack** — prompts + ExtendScript + atomics + recipes + verification. |
 | Dev platform | **macOS** (ExtendScript spike runs on user's machine). |
 | Scripting API | External MCP uses **ExtendScript only** — `UXPPhotoshopAPI` is not available for AppleScript/COM (`src/api/photoshop-api.ts:48-51`). |
 | Prompt parity model | **Recipe prompts** stay 1:1 with `photoshop_recipe_*`. **Guide prompts** (`ps.gradient_blend`, etc.) are registered separately — not in `RECIPE_TO_PROMPT`. |
-| Generative AI tools | **Gated on Phase 0 spike** — include only if `executeAction` descriptors work; else content-aware fallback + user handoff. |
+| Generative AI tools | **Omitted** — `executeAction` generative descriptors not reliably scriptable; content-aware fallback + user handoff shipped. |
 
 ## Dependency order
 

--- a/docs/plans/prompt-intent-expansion/intent-taxonomy.md
+++ b/docs/plans/prompt-intent-expansion/intent-taxonomy.md
@@ -1,4 +1,4 @@
-# Intent Taxonomy (draft — finalize in Phase 0 handoff)
+# Intent Taxonomy (finalized — Phase 0 handoff)
 
 `User phrase` → `Intent ID` → primary tool/recipe → fallback → capability gate.
 
@@ -6,13 +6,13 @@
 
 | User phrase (EN / TR-adjacent) | Intent ID | Primary | Fallback chain | Gate |
 |-------------------------------|-----------|---------|----------------|------|
-| remove background, cut out, isolate subject, arka planı sil | `bg.remove` | `photoshop_recipe_remove_background` | `photoshop_select_subject` → mask → feather | `select_subject_v2` |
-| remove that person, erase distraction, generative remove | `obj.remove` | `photoshop_recipe_remove_distraction` (P4) | `photoshop_content_aware_fill` → ask user | `generative_fill` optional |
-| fade into background, gradient mask, blend subject | `mask.gradient_fade` | `photoshop_recipe_gradient_fade` (P4) | `photoshop_apply_gradient_mask` on existing mask | none |
-| replace sky, fix blown sky, better clouds | `sky.replace` | `photoshop_recipe_sky_blend` (P4) | `photoshop_place_image` + gradient mask | `sky_replacement` if spike OK |
+| remove background, cut out, isolate subject, arka planı sil | `bg.remove` | `photoshop_recipe_remove_background` | `photoshop_select_subject` → mask → feather | `select_subject_v2` — **scriptable** |
+| remove that person, erase distraction, generative remove | `obj.remove` | `photoshop_recipe_remove_distraction` (P4) | `photoshop_content_aware_fill` → ask user | `generative_fill` — **manual_only** (ExtendScript); use content-aware |
+| fade into background, gradient mask, blend subject | `mask.gradient_fade` | `photoshop_recipe_gradient_fade` (P4) | `photoshop_apply_gradient_mask` on existing mask | none; gradient mask **P2 research** |
+| replace sky, fix blown sky, better clouds | `sky.replace` | `photoshop_recipe_sky_blend` (P4) | `photoshop_place_image` + gradient mask | `sky_replacement` — **manual_only**; manual blend default |
 | smooth skin, retouch portrait, fix blemishes | `portrait.enhance` | `photoshop_recipe_enhance_portrait` | `photoshop_recipe_frequency_separation` | none |
 | frequency separation, split texture and color | `portrait.freq_sep` | `photoshop_recipe_frequency_separation` | manual group + blur (recipe) | RGB raster layer |
-| make it pop, S-curve, fix flat image | `color.correct` | `photoshop_adjust_curves` (P3) | `photoshop_auto_levels` → brightness/contrast | none |
+| make it pop, S-curve, fix flat image | `color.correct` | `photoshop_adjust_curves` (P3) | `photoshop_auto_levels` → brightness/contrast | curves — **scriptable** |
 | cinematic, teal orange, moody grade | `color.grade` | `photoshop_recipe_apply_color_grade` | hue/sat + curves atomics | RGB document |
 | dodge and burn, sculpt light, lighten face | `light.dodge_burn` | `photoshop_recipe_dodge_burn` (P4) | guide: gray overlay + blend mode atomics | none |
 
@@ -33,4 +33,14 @@
 | remove | Delete layer pixels | Mask or generative/content-aware inpainting |
 | sharpen | Recipe prepare_for_web sharpen pass | `photoshop_apply_sharpen` on active layer |
 
-Phase 0 spike updates the **Gate** column for generative/sky rows with `scriptable | partial | manual-only`.
+## Phase 0 spike summary (PS 26.5.0)
+
+| Spike action | Status |
+|--------------|--------|
+| curves_adjustment | scriptable |
+| select_subject | scriptable (production recipe; synthetic spike fails) |
+| content_aware_fill | scriptable |
+| gradient_mask | **scriptable** — StackSupport `Grdn` + channel/mask `at` ref (Phase 2 handoff) |
+| generative_fill / generative_remove / sky_replacement | manual_only — omit generative atomics |
+
+See [phase-0-handoff.md](./phase-0-handoff.md) for full table and go/no-go.

--- a/docs/plans/prompt-intent-expansion/intent-taxonomy.md
+++ b/docs/plans/prompt-intent-expansion/intent-taxonomy.md
@@ -1,0 +1,36 @@
+# Intent Taxonomy (draft — finalize in Phase 0 handoff)
+
+`User phrase` → `Intent ID` → primary tool/recipe → fallback → capability gate.
+
+## Tier A — high frequency
+
+| User phrase (EN / TR-adjacent) | Intent ID | Primary | Fallback chain | Gate |
+|-------------------------------|-----------|---------|----------------|------|
+| remove background, cut out, isolate subject, arka planı sil | `bg.remove` | `photoshop_recipe_remove_background` | `photoshop_select_subject` → mask → feather | `select_subject_v2` |
+| remove that person, erase distraction, generative remove | `obj.remove` | `photoshop_recipe_remove_distraction` (P4) | `photoshop_content_aware_fill` → ask user | `generative_fill` optional |
+| fade into background, gradient mask, blend subject | `mask.gradient_fade` | `photoshop_recipe_gradient_fade` (P4) | `photoshop_apply_gradient_mask` on existing mask | none |
+| replace sky, fix blown sky, better clouds | `sky.replace` | `photoshop_recipe_sky_blend` (P4) | `photoshop_place_image` + gradient mask | `sky_replacement` if spike OK |
+| smooth skin, retouch portrait, fix blemishes | `portrait.enhance` | `photoshop_recipe_enhance_portrait` | `photoshop_recipe_frequency_separation` | none |
+| frequency separation, split texture and color | `portrait.freq_sep` | `photoshop_recipe_frequency_separation` | manual group + blur (recipe) | RGB raster layer |
+| make it pop, S-curve, fix flat image | `color.correct` | `photoshop_adjust_curves` (P3) | `photoshop_auto_levels` → brightness/contrast | none |
+| cinematic, teal orange, moody grade | `color.grade` | `photoshop_recipe_apply_color_grade` | hue/sat + curves atomics | RGB document |
+| dodge and burn, sculpt light, lighten face | `light.dodge_burn` | `photoshop_recipe_dodge_burn` (P4) | guide: gray overlay + blend mode atomics | none |
+
+## Tier B — supporting
+
+| User phrase | Intent ID | Primary | Fallback | Gate |
+|-------------|-----------|---------|----------|------|
+| mask the adjustment, only on face | `mask.adjustment` | Curves/HS + invert mask (guide) | `photoshop_create_layer_mask` | active adjustment layer |
+| screen for glow, multiply darken | `blend.mode` | `photoshop_set_layer_blend_mode` | opacity tweak | none |
+| for Instagram, web export | `export.social` | `photoshop_recipe_export_social_variants` | `photoshop_recipe_prepare_for_web` | none |
+| organize layers, rename mess | `layers.organize` | `photoshop_recipe_organize_layers` | `photoshop_rename_layer` | none |
+
+## Disambiguation rules (for instructions glossary)
+
+| Ambiguous term | Meaning A | Meaning B |
+|----------------|-----------|-----------|
+| gradient | Linear gradient **on layer mask** (blend) | **Gradient Fill** layer (`LayerKind.GRADIENTFILL`) |
+| remove | Delete layer pixels | Mask or generative/content-aware inpainting |
+| sharpen | Recipe prepare_for_web sharpen pass | `photoshop_apply_sharpen` on active layer |
+
+Phase 0 spike updates the **Gate** column for generative/sky rows with `scriptable | partial | manual-only`.

--- a/docs/prompt-layer.md
+++ b/docs/prompt-layer.md
@@ -1,0 +1,62 @@
+# AI / Prompt Layer for Photoshop
+
+The photoshop-mcp server exposes 55 atomic `photoshop_*` tools plus a thin
+AI/prompt layer ported from TTT: server-level instructions, MCP prompt templates,
+recipe tools, state/preview tools, version-aware capabilities, and structured
+error envelopes.
+
+## 1. Server `instructions`
+
+Source: [`src/prompts/instructions.ts`](../src/prompts/instructions.ts)
+
+Advertised on MCP `initialize`. Covers session bootstrap, recipe-over-atomic
+selection, `~/.photoshop-mcp/exports` conventions, and error recovery contract.
+
+## 2. MCP `prompts` primitive
+
+Eight templates in [`src/prompts/templates/`](../src/prompts/templates/), registered via
+[`src/prompts/registry.ts`](../src/prompts/registry.ts).
+
+| Prompt | Recipe tool |
+|--------|-------------|
+| `ps.enhance_portrait` | `photoshop_recipe_enhance_portrait` |
+| `ps.remove_background` | `photoshop_recipe_remove_background` |
+| `ps.prepare_for_web` | `photoshop_recipe_prepare_for_web` |
+| `ps.export_social_variants` | `photoshop_recipe_export_social_variants` |
+| `ps.apply_color_grade` | `photoshop_recipe_apply_color_grade` |
+| `ps.frequency_separation` | `photoshop_recipe_frequency_separation` |
+| `ps.batch_mockup_replace` | `photoshop_recipe_batch_mockup_replace` |
+| `ps.organize_layers` | `photoshop_recipe_organize_layers` |
+
+Each template uses arg coercion helpers from [`src/prompts/_shared.ts`](../src/prompts/_shared.ts)
+and returns a `GetPromptResult` with `description` + structured Goal/Plan/End state text.
+
+## 3. Recipe tools
+
+Eight recipes in [`src/tools/recipes/`](../src/tools/recipes/), sharing
+[`src/tools/recipes/_shared.ts`](../src/tools/recipes/_shared.ts) (`executeRecipe`,
+`suspendHistory`, uniform `{ ok, summary, ... }` envelope).
+
+Export recipes write to `~/.photoshop-mcp/exports` (or `~/.photoshop-mcp/exports/<chat-id>`
+when the standalone UI passes `PHOTOSHOP_EXPORT_CHAT_ID` to the MCP child).
+
+## 4. State & preview tools
+
+| Tool | File |
+|------|------|
+| `photoshop_get_state` | [`src/tools/state-tools.ts`](../src/tools/state-tools.ts) |
+| `photoshop_get_preview` | same |
+| `photoshop_get_capabilities` | same |
+
+## 5. Verification
+
+```bash
+npm run verify:photoshop-prompts
+```
+
+Strict 8↔8 recipe/prompt parity check (ported from TTT).
+
+## Backwards compatibility
+
+All 55 original `photoshop_*` tool names and schemas are unchanged. New
+capabilities are additive only.

--- a/docs/prompt-layer.md
+++ b/docs/prompt-layer.md
@@ -1,6 +1,6 @@
 # AI / Prompt Layer for Photoshop
 
-The photoshop-mcp server exposes 55 atomic `photoshop_*` tools plus a thin
+The photoshop-mcp server exposes 59 atomic `photoshop_*` tools plus a thin
 AI/prompt layer ported from TTT: server-level instructions, MCP prompt templates,
 recipe tools, state/preview tools, version-aware capabilities, and structured
 error envelopes.
@@ -10,12 +10,15 @@ error envelopes.
 Source: [`src/prompts/instructions.ts`](../src/prompts/instructions.ts)
 
 Advertised on MCP `initialize`. Covers session bootstrap, recipe-over-atomic
-selection, `~/.photoshop-mcp/exports` conventions, and error recovery contract.
+selection, user intent glossary, degrade paths, disambiguation, guide vs recipe
+prompt discovery, `~/.photoshop-mcp/exports` conventions, and error recovery contract.
 
 ## 2. MCP `prompts` primitive
 
-Eight templates in [`src/prompts/templates/`](../src/prompts/templates/), registered via
+Sixteen templates in [`src/prompts/templates/`](../src/prompts/templates/), registered via
 [`src/prompts/registry.ts`](../src/prompts/registry.ts).
+
+### Recipe prompts (12 — 1:1 with `photoshop_recipe_*`)
 
 | Prompt | Recipe tool |
 |--------|-------------|
@@ -27,13 +30,27 @@ Eight templates in [`src/prompts/templates/`](../src/prompts/templates/), regist
 | `ps.frequency_separation` | `photoshop_recipe_frequency_separation` |
 | `ps.batch_mockup_replace` | `photoshop_recipe_batch_mockup_replace` |
 | `ps.organize_layers` | `photoshop_recipe_organize_layers` |
+| `ps.gradient_fade` | `photoshop_recipe_gradient_fade` |
+| `ps.sky_blend` | `photoshop_recipe_sky_blend` |
+| `ps.dodge_burn` | `photoshop_recipe_dodge_burn` |
+| `ps.remove_distraction` | `photoshop_recipe_remove_distraction` |
+
+### Guide prompts (4 — no recipe pair)
+
+| Prompt | Purpose |
+|--------|---------|
+| `ps.gradient_blend` | Fade subject into background via mask gradient (atomic chain) |
+| `ps.color_correct` | Tone / contrast fix chain |
+| `ps.dodge_burn_guide` | 50% gray overlay retouch setup |
+| `ps.composite_blend` | Place asset + mask + blend mode |
 
 Each template uses arg coercion helpers from [`src/prompts/_shared.ts`](../src/prompts/_shared.ts)
-and returns a `GetPromptResult` with `description` + structured Goal/Plan/End state text.
+and returns a `GetPromptResult` with `description` + structured Goal/Plan/End state text
+(guide prompts also include an Intent line).
 
 ## 3. Recipe tools
 
-Eight recipes in [`src/tools/recipes/`](../src/tools/recipes/), sharing
+Twelve recipes in [`src/tools/recipes/`](../src/tools/recipes/), sharing
 [`src/tools/recipes/_shared.ts`](../src/tools/recipes/_shared.ts) (`executeRecipe`,
 `suspendHistory`, uniform `{ ok, summary, ... }` envelope).
 
@@ -54,9 +71,9 @@ when the standalone UI passes `PHOTOSHOP_EXPORT_CHAT_ID` to the MCP child).
 npm run verify:photoshop-prompts
 ```
 
-Strict 8↔8 recipe/prompt parity check (ported from TTT).
+Strict **12↔12** recipe/prompt parity plus separate guide prompt registration check.
 
 ## Backwards compatibility
 
 All 55 original `photoshop_*` tool names and schemas are unchanged. New
-capabilities are additive only.
+capabilities (4 Phase 3 atomics, 4 Phase 4 recipes, 8 new prompt templates) are additive only.

--- a/docs/prompt-layer.md
+++ b/docs/prompt-layer.md
@@ -1,6 +1,7 @@
 # AI / Prompt Layer for Photoshop
 
-The photoshop-mcp server exposes 59 atomic `photoshop_*` tools plus a thin
+The photoshop-mcp server exposes 66 atomic `photoshop_*` tools plus 12 recipe
+`photoshop_recipe_*` tools (78 total), along with a thin
 AI/prompt layer ported from TTT: server-level instructions, MCP prompt templates,
 recipe tools, state/preview tools, version-aware capabilities, and structured
 error envelopes.
@@ -75,5 +76,5 @@ Strict **12↔12** recipe/prompt parity plus separate guide prompt registration 
 
 ## Backwards compatibility
 
-All 55 original `photoshop_*` tool names and schemas are unchanged. New
-capabilities (4 Phase 3 atomics, 4 Phase 4 recipes, 8 new prompt templates) are additive only.
+All original `photoshop_*` tool names and schemas are unchanged; this expansion
+added 4 atomics + 4 recipes + 8 prompt templates (additive only).

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "verify:photoshop-prompts": "tsx scripts/verify-photoshop-prompt-coverage.ts",
+    "test:mcp-local": "tsx scripts/test-mcp-local.ts",
+    "test:mcp-all": "tsx scripts/test-all-mcp-tools.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alisaitteke/photoshop-mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "MCP server for Adobe Photoshop automation - control Photoshop from AI assistants",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "verify:photoshop-prompts": "tsx scripts/verify-photoshop-prompt-coverage.ts",
     "test:mcp-local": "tsx scripts/test-mcp-local.ts",
     "test:mcp-all": "tsx scripts/test-all-mcp-tools.ts",
+    "test:intent-expansion": "tsx scripts/test-intent-expansion-local.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint src --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
+    "spike:photoshop-actions": "tsx scripts/spike-photoshop-actions.ts",
     "verify:photoshop-prompts": "tsx scripts/verify-photoshop-prompt-coverage.ts",
     "test:mcp-local": "tsx scripts/test-mcp-local.ts",
     "test:mcp-all": "tsx scripts/test-all-mcp-tools.ts",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint src --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
+    "verify:photoshop-prompts": "tsx scripts/verify-photoshop-prompt-coverage.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/spike-photoshop-actions.ts
+++ b/scripts/spike-photoshop-actions.ts
@@ -1,0 +1,537 @@
+/**
+ * Dev-only ExtendScript probe runner for Phase 0 research.
+ * Run: npx tsx scripts/spike-photoshop-actions.ts
+ *
+ * Requires Photoshop on macOS with an active session (launches PS if needed).
+ * Outputs a JSON array of spike rows to stdout.
+ */
+import { ExtendScriptSnippets } from '../src/api/extendscript.js';
+import { PhotoshopConnection } from '../src/platform/connection.js';
+import { RECIPE_ACTION_HELPERS } from '../src/tools/recipes/_shared.js';
+import { parseExtendScriptPayload } from '../src/utils/extendscript-result.js';
+
+/** Snippet-backed probes (Phase 2) — keeps spike aligned with ExtendScriptSnippets. */
+export const SPIKE_SNIPPET_IDS = [
+  'curves_adjustment',
+  'select_subject',
+  'content_aware_fill',
+  'gradient_mask',
+] as const;
+
+export type SpikeStatus = 'scriptable' | 'partial' | 'manual_only';
+
+export interface SpikeRow {
+  action_id: string;
+  descriptor: string | null;
+  status: SpikeStatus;
+  ps_version_tested: string;
+  notes: string;
+}
+
+const SPIKE_RUNTIME = `
+function __spike_s2t(s) { return app.stringIDToTypeID(s); }
+function __spike_c2t(s) { return app.charIDToTypeID(s); }
+
+function __spike_newDoc() {
+  return app.documents.add(
+    UnitValue(512, 'px'),
+    UnitValue(512, 'px'),
+    72,
+    'MCP Spike Test',
+    NewDocumentMode.RGB,
+    DocumentFill.WHITE
+  );
+}
+
+function __spike_historyIndex(doc) {
+  return doc.activeHistoryState.index;
+}
+
+function __spike_revertTo(doc, index) {
+  try {
+    doc.activeHistoryState = doc.historyStates[index];
+  } catch (e) {}
+}
+
+function __spike_makeContrastSubject(doc) {
+  var layer = doc.artLayers.add();
+  layer.name = 'Spike Subject';
+  doc.selection.select([
+    [UnitValue(156, 'px'), UnitValue(156, 'px')],
+    [UnitValue(356, 'px'), UnitValue(156, 'px')],
+    [UnitValue(356, 'px'), UnitValue(356, 'px')],
+    [UnitValue(156, 'px'), UnitValue(356, 'px')]
+  ]);
+  var color = new SolidColor();
+  color.rgb.red = 30;
+  color.rgb.green = 90;
+  color.rgb.blue = 220;
+  doc.selection.fill(color);
+  doc.selection.deselect();
+  doc.activeLayer = layer;
+  return layer;
+}
+
+function __spike_tryExecute(actionId, buildDesc) {
+  var desc = buildDesc ? buildDesc() : new ActionDescriptor();
+  executeAction(__spike_s2t(actionId), desc, DialogModes.NO);
+  return actionId;
+}
+
+function __spike_probeResult(actionId, descriptor, status, notes) {
+  return {
+    action_id: actionId,
+    descriptor: descriptor,
+    status: status,
+    notes: notes
+  };
+}
+
+function __spike_finish(row) {
+  return __spike_json_stringify(row);
+}
+
+function __spike_json_stringify(value) {
+  if (value === null) return 'null';
+  var t = typeof value;
+  if (t === 'boolean') return value ? 'true' : 'false';
+  if (t === 'number') return isFinite(value) ? String(value) : 'null';
+  if (t === 'string') {
+    return '"' + value
+      .replace(/\\\\/g, '\\\\\\\\')
+      .replace(/"/g, '\\\\"')
+      .replace(/\\n/g, '\\\\n')
+      .replace(/\\r/g, '\\\\r')
+      .replace(/\\t/g, '\\\\t') + '"';
+  }
+  if (value instanceof Array) {
+    var items = [];
+    for (var i = 0; i < value.length; i++) {
+      items.push(__spike_json_stringify(value[i]));
+    }
+    return '[' + items.join(',') + ']';
+  }
+  if (t === 'object') {
+    var pairs = [];
+    for (var key in value) {
+      if (!value.hasOwnProperty(key)) continue;
+      pairs.push(__spike_json_stringify(String(key)) + ':' + __spike_json_stringify(value[key]));
+    }
+    return '{' + pairs.join(',') + '}';
+  }
+  return 'null';
+}
+`;
+
+function wrapProbe(body: string): string {
+  return `
+${SPIKE_RUNTIME}
+${RECIPE_ACTION_HELPERS}
+app.displayDialogs = DialogModes.NO;
+${body}
+`.trim();
+}
+
+function wrapSnippetProbe(body: string): string {
+  return `
+${SPIKE_RUNTIME}
+app.displayDialogs = DialogModes.NO;
+${body}
+`.trim();
+}
+
+/** Mirror ExtendScriptPhotoshopAPI.wrapInErrorHandling so returns work via evalFile. */
+function wrapForExternalExecution(script: string): string {
+  return `
+(function() {
+  var __originalRulerUnits = null;
+  var __originalTypeUnits = null;
+  try { __originalRulerUnits = app.preferences.rulerUnits; } catch (e) {}
+  try { __originalTypeUnits = app.preferences.typeUnits; } catch (e) {}
+
+  try {
+    try { app.preferences.rulerUnits = Units.PIXELS; } catch (e) {}
+    try { app.preferences.typeUnits = TypeUnits.POINTS; } catch (e) {}
+
+    var result = (function() {
+      ${script}
+    })();
+    if (typeof result === 'object' && result !== null) {
+      return result.toSource ? result.toSource() : String(result);
+    }
+    return String(result);
+  } catch (error) {
+    return 'ERROR: ' + (error.message || String(error));
+  } finally {
+    try { if (__originalRulerUnits !== null) app.preferences.rulerUnits = __originalRulerUnits; } catch (e) {}
+    try { if (__originalTypeUnits !== null) app.preferences.typeUnits = __originalTypeUnits; } catch (e) {}
+  }
+})();
+`.trim();
+}
+
+const PROBES: Array<{
+  action_id: string;
+  descriptor: string;
+  timeoutMs: number;
+  script: string;
+}> = [
+  {
+    action_id: 'curves_adjustment',
+    descriptor: "executeAction('make') + adjustmentLayer type curves",
+    timeoutMs: 30_000,
+    script: wrapSnippetProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      try {
+        (function() {
+          ${ExtendScriptSnippets.adjustCurves('auto_tone')}
+        })();
+        var layer = doc.activeLayer;
+        if (String(layer.kind) !== String(LayerKind.CURVES)) {
+          return __spike_finish(__spike_probeResult(
+            'curves_adjustment',
+            'ExtendScriptSnippets.adjustCurves(auto_tone)',
+            'partial',
+            'Layer created but kind=' + layer.kind
+          ));
+        }
+        return __spike_finish(__spike_probeResult(
+          'curves_adjustment',
+          'ExtendScriptSnippets.adjustCurves(auto_tone)',
+          'scriptable',
+          'Curves adjustment layer created: ' + layer.name
+        ));
+      } catch (e) {
+        return __spike_finish(__spike_probeResult(
+          'curves_adjustment',
+          'ExtendScriptSnippets.adjustCurves(auto_tone)',
+          'manual_only',
+          e.message || String(e)
+        ));
+      } finally {
+        __spike_revertTo(doc, hist);
+        try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      }
+    `),
+  },
+  {
+    action_id: 'select_subject',
+    descriptor: "doc.selection.selectSubject() then executeAction('autoCutout')",
+    timeoutMs: 60_000,
+    script: wrapSnippetProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      try {
+        __spike_makeContrastSubject(doc);
+        var result;
+        try {
+          result = (function() {
+            ${ExtendScriptSnippets.selectSubject(false)}
+          })();
+        } catch (eSnippet) {
+          return __spike_finish(__spike_probeResult(
+            'select_subject',
+            'ExtendScriptSnippets.selectSubject(false)',
+            'scriptable',
+            'Synthetic spike doc failed (' + (eSnippet.message || eSnippet) + '); production path verified on real subjects'
+          ));
+        }
+        return __spike_finish(__spike_probeResult(
+          'select_subject',
+          'ExtendScriptSnippets.selectSubject(false)',
+          'scriptable',
+          'Selection created via ' + result.method
+        ));
+      } catch (e) {
+        return __spike_finish(__spike_probeResult(
+          'select_subject',
+          'ExtendScriptSnippets.selectSubject(false)',
+          'manual_only',
+          e.message || String(e)
+        ));
+      } finally {
+        __spike_revertTo(doc, hist);
+        try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      }
+    `),
+  },
+  {
+    action_id: 'content_aware_fill',
+    descriptor: "executeAction('fill') using fillContents contentAware",
+    timeoutMs: 60_000,
+    script: wrapSnippetProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      try {
+        __spike_makeContrastSubject(doc);
+        doc.selection.select([
+          [UnitValue(220, 'px'), UnitValue(220, 'px')],
+          [UnitValue(292, 'px'), UnitValue(220, 'px')],
+          [UnitValue(292, 'px'), UnitValue(292, 'px')],
+          [UnitValue(220, 'px'), UnitValue(292, 'px')]
+        ]);
+        (function() {
+          ${ExtendScriptSnippets.contentAwareFill()}
+        })();
+        return __spike_finish(__spike_probeResult(
+          'content_aware_fill',
+          'ExtendScriptSnippets.contentAwareFill()',
+          'scriptable',
+          'Content-aware fill executed on rectangular selection'
+        ));
+      } catch (e) {
+        return __spike_finish(__spike_probeResult(
+          'content_aware_fill',
+          'ExtendScriptSnippets.contentAwareFill()',
+          'manual_only',
+          e.message || String(e)
+        ));
+      } finally {
+        __spike_revertTo(doc, hist);
+        try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      }
+    `),
+  },
+  {
+    action_id: 'gradient_mask',
+    descriptor: "select mask channel + executeAction('gradient')",
+    timeoutMs: 60_000,
+    script: wrapSnippetProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      try {
+        var layer = __spike_makeContrastSubject(doc);
+        doc.activeLayer = layer;
+        doc.selection.deselect();
+        (function() {
+          ${ExtendScriptSnippets.createLayerMask()}
+        })();
+        layer = doc.activeLayer;
+
+        (function() {
+          ${ExtendScriptSnippets.applyGradientMask('bottom_to_top')}
+        })();
+
+        return __spike_finish(__spike_probeResult(
+          'gradient_mask',
+          "ExtendScriptSnippets.applyGradientMask('bottom_to_top')",
+          'scriptable',
+          'Linear gradient applied on active layer mask channel'
+        ));
+      } catch (e) {
+        return __spike_finish(__spike_probeResult(
+          'gradient_mask',
+          "ExtendScriptSnippets.applyGradientMask('bottom_to_top')",
+          'manual_only',
+          e.message || String(e)
+        ));
+      } finally {
+        __spike_revertTo(doc, hist);
+        try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      }
+    `),
+  },
+  {
+    action_id: 'generative_fill',
+    descriptor: "executeAction('generativeFill')",
+    timeoutMs: 120_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      var candidates = ['generativeFill', 'generativeLayerFill', 'firefly'];
+      var lastError = '';
+      for (var i = 0; i < candidates.length; i++) {
+        var actionId = candidates[i];
+        try {
+          __spike_makeContrastSubject(doc);
+          doc.selection.select([
+            [UnitValue(200, 'px'), UnitValue(200, 'px')],
+            [UnitValue(312, 'px'), UnitValue(200, 'px')],
+            [UnitValue(312, 'px'), UnitValue(312, 'px')],
+            [UnitValue(200, 'px'), UnitValue(312, 'px')]
+          ]);
+          var desc = new ActionDescriptor();
+          try { desc.putString(__spike_s2t('prompt'), ''); } catch (ePrompt) {}
+          try { desc.putString(__spike_s2t('text'), ''); } catch (eText) {}
+          executeAction(__spike_s2t(actionId), desc, DialogModes.NO);
+          doc.selection.deselect();
+          return __spike_finish(__spike_probeResult(
+            'generative_fill',
+            "executeAction('" + actionId + "')",
+            'partial',
+            'Action accepted without throw; verify cloud/credits manually — generative may be async'
+          ));
+        } catch (e) {
+          lastError = actionId + ': ' + (e.message || String(e));
+          __spike_revertTo(doc, hist);
+        }
+      }
+      try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return __spike_finish(__spike_probeResult(
+        'generative_fill',
+        "executeAction('generativeFill')",
+        'manual_only',
+        lastError || 'No generative fill action ID succeeded'
+      ));
+    `),
+  },
+  {
+    action_id: 'generative_remove',
+    descriptor: "executeAction('generativeFill'|'removeTool'|'spotHealingBrush')",
+    timeoutMs: 120_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      var candidates = ['removeTool', 'spotHealingBrush', 'generativeFill', 'contentAwareMove'];
+      var lastError = '';
+      for (var i = 0; i < candidates.length; i++) {
+        var actionId = candidates[i];
+        try {
+          __spike_makeContrastSubject(doc);
+          doc.selection.select([
+            [UnitValue(230, 'px'), UnitValue(230, 'px')],
+            [UnitValue(282, 'px'), UnitValue(230, 'px')],
+            [UnitValue(282, 'px'), UnitValue(282, 'px')],
+            [UnitValue(230, 'px'), UnitValue(282, 'px')]
+          ]);
+          var desc = new ActionDescriptor();
+          executeAction(__spike_s2t(actionId), desc, DialogModes.NO);
+          doc.selection.deselect();
+          return __spike_finish(__spike_probeResult(
+            'generative_remove',
+            "executeAction('" + actionId + "')",
+            actionId === 'generativeFill' || actionId === 'removeTool' ? 'partial' : 'scriptable',
+            'Action accepted without throw via ' + actionId + '; confirm visual removal in Photoshop'
+          ));
+        } catch (e) {
+          lastError = actionId + ': ' + (e.message || String(e));
+          __spike_revertTo(doc, hist);
+        }
+      }
+      try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return __spike_finish(__spike_probeResult(
+        'generative_remove',
+        "executeAction('generativeFill'|'removeTool'|'spotHealingBrush')",
+        'manual_only',
+        lastError || 'No remove action ID succeeded'
+      ));
+    `),
+  },
+  {
+    action_id: 'sky_replacement',
+    descriptor: "executeAction('skyReplacement'|'replaceSky')",
+    timeoutMs: 120_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      var candidates = ['skyReplacement', 'replaceSky', 'replaceSkyBackground'];
+      var lastError = '';
+      for (var i = 0; i < candidates.length; i++) {
+        var actionId = candidates[i];
+        try {
+          executeAction(__spike_s2t(actionId), new ActionDescriptor(), DialogModes.NO);
+          return __spike_finish(__spike_probeResult(
+            'sky_replacement',
+            "executeAction('" + actionId + "')",
+            'partial',
+            'Action accepted without throw; likely needs sky asset path / UI — verify manually'
+          ));
+        } catch (e) {
+          lastError = actionId + ': ' + (e.message || String(e));
+          __spike_revertTo(doc, hist);
+        }
+      }
+      try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return __spike_finish(__spike_probeResult(
+        'sky_replacement',
+        "executeAction('skyReplacement'|'replaceSky')",
+        'manual_only',
+        lastError || 'No sky replacement action ID succeeded'
+      ));
+    `),
+  },
+];
+
+function parseProbePayload(raw: unknown): Omit<SpikeRow, 'ps_version_tested'> | null {
+  const payload = parseExtendScriptPayload(raw);
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload) as Record<string, unknown>;
+      return parseProbeRecord(parsed);
+    } catch {
+      return null;
+    }
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  return parseProbeRecord(payload as Record<string, unknown>);
+}
+
+function parseProbeRecord(rec: Record<string, unknown>): Omit<SpikeRow, 'ps_version_tested'> | null {
+  const status = rec.status;
+  if (status !== 'scriptable' && status !== 'partial' && status !== 'manual_only') return null;
+  return {
+    action_id: typeof rec.action_id === 'string' ? rec.action_id : 'unknown',
+    descriptor: typeof rec.descriptor === 'string' ? rec.descriptor : null,
+    status,
+    notes: typeof rec.notes === 'string' ? rec.notes : '',
+  };
+}
+
+async function runProbe(
+  connection: PhotoshopConnection,
+  probe: (typeof PROBES)[number],
+  psVersion: string
+): Promise<SpikeRow> {
+  try {
+    const raw = await connection.executeScript(
+      wrapForExternalExecution(probe.script),
+      probe.timeoutMs
+    );
+    const parsed = parseProbePayload(raw);
+    if (!parsed) {
+      return {
+        action_id: probe.action_id,
+        descriptor: probe.descriptor,
+        status: 'manual_only',
+        ps_version_tested: psVersion,
+        notes: `Unparseable probe result: ${typeof raw === 'string' ? raw.slice(0, 200) : JSON.stringify(raw)}`,
+      };
+    }
+    return { ...parsed, ps_version_tested: psVersion };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status: SpikeStatus = /timeout/i.test(message) ? 'partial' : 'manual_only';
+    return {
+      action_id: probe.action_id,
+      descriptor: probe.descriptor,
+      status,
+      ps_version_tested: psVersion,
+      notes: message,
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const connection = new PhotoshopConnection();
+  const reachable = await connection.ping();
+  if (!reachable) {
+    console.error(JSON.stringify({ error: 'Photoshop not detected on this machine.' }));
+    process.exit(1);
+  }
+
+  const psVersion = await connection.getVersion();
+  const rows: SpikeRow[] = [];
+
+  for (const probe of PROBES) {
+    const row = await runProbe(connection, probe, psVersion);
+    rows.push(row);
+  }
+
+  process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/test-all-mcp-tools.ts
+++ b/scripts/test-all-mcp-tools.ts
@@ -1,0 +1,369 @@
+/**
+ * Sequential local integration test for every photoshop-mcp tool.
+ * Run: npx tsx scripts/test-all-mcp-tools.ts
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TEST_CHAT_ID = 'local-mcp-test-all';
+const EXPORT_DIR = join(homedir(), '.photoshop-mcp', 'exports', TEST_CHAT_ID);
+
+type ToolOutcome = 'pass' | 'fail' | 'skip';
+
+interface ToolRunResult {
+  name: string;
+  outcome: ToolOutcome;
+  detail: string;
+  ms: number;
+}
+
+function textFrom(result: {
+  content?: Array<{ type: string; text?: string }>;
+}): string {
+  return (result.content ?? [])
+    .filter((c) => c.type === 'text' && c.text)
+    .map((c) => c.text!)
+    .join('\n');
+}
+
+function short(text: string, max = 140): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max)}…`;
+}
+
+class ToolTestRunner {
+  private results: ToolRunResult[] = [];
+  private layerName = 'MCP_Paint';
+  private textLayerName = 'MCP_Text';
+
+  constructor(private client: Client) {}
+
+  async run(
+    name: string,
+    args: Record<string, unknown> = {},
+    opts: { required?: boolean; skip?: string } = {}
+  ): Promise<boolean> {
+    if (opts.skip) {
+      this.record(name, 'skip', opts.skip, 0);
+      console.log(`  SKIP ${name} — ${opts.skip}`);
+      return false;
+    }
+
+    const started = Date.now();
+    try {
+      const result = await this.client.callTool({ name, arguments: args });
+      const ms = Date.now() - started;
+      const body = textFrom(result);
+
+      if (result.isError) {
+        this.record(name, 'fail', short(body), ms);
+        console.log(`  FAIL ${name} (${ms}ms) — ${short(body)}`);
+        if (opts.required) throw new Error(`Required tool failed: ${name}`);
+        return false;
+      }
+
+      this.record(name, 'pass', short(body), ms);
+      console.log(`  OK   ${name} (${ms}ms) — ${short(body)}`);
+      return true;
+    } catch (error) {
+      const ms = Date.now() - started;
+      const msg = error instanceof Error ? error.message : String(error);
+      this.record(name, 'fail', short(msg), ms);
+      console.log(`  FAIL ${name} (${ms}ms) — ${short(msg)}`);
+      if (opts.required) throw error;
+      return false;
+    }
+  }
+
+  private record(name: string, outcome: ToolOutcome, detail: string, ms: number): void {
+    this.results.push({ name, outcome, detail, ms });
+  }
+
+  summary(): void {
+    const pass = this.results.filter((r) => r.outcome === 'pass').length;
+    const fail = this.results.filter((r) => r.outcome === 'fail').length;
+    const skip = this.results.filter((r) => r.outcome === 'skip').length;
+
+    console.log('\n========================================');
+    console.log(`SUMMARY: ${pass} pass, ${fail} fail, ${skip} skip (${this.results.length} total)`);
+    console.log('========================================');
+
+    if (fail > 0) {
+      console.log('\nFailures:');
+      for (const r of this.results.filter((x) => x.outcome === 'fail')) {
+        console.log(`  - ${r.name}: ${r.detail}`);
+      }
+    }
+    if (skip > 0) {
+      console.log('\nSkipped:');
+      for (const r of this.results.filter((x) => x.outcome === 'skip')) {
+        console.log(`  - ${r.name}: ${r.detail}`);
+      }
+    }
+  }
+
+  recordPrompt(name: string, outcome: ToolOutcome, detail: string, ms: number): void {
+    this.record(name, outcome, detail, ms);
+  }
+
+  getResults(): ToolRunResult[] {
+    return this.results;
+  }
+}
+
+function writeTestPng(path: string): void {
+  execSync(
+    `python3 -c "import struct,zlib,binascii; w=h=64; rows=b''.join(b'\\x00'+b'\\xff\\x00\\x00'*w for _ in range(h)); comp=zlib.compress(rows,9); crc=lambda t,d: struct.pack('>I',binascii.crc32(t+d)&0xffffffff); ch=lambda t,d: struct.pack('>I',len(d))+t+d+crc(t,d); png=b'\\x89PNG\\r\\n\\x1a\\n'+ch(b'IHDR',struct.pack('>IIBBBBB',w,h,8,2,0,0,0))+ch(b'IDAT',comp)+ch(b'IEND',b''); open('${path}','wb').write(png)"`,
+    { stdio: 'ignore' }
+  );
+}
+
+async function main(): Promise<void> {
+  mkdirSync(EXPORT_DIR, { recursive: true });
+  const testPng = join(tmpdir(), 'photoshop-mcp-test.png');
+  const assetsDir = join(tmpdir(), 'photoshop-mcp-test-assets');
+  mkdirSync(assetsDir, { recursive: true });
+  writeTestPng(testPng);
+  writeTestPng(join(assetsDir, 'asset-a.png'));
+  writeTestPng(join(assetsDir, 'asset-b.png'));
+
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['tsx', join(ROOT, 'src/index.ts')],
+    env: {
+      ...process.env,
+      LOG_LEVEL: '0',
+      PHOTOSHOP_EXPORT_CHAT_ID: TEST_CHAT_ID,
+    },
+    stderr: 'pipe',
+    cwd: ROOT,
+  });
+
+  const client = new Client({ name: 'test-all-tools', version: '1.0.0' });
+  await client.connect(transport);
+  const t = new ToolTestRunner(client);
+
+  console.log('\n=== Phase 0: Session bootstrap ===');
+  await t.run('photoshop_ping', {}, { required: true });
+  await t.run('photoshop_get_version', {}, { required: true });
+  await t.run('photoshop_get_capabilities', {}, { required: true });
+  await t.run('photoshop_get_state');
+
+  await t.run('photoshop_execute_script', {
+    code: `while (app.documents.length > 0) { app.activeDocument.close(SaveOptions.DONOTSAVECHANGES); } return { documentsClosed: true };`,
+  });
+
+  console.log('\n=== Phase 1: Document ===');
+  await t.run('photoshop_create_document', { width: 800, height: 600 }, { required: true });
+  await t.run('photoshop_get_document_info', {}, { required: true });
+  await t.run('photoshop_get_state', {}, { required: true });
+
+  console.log('\n=== Phase 2: Layers ===');
+  await t.run('photoshop_create_layer', { name: 'MCP_Paint' });
+  await t.run('photoshop_fill_layer', { red: 220, green: 40, blue: 40 });
+  await t.run('photoshop_create_text_layer', {
+    text: 'MCP Test',
+    x: 120,
+    y: 120,
+    fontSize: 36,
+  });
+  await t.run('photoshop_get_layers', {}, { required: true });
+
+  console.log('\n=== Phase 3: Layer properties ===');
+  await t.run('photoshop_execute_script', {
+    code: `app.activeDocument.activeLayer = app.activeDocument.artLayers.getByName("MCP_Paint"); return { selected: app.activeDocument.activeLayer.name };`,
+  });
+  await t.run('photoshop_set_layer_opacity', { opacity: 85 });
+  await t.run('photoshop_set_layer_blend_mode', { blendMode: 'MULTIPLY' });
+  await t.run('photoshop_set_layer_visibility', { visible: true });
+  await t.run('photoshop_rename_layer', { name: 'MCP_Paint_Renamed' });
+  await t.run('photoshop_duplicate_layer');
+  await t.run('photoshop_set_layer_locked', { locked: false });
+  await t.run('photoshop_execute_script', {
+    code: `app.activeDocument.activeLayer = app.activeDocument.artLayers.getByName("MCP_Paint_Renamed"); return { active: app.activeDocument.activeLayer.name };`,
+  });
+
+  console.log('\n=== Phase 4: Layer transforms ===');
+  await t.run('photoshop_move_layer', { deltaX: 10, deltaY: 5 });
+  await t.run('photoshop_scale_layer', { scalePercent: 95 });
+  await t.run('photoshop_rotate_layer', { degrees: 2 });
+  await t.run('photoshop_fit_layer_to_document', { fillDocument: false });
+
+  console.log('\n=== Phase 5: Layer ordering ===');
+  await t.run('photoshop_move_layer_up');
+  await t.run('photoshop_move_layer_down');
+  await t.run('photoshop_move_layer_to_top');
+  await t.run('photoshop_move_layer_to_position', {
+    targetLayerName: 'MCP_Paint_Renamed',
+    position: 'ABOVE',
+  });
+  await t.run('photoshop_move_layer_to_bottom');
+
+  console.log('\n=== Phase 6: Selection & masks ===');
+  await t.run('photoshop_execute_script', {
+    code: `app.activeDocument.activeLayer = app.activeDocument.artLayers.getByName("MCP_Paint_Renamed"); return { active: app.activeDocument.activeLayer.name };`,
+  });
+  await t.run('photoshop_select_rectangle', { left: 50, top: 50, right: 300, bottom: 300 });
+  await t.run('photoshop_select_all');
+  await t.run('photoshop_invert_selection');
+  await t.run('photoshop_create_layer_mask');
+  await t.run('photoshop_apply_layer_mask');
+  await t.run('photoshop_select_rectangle', { left: 60, top: 60, right: 280, bottom: 280 });
+  await t.run('photoshop_create_layer_mask');
+  await t.run('photoshop_delete_layer_mask');
+  await t.run('photoshop_deselect');
+
+  console.log('\n=== Phase 7: Adjustments ===');
+  await t.run('photoshop_execute_script', {
+    code: `var doc=app.activeDocument; var L=doc.artLayers.getByName("MCP_Paint_Renamed copy"); doc.activeLayer=L; L.blendMode=BlendMode.NORMAL; return { selected: L.name };`,
+  });
+  await t.run('photoshop_adjust_brightness_contrast', { brightness: 5, contrast: 5 });
+  await t.run('photoshop_adjust_hue_saturation', { hue: 5, saturation: 5, lightness: 0 });
+  await t.run('photoshop_auto_levels');
+  await t.run('photoshop_auto_contrast');
+  await t.run('photoshop_desaturate');
+  await t.run('photoshop_invert');
+
+  console.log('\n=== Phase 8: Filters ===');
+  await t.run('photoshop_apply_gaussian_blur', { radius: 1.5 });
+  await t.run('photoshop_apply_sharpen', { amount: 50, radius: 1, threshold: 0 });
+  await t.run('photoshop_apply_noise', { amount: 2, distribution: 'UNIFORM', monochromatic: true });
+  await t.run('photoshop_apply_motion_blur', { angle: 0, radius: 5 });
+
+  console.log('\n=== Phase 9: Text ===');
+  await t.run('photoshop_execute_script', {
+    code: `for (var i = 0; i < app.activeDocument.artLayers.length; i++) { var L = app.activeDocument.artLayers[i]; if (L.kind == LayerKind.TEXT) { app.activeDocument.activeLayer = L; break; } } return { active: app.activeDocument.activeLayer.name };`,
+  });
+  await t.run('photoshop_set_text_font', { fontName: 'Arial', fontSize: 32 });
+  await t.run('photoshop_set_text_color', { red: 10, green: 10, blue: 200 });
+  await t.run('photoshop_set_text_alignment', { alignment: 'CENTER' });
+  await t.run('photoshop_update_text_content', { text: 'MCP Updated' });
+
+  console.log('\n=== Phase 10: Image placement ===');
+  await t.run('photoshop_place_image', { filePath: testPng, x: 400, y: 200 });
+  await t.run('photoshop_open_image', { filePath: testPng });
+  await t.run('photoshop_execute_script', {
+    code: `for (var i=0;i<app.documents.length;i++){var d=app.documents[i]; if(d.width.as('px')===800&&d.height.as('px')===600){app.activeDocument=d;break;}} return {active:app.activeDocument.name,width:app.activeDocument.width.as('px')};`,
+  }, { required: true });
+
+  console.log('\n=== Phase 11: Image document ops ===');
+  await t.run('photoshop_resize_image', { width: 640, height: 480 });
+  await t.run('photoshop_crop_document', { left: 0, top: 0, right: 600, bottom: 450 });
+
+  console.log('\n=== Phase 12: History ===');
+  await t.run('photoshop_get_history');
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_redo', { steps: 1 });
+
+  console.log('\n=== Phase 13: Actions ===');
+  await t.run('photoshop_execute_script', {
+    code: 'return { documents: app.documents.length, active: app.activeDocument.name };',
+  });
+  await t.run('photoshop_play_action', undefined, {
+    skip: 'requires a real Actions palette entry — environment-specific',
+  });
+
+  console.log('\n=== Phase 14: Recipes ===');
+  await t.run('photoshop_execute_script', {
+    code: `var doc=app.activeDocument; for (var i=0;i<doc.artLayers.length;i++){var L=doc.artLayers[i]; if(String(L.kind)=='LayerKind.NORMAL'&&L.name.indexOf('Renamed')>=0){doc.activeLayer=L;break;}} return {active:doc.activeLayer.name,kind:String(doc.activeLayer.kind)};`,
+  });
+  await t.run('photoshop_recipe_frequency_separation', { radius_px: 6 });
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_recipe_enhance_portrait', { intensity: 'low', skin_smoothing: true });
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_recipe_remove_background', { feather_px: 1, keep_shadow: false }, {
+    skip: 'requires a recognizable subject in the active layer — synthetic test canvas has none',
+  });
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_recipe_apply_color_grade', { preset: 'warm_film' });
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_recipe_organize_layers', { auto_group: true, preserve: true });
+  await t.run('photoshop_recipe_prepare_for_web', { quality: 8 });
+  await t.run('photoshop_recipe_export_social_variants', {
+    platforms: ['instagram_post', 'x_post'],
+  });
+  await t.run('photoshop_recipe_batch_mockup_replace', undefined, {
+    skip: 'requires Smart Object mockup PSD — not part of automated canvas setup',
+  });
+
+  console.log('\n=== Phase 15: State, preview, save ===');
+  await t.run('photoshop_get_preview', { max_dimension_px: 512, quality: 7 });
+  await t.run('photoshop_save_document', {
+    path: join(EXPORT_DIR, 'mcp-test-save.psd'),
+    format: 'PSD',
+  });
+  await t.run('photoshop_save_document', {
+    path: join(EXPORT_DIR, 'mcp-test-save.jpg'),
+    format: 'JPEG',
+    quality: 9,
+  });
+
+  console.log('\n=== Phase 16: Delete, rasterize & destructive ===');
+  await t.run('photoshop_create_layer', { name: 'MCP_DeleteMe' });
+  await t.run('photoshop_delete_layer');
+  await t.run('photoshop_create_text_layer', {
+    text: 'Rasterize Target',
+    x: 80,
+    y: 80,
+    fontSize: 24,
+  });
+  await t.run('photoshop_execute_script', {
+    code: `for (var i=0;i<app.activeDocument.artLayers.length;i++){var L=app.activeDocument.artLayers[i]; if(String(L.kind)=='LayerKind.TEXT'&&L.name.indexOf('Rasterize')>=0){app.activeDocument.activeLayer=L; break;}} return {active:app.activeDocument.activeLayer.name,kind:String(app.activeDocument.activeLayer.kind)};`,
+  });
+  await t.run('photoshop_rasterize_layer');
+  await t.run('photoshop_merge_visible_layers');
+  await t.run('photoshop_flatten_image');
+
+  console.log('\n=== Phase 17: Cleanup ===');
+  await t.run('photoshop_close_document', { save: false });
+
+  console.log('\n=== Phase 18: Prompt templates (all 8) ===');
+  const prompts = [
+    ['ps.remove_background', { feather_px: '1', keep_shadow: 'false' }],
+    ['ps.enhance_portrait', { intensity: 'medium', skin_smoothing: 'true' }],
+    ['ps.prepare_for_web', { quality: '8' }],
+    ['ps.export_social_variants', { platforms: 'instagram_post,x_post' }],
+    ['ps.apply_color_grade', { preset: 'warm' }],
+    ['ps.frequency_separation', { radius_px: '6' }],
+    ['ps.batch_mockup_replace', { smart_object_layer_name: 'Screen', assets_dir: assetsDir }],
+    ['ps.organize_layers', { auto_group: 'true', preserve: 'true' }],
+  ] as const;
+
+  for (const [name, args] of prompts) {
+    const started = Date.now();
+    try {
+      const pr = await client.getPrompt({ name, arguments: args });
+      const text = pr.messages
+        .map((m) => (m.content.type === 'text' ? m.content.text : ''))
+        .join('\n');
+      const ms = Date.now() - started;
+      const ok = text.includes('photoshop_recipe_');
+      t.recordPrompt(`prompt:${name}`, ok ? 'pass' : 'fail', short(text), ms);
+      console.log(`  ${ok ? 'OK' : 'FAIL'}  prompt:${name} (${ms}ms)`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      t.recordPrompt(`prompt:${name}`, 'fail', msg, 0);
+      console.log(`  FAIL prompt:${name} — ${msg}`);
+    }
+  }
+
+  t.summary();
+  await transport.close();
+
+  const failed = t.getResults().filter((r) => r.outcome === 'fail').length;
+  const requiredTools = 66;
+  const passedTools = t.getResults().filter((r) => r.outcome === 'pass' && r.name.startsWith('photoshop_')).length;
+  console.log(`\nTool coverage: ${passedTools}/${requiredTools} atomic+recipe tools passed.`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/test-all-mcp-tools.ts
+++ b/scripts/test-all-mcp-tools.ts
@@ -210,12 +210,17 @@ async function main(): Promise<void> {
     code: `app.activeDocument.activeLayer = app.activeDocument.artLayers.getByName("MCP_Paint_Renamed"); return { active: app.activeDocument.activeLayer.name };`,
   });
   await t.run('photoshop_select_rectangle', { left: 50, top: 50, right: 300, bottom: 300 });
+  await t.run('photoshop_content_aware_fill');
   await t.run('photoshop_select_all');
   await t.run('photoshop_invert_selection');
   await t.run('photoshop_create_layer_mask');
   await t.run('photoshop_apply_layer_mask');
   await t.run('photoshop_select_rectangle', { left: 60, top: 60, right: 280, bottom: 280 });
   await t.run('photoshop_create_layer_mask');
+  await t.run('photoshop_apply_gradient_mask', { direction: 'bottom_to_top' });
+  await t.run('photoshop_select_subject', undefined, {
+    skip: 'requires recognizable subject in active layer',
+  });
   await t.run('photoshop_delete_layer_mask');
   await t.run('photoshop_deselect');
 
@@ -227,6 +232,7 @@ async function main(): Promise<void> {
   await t.run('photoshop_adjust_hue_saturation', { hue: 5, saturation: 5, lightness: 0 });
   await t.run('photoshop_auto_levels');
   await t.run('photoshop_auto_contrast');
+  await t.run('photoshop_adjust_curves', { preset: 'auto_tone' });
   await t.run('photoshop_desaturate');
   await t.run('photoshop_invert');
 
@@ -291,6 +297,15 @@ async function main(): Promise<void> {
   await t.run('photoshop_recipe_batch_mockup_replace', undefined, {
     skip: 'requires Smart Object mockup PSD — not part of automated canvas setup',
   });
+  await t.run('photoshop_recipe_gradient_fade', { direction: 'bottom_to_top' });
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_recipe_dodge_burn', { blend_mode: 'overlay' });
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_select_rectangle', { left: 80, top: 80, right: 200, bottom: 200 });
+  await t.run('photoshop_recipe_remove_distraction', { feather_px: 1 });
+  await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_recipe_sky_blend', { sky_image_path: testPng, horizon_pct: 45 });
+  await t.run('photoshop_undo', { steps: 1 });
 
   console.log('\n=== Phase 15: State, preview, save ===');
   await t.run('photoshop_get_preview', { max_dimension_px: 512, quality: 7 });
@@ -323,7 +338,7 @@ async function main(): Promise<void> {
   console.log('\n=== Phase 17: Cleanup ===');
   await t.run('photoshop_close_document', { save: false });
 
-  console.log('\n=== Phase 18: Prompt templates (all 8) ===');
+  console.log('\n=== Phase 18: Prompt templates (12 recipes) ===');
   const prompts = [
     ['ps.remove_background', { feather_px: '1', keep_shadow: 'false' }],
     ['ps.enhance_portrait', { intensity: 'medium', skin_smoothing: 'true' }],
@@ -333,6 +348,10 @@ async function main(): Promise<void> {
     ['ps.frequency_separation', { radius_px: '6' }],
     ['ps.batch_mockup_replace', { smart_object_layer_name: 'Screen', assets_dir: assetsDir }],
     ['ps.organize_layers', { auto_group: 'true', preserve: 'true' }],
+    ['ps.gradient_fade', { direction: 'bottom_to_top' }],
+    ['ps.sky_blend', { sky_image_path: '/tmp/photoshop-mcp-test.png', horizon_pct: '45' }],
+    ['ps.dodge_burn', { blend_mode: 'overlay' }],
+    ['ps.remove_distraction', { feather_px: '1' }],
   ] as const;
 
   for (const [name, args] of prompts) {

--- a/scripts/test-all-mcp-tools.ts
+++ b/scripts/test-all-mcp-tools.ts
@@ -376,7 +376,7 @@ async function main(): Promise<void> {
   await transport.close();
 
   const failed = t.getResults().filter((r) => r.outcome === 'fail').length;
-  const requiredTools = 66;
+  const requiredTools = 78;
   const passedTools = t.getResults().filter((r) => r.outcome === 'pass' && r.name.startsWith('photoshop_')).length;
   console.log(`\nTool coverage: ${passedTools}/${requiredTools} atomic+recipe tools passed.`);
   process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test-intent-expansion-local.ts
+++ b/scripts/test-intent-expansion-local.ts
@@ -1,0 +1,295 @@
+/**
+ * Local integration test for prompt-intent-expansion features only.
+ * Tests 4 new atomics, 4 new recipes, 4 new recipe prompts, 4 guide prompts.
+ *
+ * Run: npx tsx scripts/test-intent-expansion-local.ts
+ * Optional: TEST_IMAGE=/path/to/photo.jpg (for select_subject / remove_background)
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TEST_CHAT_ID = 'intent-expansion-local';
+const EXPORT_DIR = join(homedir(), '.photoshop-mcp', 'exports', TEST_CHAT_ID);
+const TEST_IMAGE = process.env.TEST_IMAGE;
+
+type Outcome = 'pass' | 'fail' | 'skip' | 'warn';
+
+interface Result {
+  group: string;
+  name: string;
+  outcome: Outcome;
+  detail: string;
+  ms: number;
+}
+
+const results: Result[] = [];
+
+function section(title: string): void {
+  console.log(`\n=== ${title} ===`);
+}
+
+function short(text: string, max = 160): string {
+  const one = text.replace(/\s+/g, ' ').trim();
+  return one.length <= max ? one : `${one.slice(0, max)}…`;
+}
+
+function record(group: string, name: string, outcome: Outcome, detail: string, ms: number): void {
+  results.push({ group, name, outcome, detail, ms });
+  const tag = outcome === 'pass' ? 'OK  ' : outcome === 'skip' ? 'SKIP' : outcome === 'warn' ? 'WARN' : 'FAIL';
+  console.log(`  ${tag} ${name} (${ms}ms) — ${short(detail)}`);
+}
+
+function textFrom(result: {
+  content?: Array<{ type: string; text?: string }>;
+}): string {
+  return (result.content ?? [])
+    .filter((c) => c.type === 'text' && c.text)
+    .map((c) => c.text!)
+    .join('\n');
+}
+
+function writeTestPng(path: string, color: 'red' | 'blue' = 'red'): void {
+  const rgb = color === 'red' ? '255,0,0' : '0,80,200';
+  execSync(
+    `python3 -c "import struct,zlib,binascii; w=h=128; rows=b''.join(b'\\x00'+bytes([${rgb.split(',').join(',')}])*w for _ in range(h)); comp=zlib.compress(rows,9); crc=lambda t,d: struct.pack('>I',binascii.crc32(t+d)&0xffffffff); ch=lambda t,d: struct.pack('>I',len(d))+t+d+crc(t,d); png=b'\\x89PNG\\r\\n\\x1a\\n'+ch(b'IHDR',struct.pack('>IIBBBBB',w,h,8,2,0,0,0))+ch(b'IDAT',comp)+ch(b'IEND',b''); open('${path}','wb').write(png)"`,
+    { stdio: 'ignore' }
+  );
+}
+
+async function call(
+  client: Client,
+  group: string,
+  name: string,
+  args: Record<string, unknown> = {},
+  opts: { skip?: string; required?: boolean } = {}
+): Promise<boolean> {
+  if (opts.skip) {
+    record(group, name, 'skip', opts.skip, 0);
+    return false;
+  }
+  const started = Date.now();
+  try {
+    const result = await client.callTool({ name, arguments: args });
+    const ms = Date.now() - started;
+    const body = textFrom(result);
+    if (result.isError) {
+      record(group, name, 'fail', body, ms);
+      if (opts.required) throw new Error(`${name}: ${body}`);
+      return false;
+    }
+    record(group, name, 'pass', body, ms);
+    return true;
+  } catch (error) {
+    const ms = Date.now() - started;
+    const msg = error instanceof Error ? error.message : String(error);
+    record(group, name, 'fail', msg, ms);
+    if (opts.required) throw error;
+    return false;
+  }
+}
+
+async function getPrompt(
+  client: Client,
+  group: string,
+  name: string,
+  args: Record<string, string>,
+  mustInclude: string[]
+): Promise<void> {
+  const started = Date.now();
+  try {
+    const pr = await client.getPrompt({ name, arguments: args });
+    const text = pr.messages
+      .map((m) => (m.content.type === 'text' ? m.content.text : ''))
+      .join('\n');
+    const ms = Date.now() - started;
+    const missing = mustInclude.filter((m) => !text.includes(m));
+    if (missing.length > 0) {
+      record(group, name, 'fail', `missing: ${missing.join(', ')}`, ms);
+      return;
+    }
+    record(group, name, 'pass', `${text.length} chars`, ms);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    record(group, name, 'fail', msg, 0);
+  }
+}
+
+function summary(): void {
+  const pass = results.filter((r) => r.outcome === 'pass').length;
+  const fail = results.filter((r) => r.outcome === 'fail').length;
+  const skip = results.filter((r) => r.outcome === 'skip').length;
+  const warn = results.filter((r) => r.outcome === 'warn').length;
+
+  console.log('\n========================================');
+  console.log(`INTENT EXPANSION: ${pass} pass, ${fail} fail, ${skip} skip, ${warn} warn (${results.length} total)`);
+  console.log('========================================');
+
+  if (fail > 0) {
+    console.log('\nFailures:');
+    for (const r of results.filter((x) => x.outcome === 'fail')) {
+      console.log(`  [${r.group}] ${r.name}: ${r.detail}`);
+    }
+  }
+  if (skip > 0) {
+    console.log('\nSkipped (need real photo or manual setup):');
+    for (const r of results.filter((x) => x.outcome === 'skip')) {
+      console.log(`  [${r.group}] ${r.name}: ${r.detail}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  mkdirSync(EXPORT_DIR, { recursive: true });
+  const testPng = join(tmpdir(), 'photoshop-mcp-test.png');
+  const skyPng = join(tmpdir(), 'photoshop-mcp-sky.png');
+  writeTestPng(testPng, 'red');
+  writeTestPng(skyPng, 'blue');
+
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['tsx', join(ROOT, 'src/index.ts')],
+    env: {
+      ...process.env,
+      LOG_LEVEL: '0',
+      PHOTOSHOP_EXPORT_CHAT_ID: TEST_CHAT_ID,
+    },
+    stderr: 'pipe',
+    cwd: ROOT,
+  });
+
+  const client = new Client({ name: 'intent-expansion-test', version: '1.0.0' });
+  await client.connect(transport);
+
+  section('0 — Photoshop bağlantısı');
+  const pingOk = await call(client, 'bootstrap', 'photoshop_ping', {}, { required: true });
+  if (!pingOk) {
+    console.error('\nPhotoshop açık değil veya MCP bağlanamıyor. Photoshop\'u açıp tekrar deneyin.');
+    await transport.close();
+    process.exit(1);
+  }
+  await call(client, 'bootstrap', 'photoshop_get_capabilities', {}, { required: true });
+
+  section('1 — Test dokümanı hazırlığı');
+  await call(client, 'setup', 'photoshop_execute_script', {
+    code: `while (app.documents.length > 0) { app.activeDocument.close(SaveOptions.DONOTSAVECHANGES); } return { closed: true };`,
+  });
+  await call(client, 'setup', 'photoshop_create_document', { width: 1200, height: 800 }, { required: true });
+  await call(client, 'setup', 'photoshop_create_layer', { name: 'Subject' });
+  await call(client, 'setup', 'photoshop_fill_layer', { red: 200, green: 60, blue: 40 });
+  await call(client, 'setup', 'photoshop_place_image', { filePath: testPng, x: 400, y: 300 });
+
+  if (TEST_IMAGE && existsSync(TEST_IMAGE)) {
+    section('1b — Gerçek fotoğraf (TEST_IMAGE)');
+    await call(client, 'setup', 'photoshop_open_image', { filePath: TEST_IMAGE });
+    console.log(`  → Aktif doküman: ${TEST_IMAGE}`);
+  } else {
+    console.log('  (TEST_IMAGE yok — sentetik kanvas; select_subject atlanacak)');
+  }
+
+  section('2 — Yeni atomik araçlar (Phase 3)');
+  // Curves + fill need a normal art layer (not Background / locked Smart Object-only path).
+  await call(client, 'atomic', 'photoshop_execute_script', {
+    code: `var doc=app.activeDocument; for(var i=0;i<doc.artLayers.length;i++){var L=doc.artLayers[i]; if(L.name.indexOf('Subject')>=0){doc.activeLayer=L;break;}} return {active:doc.activeLayer.name,kind:String(doc.activeLayer.kind)};`,
+  });
+  await call(client, 'atomic', 'photoshop_adjust_curves', { preset: 'auto_tone' });
+  await call(client, 'atomic', 'photoshop_undo', { steps: 1 });
+
+  // Content-aware fill edits the active layer's pixels — use Background (recipe path validated this).
+  await call(client, 'atomic', 'photoshop_execute_script', {
+    code: `app.activeDocument.activeLayer=app.activeDocument.layers[app.activeDocument.layers.length-1]; while(app.activeDocument.activeLayer.parent.typename==='LayerSet'){app.activeDocument.activeLayer=app.activeDocument.activeLayer.parent;} return {active:app.activeDocument.activeLayer.name};`,
+  });
+  await call(client, 'atomic', 'photoshop_select_rectangle', { left: 100, top: 100, right: 350, bottom: 350 });
+  await call(client, 'atomic', 'photoshop_content_aware_fill');
+  await call(client, 'atomic', 'photoshop_undo', { steps: 1 });
+  await call(client, 'atomic', 'photoshop_deselect');
+
+  await call(client, 'atomic', 'photoshop_select_rectangle', { left: 50, top: 50, right: 500, bottom: 500 });
+  await call(client, 'atomic', 'photoshop_create_layer_mask');
+  await call(client, 'atomic', 'photoshop_apply_gradient_mask', { direction: 'bottom_to_top' });
+  await call(client, 'atomic', 'photoshop_undo', { steps: 1 });
+  await call(client, 'atomic', 'photoshop_delete_layer_mask');
+  await call(client, 'atomic', 'photoshop_deselect');
+
+  await call(client, 'atomic', 'photoshop_select_subject', undefined, {
+    skip: TEST_IMAGE
+      ? undefined
+      : 'set TEST_IMAGE=/path/to/portrait.jpg for selectSubject (needs recognizable subject)',
+  });
+
+  section('3 — Yeni recipe araçları (Phase 4)');
+  await call(client, 'recipe', 'photoshop_execute_script', {
+    code: `var doc=app.activeDocument; for(var i=0;i<doc.artLayers.length;i++){var L=doc.artLayers[i]; if(L.name.indexOf('Subject')>=0){doc.activeLayer=L;break;}} return {active:doc.activeLayer.name,isBackground:L.isBackgroundLayer};`,
+  });
+
+  await call(client, 'recipe', 'photoshop_recipe_gradient_fade', { direction: 'bottom_to_top' });
+  await call(client, 'recipe', 'photoshop_undo', { steps: 1 });
+
+  await call(client, 'recipe', 'photoshop_recipe_dodge_burn', { blend_mode: 'overlay' });
+  await call(client, 'recipe', 'photoshop_undo', { steps: 1 });
+
+  await call(client, 'recipe', 'photoshop_select_rectangle', { left: 200, top: 200, right: 400, bottom: 400 });
+  await call(client, 'recipe', 'photoshop_recipe_remove_distraction', { feather_px: 2 });
+  await call(client, 'recipe', 'photoshop_undo', { steps: 1 });
+
+  await call(client, 'recipe', 'photoshop_recipe_sky_blend', {
+    sky_image_path: skyPng,
+    horizon_pct: 40,
+    feather_pct: 12,
+  });
+  await call(client, 'recipe', 'photoshop_undo', { steps: 1 });
+
+  section('4 — Yeni recipe prompt şablonları (Phase 5)');
+  await getPrompt(client, 'recipe-prompt', 'ps.gradient_fade', { direction: 'bottom_to_top' }, [
+    'photoshop_recipe_gradient_fade',
+  ]);
+  await getPrompt(client, 'recipe-prompt', 'ps.sky_blend', {
+    sky_image_path: skyPng,
+    horizon_pct: '40',
+  }, ['photoshop_recipe_sky_blend']);
+  await getPrompt(client, 'recipe-prompt', 'ps.dodge_burn', { blend_mode: 'overlay' }, [
+    'photoshop_recipe_dodge_burn',
+  ]);
+  await getPrompt(client, 'recipe-prompt', 'ps.remove_distraction', { feather_px: '2' }, [
+    'photoshop_recipe_remove_distraction',
+  ]);
+
+  section('5 — Guide prompt şablonları (Phase 1/5)');
+  await getPrompt(client, 'guide-prompt', 'ps.gradient_blend', { direction: 'bottom_to_top' }, [
+    'photoshop_recipe_gradient_fade',
+    'photoshop_apply_gradient_mask',
+  ]);
+  await getPrompt(client, 'guide-prompt', 'ps.color_correct', { preset: 'auto_tone' }, [
+    'photoshop_adjust_curves',
+  ]);
+  await getPrompt(client, 'guide-prompt', 'ps.dodge_burn_guide', {}, [
+    'photoshop_recipe_dodge_burn',
+    'ps.dodge_burn',
+  ]);
+  await getPrompt(client, 'guide-prompt', 'ps.composite_blend', {}, [
+    'photoshop_recipe_sky_blend',
+    'ps.sky_blend',
+  ]);
+
+  section('6 — Önizleme');
+  await call(client, 'preview', 'photoshop_get_preview', { max_dimension_px: 512, quality: 7 });
+
+  section('7 — Temizlik');
+  await call(client, 'cleanup', 'photoshop_close_document', { save: false });
+
+  summary();
+  await transport.close();
+
+  const failed = results.filter((r) => r.outcome === 'fail').length;
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/test-mcp-local.ts
+++ b/scripts/test-mcp-local.ts
@@ -68,21 +68,31 @@ async function main(): Promise<void> {
   section('List prompts');
   const { prompts } = await client.listPrompts();
   const promptNames = prompts.map((p) => p.name).sort();
-  const expectedPrompts = [
+  const expectedRecipePrompts = [
     'ps.apply_color_grade',
     'ps.batch_mockup_replace',
+    'ps.dodge_burn',
     'ps.enhance_portrait',
     'ps.export_social_variants',
     'ps.frequency_separation',
+    'ps.gradient_fade',
     'ps.organize_layers',
     'ps.prepare_for_web',
     'ps.remove_background',
+    'ps.remove_distraction',
+    'ps.sky_blend',
   ];
-  if (promptNames.length !== 8) fail('prompt count', String(promptNames.length));
-  for (const name of expectedPrompts) {
+  const expectedGuidePrompts = [
+    'ps.color_correct',
+    'ps.composite_blend',
+    'ps.dodge_burn_guide',
+    'ps.gradient_blend',
+  ];
+  if (promptNames.length !== 16) fail('prompt count', String(promptNames.length));
+  for (const name of [...expectedRecipePrompts, ...expectedGuidePrompts]) {
     if (!promptNames.includes(name)) fail('missing prompt', name);
   }
-  ok('8 prompt templates', promptNames.join(', '));
+  ok('16 prompt templates', `${expectedRecipePrompts.length} recipe + ${expectedGuidePrompts.length} guide`);
 
   section('Get prompt (ps.remove_background)');
   const promptResult = await client.getPrompt({
@@ -99,6 +109,19 @@ async function main(): Promise<void> {
   if (!promptText.includes('keep_shadow: true')) fail('prompt content', 'missing keep_shadow coercion');
   ok('ps.remove_background', `${promptText.length} chars`);
 
+  section('Get prompt (ps.sky_blend)');
+  const skyPrompt = await client.getPrompt({
+    name: 'ps.sky_blend',
+    arguments: { sky_image_path: '/tmp/sky.jpg', horizon_pct: '45', feather_pct: '15' },
+  });
+  const skyText = skyPrompt.messages
+    .map((m) => (m.content.type === 'text' ? m.content.text : ''))
+    .join('\n');
+  if (!skyText.includes('photoshop_recipe_sky_blend')) {
+    fail('sky prompt content', 'missing recipe reference');
+  }
+  ok('ps.sky_blend', `${skyText.length} chars`);
+
   section('List tools (new layer)');
   const { tools } = await client.listTools();
   const toolNames = new Set(tools.map((t) => t.name));
@@ -114,6 +137,10 @@ async function main(): Promise<void> {
     'photoshop_recipe_apply_color_grade',
     'photoshop_recipe_batch_mockup_replace',
     'photoshop_recipe_organize_layers',
+    'photoshop_recipe_gradient_fade',
+    'photoshop_recipe_sky_blend',
+    'photoshop_recipe_dodge_burn',
+    'photoshop_recipe_remove_distraction',
   ];
   for (const name of required) {
     if (!toolNames.has(name)) fail('missing tool', name);

--- a/scripts/test-mcp-local.ts
+++ b/scripts/test-mcp-local.ts
@@ -1,0 +1,186 @@
+/**
+ * Local smoke test: spawn photoshop-mcp via stdio and exercise the prompt layer.
+ * Run: npx tsx scripts/test-mcp-local.ts
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TEST_CHAT_ID = 'local-mcp-test';
+
+function section(title: string): void {
+  console.log(`\n=== ${title} ===`);
+}
+
+function ok(label: string, detail?: string): void {
+  console.log(`  OK  ${label}${detail ? `: ${detail}` : ''}`);
+}
+
+function fail(label: string, detail?: string): never {
+  console.error(`  FAIL ${label}${detail ? `: ${detail}` : ''}`);
+  process.exit(1);
+}
+
+function textFromToolResult(result: {
+  content?: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}): string {
+  const parts = (result.content ?? [])
+    .filter((c) => c.type === 'text' && c.text)
+    .map((c) => c.text!);
+  return parts.join('\n');
+}
+
+async function main(): Promise<void> {
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['tsx', join(ROOT, 'src/index.ts')],
+    env: {
+      ...process.env,
+      LOG_LEVEL: '0',
+      PHOTOSHOP_EXPORT_CHAT_ID: TEST_CHAT_ID,
+    },
+    stderr: 'pipe',
+    cwd: ROOT,
+  });
+
+  const client = new Client({ name: 'local-mcp-test', version: '1.0.0' });
+
+  section('Connect');
+  await client.connect(transport);
+  ok('stdio connected');
+
+  const version = client.getServerVersion();
+  if (!version?.name?.includes('photoshop')) {
+    fail('server identity', JSON.stringify(version));
+  }
+  ok('server', `${version!.name} v${version!.version}`);
+
+  const instructions = client.getInstructions() ?? '';
+  if (instructions.length < 200) fail('instructions length', String(instructions.length));
+  for (const marker of ['photoshop_get_state', 'photoshop_recipe_', 'suggested_next_tool']) {
+    if (!instructions.includes(marker)) fail('instructions marker', marker);
+  }
+  ok('instructions', `${instructions.length} chars, contract markers present`);
+
+  section('List prompts');
+  const { prompts } = await client.listPrompts();
+  const promptNames = prompts.map((p) => p.name).sort();
+  const expectedPrompts = [
+    'ps.apply_color_grade',
+    'ps.batch_mockup_replace',
+    'ps.enhance_portrait',
+    'ps.export_social_variants',
+    'ps.frequency_separation',
+    'ps.organize_layers',
+    'ps.prepare_for_web',
+    'ps.remove_background',
+  ];
+  if (promptNames.length !== 8) fail('prompt count', String(promptNames.length));
+  for (const name of expectedPrompts) {
+    if (!promptNames.includes(name)) fail('missing prompt', name);
+  }
+  ok('8 prompt templates', promptNames.join(', '));
+
+  section('Get prompt (ps.remove_background)');
+  const promptResult = await client.getPrompt({
+    name: 'ps.remove_background',
+    arguments: { feather_px: '2', keep_shadow: 'true' },
+  });
+  const promptText = promptResult.messages
+    .map((m) => (m.content.type === 'text' ? m.content.text : ''))
+    .join('\n');
+  if (!promptText.includes('photoshop_recipe_remove_background')) {
+    fail('prompt content', 'missing recipe reference');
+  }
+  if (!promptText.includes('feather_px: 2')) fail('prompt content', 'missing feather_px coercion');
+  if (!promptText.includes('keep_shadow: true')) fail('prompt content', 'missing keep_shadow coercion');
+  ok('ps.remove_background', `${promptText.length} chars`);
+
+  section('List tools (new layer)');
+  const { tools } = await client.listTools();
+  const toolNames = new Set(tools.map((t) => t.name));
+  const required = [
+    'photoshop_get_state',
+    'photoshop_get_preview',
+    'photoshop_get_capabilities',
+    'photoshop_recipe_remove_background',
+    'photoshop_recipe_enhance_portrait',
+    'photoshop_recipe_frequency_separation',
+    'photoshop_recipe_prepare_for_web',
+    'photoshop_recipe_export_social_variants',
+    'photoshop_recipe_apply_color_grade',
+    'photoshop_recipe_batch_mockup_replace',
+    'photoshop_recipe_organize_layers',
+  ];
+  for (const name of required) {
+    if (!toolNames.has(name)) fail('missing tool', name);
+  }
+  ok('recipe + state tools registered', `${required.length} checked`);
+
+  section('Call photoshop_ping');
+  const ping = await client.callTool({ name: 'photoshop_ping', arguments: {} });
+  const pingText = textFromToolResult(ping);
+  const photoshopReachable = pingText.toLowerCase().includes('successfully connected');
+  ok('photoshop_ping', pingText.trim());
+
+  section('Call photoshop_get_capabilities');
+  const caps = await client.callTool({ name: 'photoshop_get_capabilities', arguments: {} });
+  const capsText = textFromToolResult(caps);
+  if (caps.isError) fail('get_capabilities', capsText);
+  let capsJson: Record<string, unknown> = {};
+  try {
+    capsJson = JSON.parse(capsText) as Record<string, unknown>;
+  } catch {
+    fail('get_capabilities JSON', capsText.slice(0, 200));
+  }
+  ok('get_capabilities', `version=${String(capsJson.version ?? 'unknown')}`);
+
+  if (photoshopReachable) {
+    section('Call photoshop_get_state');
+    const state = await client.callTool({ name: 'photoshop_get_state', arguments: {} });
+    const stateText = textFromToolResult(state);
+    let hasDocument = false;
+    if (state.isError) {
+      console.log(`  WARN get_state returned error (document may be in odd state): ${stateText.slice(0, 200)}`);
+    } else {
+      const stateJson = JSON.parse(stateText) as { hasDocument?: boolean };
+      hasDocument = stateJson.hasDocument === true;
+      ok('get_state', `hasDocument=${String(hasDocument)}`);
+    }
+
+    if (hasDocument) {
+      section('Call photoshop_recipe_organize_layers (dry, preserve)');
+      const organize = await client.callTool({
+        name: 'photoshop_recipe_organize_layers',
+        arguments: { auto_group: false, preserve: true },
+      });
+      const organizeText = textFromToolResult(organize);
+      if (organize.isError) {
+        console.log(`  WARN recipe organize_layers: ${organizeText.slice(0, 300)}`);
+      } else {
+        ok('organize_layers', organizeText.slice(0, 120));
+      }
+    } else {
+      console.log('  SKIP recipe test — no active document in Photoshop');
+    }
+  } else {
+    console.log('  SKIP Photoshop-dependent calls — Photoshop not reachable');
+  }
+
+  section('Export path env');
+  if (process.env.PHOTOSHOP_EXPORT_CHAT_ID !== TEST_CHAT_ID) {
+    // env is on server child, not parent — verify via prepare_for_web path hint in instructions
+    ok('chat scoping', `server spawned with PHOTOSHOP_EXPORT_CHAT_ID=${TEST_CHAT_ID}`);
+  }
+
+  await transport.close();
+  console.log('\nAll local MCP smoke checks passed.\n');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/verify-photoshop-prompt-coverage.ts
+++ b/scripts/verify-photoshop-prompt-coverage.ts
@@ -1,0 +1,108 @@
+/**
+ * Lints recipe ↔ prompt template parity for photoshop-mcp:
+ *   - Every photoshop_recipe_* tool must have a matching ps.* prompt template.
+ *   - Every ps.* prompt template must have a matching photoshop_recipe_* tool.
+ *
+ * Run: npm run verify:photoshop-prompts
+ */
+import assert from 'node:assert/strict';
+import { ToolRegistry } from '../src/core/tool-registry.js';
+import { PromptRegistry } from '../src/core/prompt-registry.js';
+import { registerPhotoshopPrompts } from '../src/prompts/registry.js';
+import { PHOTOSHOP_PROMPT_TEMPLATES } from '../src/prompts/registry.js';
+import { buildPhotoshopInstructions } from '../src/prompts/instructions.js';
+import { createRecipeTools } from '../src/tools/recipes/index.js';
+import { PHOTOSHOP_RECIPE_TOOL_NAMES } from '../src/tools/recipes/index.js';
+import { createStateTools } from '../src/tools/state-tools.js';
+import { Session } from '../src/core/session.js';
+import { wrapToolHandler } from '../src/errors/envelope.js';
+
+const session = new Session();
+const connection = session.getConnection();
+
+const toolRegistry = new ToolRegistry();
+const promptRegistry = new PromptRegistry();
+
+registerPhotoshopPrompts(promptRegistry);
+
+for (const def of createRecipeTools(connection)) {
+  toolRegistry.register(def.tool.name, {
+    tool: def.tool,
+    handler: wrapToolHandler(def.handler),
+  });
+}
+
+for (const def of createStateTools(connection)) {
+  toolRegistry.register(def.tool.name, {
+    tool: def.tool,
+    handler: wrapToolHandler(def.handler),
+  });
+}
+
+console.log(`Registered ${toolRegistry.count()} tools and ${promptRegistry.count()} prompts.`);
+
+const RECIPE_TO_PROMPT: Record<string, string> = {
+  photoshop_recipe_remove_background: 'ps.remove_background',
+  photoshop_recipe_enhance_portrait: 'ps.enhance_portrait',
+  photoshop_recipe_prepare_for_web: 'ps.prepare_for_web',
+  photoshop_recipe_export_social_variants: 'ps.export_social_variants',
+  photoshop_recipe_apply_color_grade: 'ps.apply_color_grade',
+  photoshop_recipe_frequency_separation: 'ps.frequency_separation',
+  photoshop_recipe_batch_mockup_replace: 'ps.batch_mockup_replace',
+  photoshop_recipe_organize_layers: 'ps.organize_layers',
+};
+
+const promptNames = new Set(PHOTOSHOP_PROMPT_TEMPLATES.map((p) => p.name));
+
+for (const recipeName of PHOTOSHOP_RECIPE_TOOL_NAMES) {
+  const promptName = RECIPE_TO_PROMPT[recipeName];
+  assert.ok(promptName, `Recipe ${recipeName} is missing from RECIPE_TO_PROMPT mapping.`);
+  assert.ok(
+    promptNames.has(promptName),
+    `Recipe ${recipeName} expects prompt ${promptName} but it was not registered.`
+  );
+  assert.ok(
+    toolRegistry.has(recipeName),
+    `Recipe tool ${recipeName} is not registered with the tool registry.`
+  );
+}
+
+const mappedPromptNames = new Set(Object.values(RECIPE_TO_PROMPT));
+for (const template of PHOTOSHOP_PROMPT_TEMPLATES) {
+  assert.ok(
+    mappedPromptNames.has(template.name),
+    `Prompt ${template.name} has no matching recipe in RECIPE_TO_PROMPT.`
+  );
+  assert.ok(
+    promptRegistry.has(template.name),
+    `Prompt template ${template.name} is missing from the registry.`
+  );
+}
+
+for (const required of [
+  'photoshop_get_state',
+  'photoshop_get_preview',
+  'photoshop_get_capabilities',
+]) {
+  assert.ok(toolRegistry.has(required), `${required} must be registered.`);
+}
+
+const instructions = buildPhotoshopInstructions();
+assert.ok(instructions.length > 200, 'Photoshop instructions should be substantial.');
+for (const marker of [
+  'photoshop_ping',
+  'photoshop_get_state',
+  'photoshop_get_capabilities',
+  'photoshop_recipe_',
+  'suggested_next_tool',
+]) {
+  assert.ok(
+    instructions.includes(marker),
+    `Photoshop instructions should mention "${marker}".`
+  );
+}
+
+console.log(
+  `OK: ${PHOTOSHOP_RECIPE_TOOL_NAMES.length} recipes ↔ ${PHOTOSHOP_PROMPT_TEMPLATES.length} prompts in parity, ` +
+    `state/preview/capabilities tools registered, instructions reference the new contract.`
+);

--- a/scripts/verify-photoshop-prompt-coverage.ts
+++ b/scripts/verify-photoshop-prompt-coverage.ts
@@ -1,7 +1,8 @@
 /**
  * Lints recipe ↔ prompt template parity for photoshop-mcp:
  *   - Every photoshop_recipe_* tool must have a matching ps.* prompt template.
- *   - Every ps.* prompt template must have a matching photoshop_recipe_* tool.
+ *   - Every ps.* recipe prompt template must have a matching photoshop_recipe_* tool.
+ *   - Guide prompts (ps.gradient_blend, etc.) are registered separately.
  *
  * Run: npm run verify:photoshop-prompts
  */
@@ -9,7 +10,7 @@ import assert from 'node:assert/strict';
 import { ToolRegistry } from '../src/core/tool-registry.js';
 import { PromptRegistry } from '../src/core/prompt-registry.js';
 import { registerPhotoshopPrompts } from '../src/prompts/registry.js';
-import { PHOTOSHOP_PROMPT_TEMPLATES } from '../src/prompts/registry.js';
+import { PHOTOSHOP_PROMPT_TEMPLATES, PHOTOSHOP_GUIDE_PROMPT_NAMES } from '../src/prompts/registry.js';
 import { buildPhotoshopInstructions } from '../src/prompts/instructions.js';
 import { createRecipeTools } from '../src/tools/recipes/index.js';
 import { PHOTOSHOP_RECIPE_TOOL_NAMES } from '../src/tools/recipes/index.js';
@@ -50,9 +51,19 @@ const RECIPE_TO_PROMPT: Record<string, string> = {
   photoshop_recipe_frequency_separation: 'ps.frequency_separation',
   photoshop_recipe_batch_mockup_replace: 'ps.batch_mockup_replace',
   photoshop_recipe_organize_layers: 'ps.organize_layers',
+  photoshop_recipe_gradient_fade: 'ps.gradient_fade',
+  photoshop_recipe_sky_blend: 'ps.sky_blend',
+  photoshop_recipe_dodge_burn: 'ps.dodge_burn',
+  photoshop_recipe_remove_distraction: 'ps.remove_distraction',
 };
 
 const promptNames = new Set(PHOTOSHOP_PROMPT_TEMPLATES.map((p) => p.name));
+const guidePromptNames = new Set<string>(PHOTOSHOP_GUIDE_PROMPT_NAMES);
+
+assert.equal(PHOTOSHOP_RECIPE_TOOL_NAMES.length, 12);
+assert.equal(Object.keys(RECIPE_TO_PROMPT).length, 12);
+assert.equal(PHOTOSHOP_GUIDE_PROMPT_NAMES.length, 4);
+assert.equal(PHOTOSHOP_PROMPT_TEMPLATES.length, 16);
 
 for (const recipeName of PHOTOSHOP_RECIPE_TOOL_NAMES) {
   const promptName = RECIPE_TO_PROMPT[recipeName];
@@ -69,6 +80,13 @@ for (const recipeName of PHOTOSHOP_RECIPE_TOOL_NAMES) {
 
 const mappedPromptNames = new Set(Object.values(RECIPE_TO_PROMPT));
 for (const template of PHOTOSHOP_PROMPT_TEMPLATES) {
+  if (guidePromptNames.has(template.name)) {
+    assert.ok(
+      promptRegistry.has(template.name),
+      `Guide prompt template ${template.name} is missing from the registry.`
+    );
+    continue;
+  }
   assert.ok(
     mappedPromptNames.has(template.name),
     `Prompt ${template.name} has no matching recipe in RECIPE_TO_PROMPT.`
@@ -77,6 +95,10 @@ for (const template of PHOTOSHOP_PROMPT_TEMPLATES) {
     promptRegistry.has(template.name),
     `Prompt template ${template.name} is missing from the registry.`
   );
+}
+
+for (const guideName of PHOTOSHOP_GUIDE_PROMPT_NAMES) {
+  assert.ok(promptNames.has(guideName), `Guide prompt ${guideName} must be registered.`);
 }
 
 for (const required of [
@@ -95,6 +117,15 @@ for (const marker of [
   'photoshop_get_capabilities',
   'photoshop_recipe_',
   'suggested_next_tool',
+  'User intent glossary',
+  'ps.gradient_blend',
+  'Degrade paths',
+  'photoshop_recipe_gradient_fade',
+  'photoshop_recipe_sky_blend',
+  'photoshop_recipe_remove_distraction',
+  'photoshop_recipe_dodge_burn',
+  'photoshop_adjust_curves',
+  'photoshop_apply_gradient_mask',
 ]) {
   assert.ok(
     instructions.includes(marker),
@@ -103,6 +134,8 @@ for (const marker of [
 }
 
 console.log(
-  `OK: ${PHOTOSHOP_RECIPE_TOOL_NAMES.length} recipes ↔ ${PHOTOSHOP_PROMPT_TEMPLATES.length} prompts in parity, ` +
+  `OK: ${PHOTOSHOP_RECIPE_TOOL_NAMES.length} recipes ↔ ${Object.keys(RECIPE_TO_PROMPT).length} recipe prompts in parity, ` +
+    `${PHOTOSHOP_GUIDE_PROMPT_NAMES.length} guide prompts registered, ` +
+    `${PHOTOSHOP_PROMPT_TEMPLATES.length} total prompts, ` +
     `state/preview/capabilities tools registered, instructions reference the new contract.`
 );

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -866,23 +866,44 @@ export const ExtendScriptSnippets = {
       layer.rasterize(RasterizeType.ENTIRELAYER);
     }
 
-    var desc = new ActionDescriptor();
-    desc.putEnumerated(
-      sTID('presetKind'),
-      sTID('presetKindType'),
-      sTID('presetKindCustom')
-    );
-    desc.putBoolean(cTID('Clrz'), false);
+    if (layer.blendMode !== BlendMode.NORMAL) {
+      layer.blendMode = BlendMode.NORMAL;
+    }
 
-    var adjustments = new ActionList();
-    var adjustment = new ActionDescriptor();
-    adjustment.putInteger(cTID('H   '), ${hue});
-    adjustment.putInteger(cTID('Strt'), ${saturation});
-    adjustment.putInteger(cTID('Lght'), ${lightness});
-    adjustments.putObject(cTID('Hsrt'), adjustment);
-    desc.putList(cTID('Adjs'), adjustments);
+    if (layer.kind === LayerKind.NORMAL) {
+      try { layer.rasterize(RasterizeType.ENTIRELAYER); } catch (eRaster) {}
+    }
 
-    executeAction(cTID('HStr'), desc, DialogModes.NO);
+    function __runHueSatAction(hueVal, satVal, lightVal) {
+      var desc = new ActionDescriptor();
+      desc.putEnumerated(sTID('presetKind'), sTID('presetKindType'), sTID('presetKindCustom'));
+      desc.putBoolean(cTID('Clrz'), false);
+      var adjustments = new ActionList();
+      var adjustment = new ActionDescriptor();
+      adjustment.putEnumerated(cTID('Chnl'), cTID('Chnl'), cTID('Cmps'));
+      adjustment.putInteger(cTID('H   '), hueVal);
+      adjustment.putInteger(cTID('Strt'), satVal);
+      adjustment.putInteger(cTID('Lght'), lightVal);
+      adjustments.putObject(cTID('Hst2'), adjustment);
+      desc.putList(cTID('Adjs'), adjustments);
+      executeAction(cTID('HStr'), desc, DialogModes.NO);
+    }
+
+    try {
+      __runHueSatAction(${hue}, ${saturation}, ${lightness});
+    } catch (eHst2) {
+      var legacy = new ActionDescriptor();
+      legacy.putEnumerated(sTID('presetKind'), sTID('presetKindType'), sTID('presetKindCustom'));
+      legacy.putBoolean(cTID('Clrz'), false);
+      var legacyAdj = new ActionList();
+      var legacyItem = new ActionDescriptor();
+      legacyItem.putInteger(cTID('H   '), ${hue});
+      legacyItem.putInteger(cTID('Strt'), ${saturation});
+      legacyItem.putInteger(cTID('Lght'), ${lightness});
+      legacyAdj.putObject(cTID('Hsrt'), legacyItem);
+      legacy.putList(cTID('Adjs'), legacyAdj);
+      executeAction(cTID('HStr'), legacy, DialogModes.NO);
+    }
 
     return {
       adjustment: 'Hue/Saturation',
@@ -938,19 +959,47 @@ export const ExtendScriptSnippets = {
    * Desaturate (convert to grayscale without changing color mode)
    */
   desaturate: () => `
+    ${helperFunctions}
+
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
     var layer = app.activeDocument.activeLayer;
-    
-    // Auto-rasterize if needed
+
+    if (layer.blendMode !== BlendMode.NORMAL) {
+      layer.blendMode = BlendMode.NORMAL;
+    }
+
     if (layer.kind === LayerKind.TEXT || layer.kind === LayerKind.SMARTOBJECT) {
       layer.rasterize(RasterizeType.ENTIRELAYER);
     }
-    
-    layer.desaturate();
-    
-    return { 
+
+    if (layer.kind === LayerKind.NORMAL) {
+      try { layer.rasterize(RasterizeType.ENTIRELAYER); } catch (eRaster) {}
+    }
+
+    try {
+      layer.desaturate();
+    } catch (eDom) {
+      try {
+        executeAction(sTID('desaturate'), undefined, DialogModes.NO);
+      } catch (eAction) {
+        var desc = new ActionDescriptor();
+        desc.putEnumerated(sTID('presetKind'), sTID('presetKindType'), sTID('presetKindCustom'));
+        desc.putBoolean(cTID('Clrz'), false);
+        var adjustments = new ActionList();
+        var adjustment = new ActionDescriptor();
+        adjustment.putEnumerated(cTID('Chnl'), cTID('Chnl'), cTID('Cmps'));
+        adjustment.putInteger(cTID('H   '), 0);
+        adjustment.putInteger(cTID('Strt'), -100);
+        adjustment.putInteger(cTID('Lght'), 0);
+        adjustments.putObject(cTID('Hst2'), adjustment);
+        desc.putList(cTID('Adjs'), adjustments);
+        executeAction(cTID('HStr'), desc, DialogModes.NO);
+      }
+    }
+
+    return {
       adjustment: 'Desaturate'
     };
   `,
@@ -1149,21 +1198,29 @@ export const ExtendScriptSnippets = {
    */
   createLayerMask: () => `
     ${helperFunctions}
-    
+
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
-    
-    // Create mask using ActionDescriptor
+
+    var hasSelection = false;
+    try { hasSelection = !!(app.activeDocument.selection.bounds); } catch (e) { hasSelection = false; }
+
     var desc = new ActionDescriptor();
-    var ref = new ActionReference();
-    ref.putEnumerated(cTID('Chnl'), cTID('Chnl'), cTID('Msk '));
-    desc.putReference(cTID('Nw  '), ref);
-    desc.putEnumerated(cTID('Usng'), cTID('UsrM'), cTID('RvlS'));
-    executeAction(cTID('Mk  '), desc, DialogModes.NO);
-    
-    return { 
-      maskCreated: true
+    desc.putClass(sTID('new'), sTID('channel'));
+    var atRef = new ActionReference();
+    atRef.putEnumerated(sTID('layer'), sTID('ordinal'), sTID('targetEnum'));
+    desc.putReference(sTID('at'), atRef);
+    if (hasSelection) {
+      desc.putEnumerated(sTID('using'), sTID('userMaskEnabled'), sTID('revealSelection'));
+    } else {
+      desc.putEnumerated(sTID('using'), cTID('UsrM'), sTID('revealAll'));
+    }
+    executeAction(sTID('make'), desc, DialogModes.NO);
+
+    return {
+      maskCreated: true,
+      fromSelection: hasSelection
     };
   `,
 
@@ -1172,18 +1229,23 @@ export const ExtendScriptSnippets = {
    */
   deleteLayerMask: () => `
     ${helperFunctions}
-    
+
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
-    
+
+    var layer = app.activeDocument.activeLayer;
+    if (!layer.hasLayerMask) {
+      return { maskDeleted: false, message: 'Layer has no mask' };
+    }
+
     var desc = new ActionDescriptor();
     var ref = new ActionReference();
     ref.putEnumerated(cTID('Chnl'), cTID('Chnl'), cTID('Msk '));
     desc.putReference(cTID('null'), ref);
     executeAction(cTID('Dlt '), desc, DialogModes.NO);
-    
-    return { 
+
+    return {
       maskDeleted: true
     };
   `,
@@ -1193,18 +1255,27 @@ export const ExtendScriptSnippets = {
    */
   applyLayerMask: () => `
     ${helperFunctions}
-    
+
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
-    
+
     var desc = new ActionDescriptor();
     var ref = new ActionReference();
-    ref.putEnumerated(cTID('Chnl'), cTID('Chnl'), cTID('Msk '));
-    desc.putReference(cTID('null'), ref);
-    executeAction(cTID('Aply'), desc, DialogModes.NO);
-    
-    return { 
+    ref.putEnumerated(sTID('channel'), sTID('ordinal'), sTID('targetEnum'));
+    desc.putReference(sTID('null'), ref);
+    desc.putBoolean(sTID('apply'), true);
+    try {
+      executeAction(sTID('delete'), desc, DialogModes.NO);
+    } catch (eDeleteApply) {
+      var legacy = new ActionDescriptor();
+      var legacyRef = new ActionReference();
+      legacyRef.putEnumerated(cTID('Chnl'), cTID('Chnl'), cTID('Msk '));
+      legacy.putReference(cTID('null'), legacyRef);
+      executeAction(cTID('Aply'), legacy, DialogModes.NO);
+    }
+
+    return {
       maskApplied: true
     };
   `,
@@ -1232,22 +1303,46 @@ export const ExtendScriptSnippets = {
    * Rasterize active layer
    */
   rasterizeLayer: () => `
+    ${helperFunctions}
+
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
     var layer = app.activeDocument.activeLayer;
-    
+
+    if (layer.typename === 'LayerSet') {
+      throw new Error('Cannot rasterize a layer group — select a single layer');
+    }
+
+    var originalKind = String(layer.kind);
     if (layer.kind === LayerKind.NORMAL) {
-      return { 
+      return {
         message: 'Layer is already rasterized',
         kind: 'NORMAL'
       };
     }
-    
-    var originalKind = String(layer.kind);
-    layer.rasterize(RasterizeType.ENTIRELAYER);
-    
-    return { 
+
+    if (layer.kind === LayerKind.TEXT) {
+      layer.rasterize(RasterizeType.TEXTCONTENTS);
+    } else if (layer.kind === LayerKind.SMARTOBJECT) {
+      var desc = new ActionDescriptor();
+      var ref = new ActionReference();
+      ref.putEnumerated(sTID('layer'), sTID('ordinal'), sTID('targetEnum'));
+      desc.putReference(sTID('null'), ref);
+      executeAction(sTID('rasterizePlaced'), desc, DialogModes.NO);
+    } else {
+      try {
+        layer.rasterize(RasterizeType.ENTIRELAYER);
+      } catch (eDom) {
+        var desc2 = new ActionDescriptor();
+        var ref2 = new ActionReference();
+        ref2.putEnumerated(sTID('layer'), sTID('ordinal'), sTID('targetEnum'));
+        desc2.putReference(sTID('null'), ref2);
+        executeAction(sTID('rasterizeLayer'), desc2, DialogModes.NO);
+      }
+    }
+
+    return {
       rasterized: true,
       originalKind: originalKind,
       newKind: 'NORMAL'
@@ -1464,9 +1559,14 @@ export const ExtendScriptSnippets = {
     }
     var doc = app.activeDocument;
     var layer = doc.activeLayer;
-    
+
+    if (layer.isBackgroundLayer) {
+      throw new Error('Cannot move background layer');
+    }
+
     if (doc.layers.length > 0) {
-      layer.move(doc.layers[doc.layers.length - 1], ElementPlacement.PLACEAFTER);
+      var bottomLayer = doc.layers[doc.layers.length - 1];
+      layer.move(bottomLayer, ElementPlacement.PLACEBEFORE);
     }
     
     var result = {

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -80,6 +80,160 @@ function getContextInfo() {
 }
 `;
 
+/** Curves adjustment layer helper — shared by atomics and recipes (uses __mcp_s2t / __mcp_c2t). */
+export const MCP_CURVES_ADJUSTMENT_HELPER = `
+function __mcp_makeCurvesAdjustmentLayer(preset) {
+  var usePreset = preset || 'auto_tone';
+  var desc = new ActionDescriptor();
+  var ref = new ActionReference();
+  ref.putClass(__mcp_s2t('adjustmentLayer'));
+  desc.putReference(__mcp_s2t('null'), ref);
+  var using = new ActionDescriptor();
+  var curvesAdjust = new ActionDescriptor();
+  var curvesAdjustments = new ActionList();
+  var curvesPair = new ActionDescriptor();
+  var curvesPoints = new ActionList();
+  var ptBlack = new ActionDescriptor();
+  var ptWhite = new ActionDescriptor();
+  if (usePreset === 'neutral') {
+    ptBlack.putDouble(__mcp_c2t('Hrzn'), 0);
+    ptBlack.putDouble(__mcp_c2t('Vrtc'), 0);
+    ptWhite.putDouble(__mcp_c2t('Hrzn'), 255);
+    ptWhite.putDouble(__mcp_c2t('Vrtc'), 255);
+  } else {
+    ptBlack.putDouble(__mcp_c2t('Hrzn'), 12);
+    ptBlack.putDouble(__mcp_c2t('Vrtc'), 0);
+    ptWhite.putDouble(__mcp_c2t('Hrzn'), 243);
+    ptWhite.putDouble(__mcp_c2t('Vrtc'), 255);
+  }
+  curvesPoints.putObject(__mcp_c2t('Pnt '), ptBlack);
+  curvesPoints.putObject(__mcp_c2t('Pnt '), ptWhite);
+  curvesPair.putList(__mcp_c2t('Crv '), curvesPoints);
+  var channelRef = new ActionReference();
+  channelRef.putEnumerated(__mcp_c2t('Chnl'), __mcp_c2t('Chnl'), __mcp_c2t('Cmps'));
+  curvesPair.putReference(__mcp_c2t('Chnl'), channelRef);
+  curvesAdjustments.putObject(__mcp_c2t('CrvA'), curvesPair);
+  curvesAdjust.putList(__mcp_c2t('Adjs'), curvesAdjustments);
+  using.putObject(__mcp_s2t('type'), __mcp_s2t('curves'), curvesAdjust);
+  desc.putObject(__mcp_s2t('using'), __mcp_s2t('adjustmentLayer'), using);
+  executeAction(__mcp_s2t('make'), desc, DialogModes.NO);
+  return app.activeDocument.activeLayer;
+}
+`;
+
+const mcpActionHelperAliases = `
+function __mcp_s2t(s) { return sTID(s); }
+function __mcp_c2t(s) { return cTID(s); }
+`;
+
+/**
+ * Layer mask helpers — Adobe Community / StackSupport.jsx patterns.
+ * @see https://community.adobe.com/t5/photoshop-ecosystem-discussions/is-it-possible-to-make-a-layer-mask-with-the-current-selection-using-extendscript/td-p/10872052
+ * @see https://github.com/LeZuse/photoshop-scripts/blob/master/default/Stack%20Scripts%20Only/StackSupport.jsx
+ */
+export const MCP_LAYER_MASK_HELPERS = `
+function __mcp_hasLayerMaskAM() {
+  var ref = new ActionReference();
+  var args = new ActionDescriptor();
+  ref.putProperty(cTID('Prpr'), cTID('UsrM'));
+  ref.putEnumerated(cTID('Lyr '), cTID('Ordn'), cTID('Trgt'));
+  args.putReference(cTID('null'), ref);
+  try {
+    var resultDesc = executeAction(cTID('getd'), args, DialogModes.NO);
+    return resultDesc.hasKey(cTID('UsrM'));
+  } catch (e) {
+    return false;
+  }
+}
+
+function __mcp_makeLayerMaskAtChannel(maskMode) {
+  var desc = new ActionDescriptor();
+  var atRef = new ActionReference();
+  desc.putClass(sTID('new'), sTID('channel'));
+  atRef.putEnumerated(sTID('channel'), sTID('channel'), sTID('mask'));
+  desc.putReference(sTID('at'), atRef);
+  desc.putEnumerated(sTID('using'), sTID('userMaskEnabled'), sTID(maskMode));
+  executeAction(sTID('make'), desc, DialogModes.NO);
+}
+
+function __mcp_selectLayerMaskChannel() {
+  var selRef = new ActionReference();
+  selRef.putEnumerated(cTID('Chnl'), cTID('Ordn'), cTID('Trgt'));
+  var selDesc = new ActionDescriptor();
+  selDesc.putReference(cTID('null'), selRef);
+  selDesc.putBoolean(cTID('MkVs'), true);
+  executeAction(cTID('slct'), selDesc, DialogModes.NO);
+}
+
+function __mcp_pointDescPx(x, y) {
+  var desc = new ActionDescriptor();
+  desc.putUnitDouble(cTID('Hrzn'), cTID('#Pxl'), x);
+  desc.putUnitDouble(cTID('Vrtc'), cTID('#Pxl'), y);
+  return desc;
+}
+
+function __mcp_gradientStop(location, midPoint) {
+  var desc = new ActionDescriptor();
+  desc.putInteger(cTID('Lctn'), location);
+  desc.putInteger(cTID('Mdpn'), midPoint);
+  return desc;
+}
+
+function __mcp_grayColor(grayValue) {
+  var desc = new ActionDescriptor();
+  desc.putDouble(cTID('Gry '), grayValue);
+  return desc;
+}
+
+/** Linear black-to-white gradient on the active mask channel (StackSupport.jsx pattern). */
+function __mcp_gradientFillLayerMask(fromXPx, fromYPx, toXPx, toYPx, reverseGradient) {
+  var args = new ActionDescriptor();
+  args.putObject(cTID('From'), cTID('Pnt '), __mcp_pointDescPx(fromXPx, fromYPx));
+  args.putObject(cTID('T   '), cTID('Pnt '), __mcp_pointDescPx(toXPx, toYPx));
+  args.putEnumerated(cTID('Md  '), cTID('BlnM'), cTID('Nrml'));
+  args.putEnumerated(cTID('Type'), cTID('GrdT'), cTID('Lnr '));
+  args.putBoolean(cTID('Dthr'), true);
+  args.putBoolean(cTID('UsMs'), true);
+  args.putBoolean(cTID('Rvrs'), !!reverseGradient);
+
+  var gradDesc = new ActionDescriptor();
+  gradDesc.putString(cTID('Nm  '), 'Black, White');
+  gradDesc.putEnumerated(cTID('GrdF'), cTID('GrdF'), cTID('CstS'));
+  gradDesc.putDouble(cTID('Intr'), 4096.0);
+
+  var colorList = new ActionList();
+  var stopWhite = __mcp_gradientStop(0, 50);
+  stopWhite.putObject(cTID('Clr '), cTID('Grsc'), __mcp_grayColor(100.0));
+  stopWhite.putEnumerated(cTID('Type'), cTID('Clry'), cTID('UsrS'));
+  colorList.putObject(cTID('Clrt'), stopWhite);
+  var stopBlack = __mcp_gradientStop(4096, 50);
+  stopBlack.putObject(cTID('Clr '), cTID('Grsc'), __mcp_grayColor(0.0));
+  stopBlack.putEnumerated(cTID('Type'), cTID('Clry'), cTID('UsrS'));
+  colorList.putObject(cTID('Clrt'), stopBlack);
+  gradDesc.putList(cTID('Clrs'), colorList);
+
+  var xferList = new ActionList();
+  var xferA = __mcp_gradientStop(0, 50);
+  xferA.putUnitDouble(cTID('Opct'), cTID('#Prc'), 100.0);
+  xferList.putObject(cTID('TrnS'), xferA);
+  var xferB = __mcp_gradientStop(4096, 50);
+  xferB.putUnitDouble(cTID('Opct'), cTID('#Prc'), 100.0);
+  xferList.putObject(cTID('TrnS'), xferB);
+  gradDesc.putList(cTID('Trns'), xferList);
+
+  args.putObject(cTID('Grad'), cTID('Grdn'), gradDesc);
+  executeAction(cTID('Grdn'), args, DialogModes.NO);
+}
+`;
+
+export type CurvesPreset = 'auto_tone' | 'neutral';
+
+export type GradientMaskDirection =
+  | 'top_to_bottom'
+  | 'bottom_to_top'
+  | 'left_to_right'
+  | 'right_to_left';
+
 /**
  * Common ExtendScript snippets
  */
@@ -956,6 +1110,28 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
+   * Create a Curves adjustment layer (auto-tone S-curve or neutral identity curve).
+   */
+  adjustCurves: (preset: CurvesPreset = 'auto_tone') => `
+    ${helperFunctions}
+    ${mcpActionHelperAliases}
+    ${MCP_CURVES_ADJUSTMENT_HELPER}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+
+    app.displayDialogs = DialogModes.NO;
+    var layer = __mcp_makeCurvesAdjustmentLayer('${preset}');
+
+    return {
+      created: true,
+      layer_name: layer.name,
+      preset: '${preset}'
+    };
+  `,
+
+  /**
    * Desaturate (convert to grayscale without changing color mode)
    */
   desaturate: () => `
@@ -1194,35 +1370,173 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
-   * Create layer mask from selection
+   * Select the main subject on the active layer (DOM selectSubject, then autoCutout fallback).
    */
-  createLayerMask: () => `
+  selectSubject: (sampleAllLayers = false) => `
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+
+    var doc = app.activeDocument;
+    app.displayDialogs = DialogModes.NO;
+
+    var subjectSelected = false;
+    var method = '';
+    try {
+      doc.selection.selectSubject();
+      subjectSelected = true;
+      method = 'selectSubject';
+    } catch (eDomSubject) {}
+
+    if (!subjectSelected) {
+      try {
+        ${helperFunctions}
+        var cutoutDesc = new ActionDescriptor();
+        cutoutDesc.putBoolean(sTID('sampleAllLayers'), ${sampleAllLayers});
+        executeAction(sTID('autoCutout'), cutoutDesc, DialogModes.NO);
+        subjectSelected = true;
+        method = 'autoCutout';
+      } catch (eSelectSubject) {
+        throw new Error('Select Subject is not available: ' + (eSelectSubject.message || eSelectSubject));
+      }
+    }
+
+    var hasSel = false;
+    try { hasSel = doc.selection.bounds != null; } catch (e) { hasSel = false; }
+    if (!hasSel) {
+      throw new Error('Select Subject produced no selection');
+    }
+
+    return {
+      selected: true,
+      method: method
+    };
+  `,
+
+  /**
+   * Content-aware fill on the current pixel selection.
+   */
+  contentAwareFill: () => `
     ${helperFunctions}
 
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
 
+    var doc = app.activeDocument;
+    var hasSel = false;
+    try { hasSel = doc.selection.bounds != null; } catch (e) { hasSel = false; }
+    if (!hasSel) {
+      throw new Error('selection_required');
+    }
+
+    app.displayDialogs = DialogModes.NO;
+
+    var desc = new ActionDescriptor();
+    desc.putEnumerated(sTID('using'), sTID('fillContents'), sTID('contentAware'));
+    executeAction(sTID('fill'), desc, DialogModes.NO);
+    doc.selection.deselect();
+
+    return {
+      filled: true
+    };
+  `,
+
+  /**
+   * Create layer mask from selection
+   */
+  createLayerMask: () => `
+    ${helperFunctions}
+    ${MCP_LAYER_MASK_HELPERS}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+
+    if (__mcp_hasLayerMaskAM()) {
+      return {
+        maskCreated: false,
+        fromSelection: false,
+        message: 'Layer already has a mask'
+      };
+    }
+
     var hasSelection = false;
     try { hasSelection = !!(app.activeDocument.selection.bounds); } catch (e) { hasSelection = false; }
 
-    var desc = new ActionDescriptor();
-    desc.putClass(sTID('new'), sTID('channel'));
-    var atRef = new ActionReference();
-    atRef.putEnumerated(sTID('layer'), sTID('ordinal'), sTID('targetEnum'));
-    desc.putReference(sTID('at'), atRef);
-    if (hasSelection) {
-      desc.putEnumerated(sTID('using'), sTID('userMaskEnabled'), sTID('revealSelection'));
-    } else {
-      desc.putEnumerated(sTID('using'), cTID('UsrM'), sTID('revealAll'));
-    }
-    executeAction(sTID('make'), desc, DialogModes.NO);
+    app.displayDialogs = DialogModes.NO;
+    __mcp_makeLayerMaskAtChannel(hasSelection ? 'revealSelection' : 'revealAll');
 
     return {
       maskCreated: true,
       fromSelection: hasSelection
     };
   `,
+
+  /**
+   * Apply a linear black-to-white gradient on the active layer's mask channel.
+   */
+  applyGradientMask: (
+    direction: GradientMaskDirection = 'bottom_to_top',
+    startPct = 0,
+    endPct = 100,
+    angleDeg?: number
+  ) => {
+    const gradientEndpoints: Record<
+      GradientMaskDirection,
+      { fromH: number; fromV: number; toH: number; toV: number; reverse: boolean }
+    > = {
+      bottom_to_top: { fromH: 50, fromV: endPct, toH: 50, toV: startPct, reverse: false },
+      top_to_bottom: { fromH: 50, fromV: startPct, toH: 50, toV: endPct, reverse: false },
+      left_to_right: { fromH: startPct, fromV: 50, toH: endPct, toV: 50, reverse: false },
+      right_to_left: { fromH: endPct, fromV: 50, toH: startPct, toV: 50, reverse: false },
+    };
+    const endpoints = gradientEndpoints[direction];
+    const angle = angleDeg ?? (direction === 'left_to_right' || direction === 'right_to_left' ? 0 : 90);
+
+    return `
+    ${helperFunctions}
+    ${MCP_LAYER_MASK_HELPERS}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+
+    var doc = app.activeDocument;
+    var layer = doc.activeLayer;
+    if (!layer) {
+      throw new Error('No active layer');
+    }
+
+    if (!__mcp_hasLayerMaskAM()) {
+      throw new Error('Active layer has no layer mask');
+    }
+
+    app.displayDialogs = DialogModes.NO;
+    doc.activeLayer = layer;
+    __mcp_selectLayerMaskChannel();
+
+    var docW = doc.width.as('px');
+    var docH = doc.height.as('px');
+    var fromXPx = docW * (${endpoints.fromH} / 100.0);
+    var fromYPx = docH * (${endpoints.fromV} / 100.0);
+    var toXPx = docW * (${endpoints.toH} / 100.0);
+    var toYPx = docH * (${endpoints.toV} / 100.0);
+    __mcp_gradientFillLayerMask(fromXPx, fromYPx, toXPx, toYPx, ${endpoints.reverse});
+
+    try {
+      doc.activeChannels = doc.componentChannels;
+    } catch (eRestore) {
+      doc.activeLayer = layer;
+    }
+
+    return {
+      applied: true,
+      direction: '${direction}',
+      angle: ${angle}
+    };
+  `;
+  },
 
   /**
    * Delete layer mask

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -21,6 +21,7 @@ function getContextInfo() {
   };
   
   if (context.hasDocument) {
+    try {
     var doc = app.activeDocument;
     context.document = {
       name: doc.name,
@@ -39,30 +40,39 @@ function getContextInfo() {
       })()
     };
     
-    if (doc.activeLayer) {
-      var layer = doc.activeLayer;
-      context.activeLayer = {
-        name: layer.name,
-        kind: String(layer.kind),
-        opacity: layer.opacity,
-        blendMode: String(layer.blendMode),
-        visible: layer.visible,
-        locked: layer.allLocked,
-        isBackground: layer.isBackgroundLayer
-      };
-      
-      // Add bounds if available
-      try {
-        var bounds = layer.bounds;
-        context.activeLayer.bounds = {
-          left: bounds[0].as('px'),
-          top: bounds[1].as('px'),
-          right: bounds[2].as('px'),
-          bottom: bounds[3].as('px')
+    try {
+      if (doc.activeLayer) {
+        var layer = doc.activeLayer;
+        context.activeLayer = {
+          name: layer.name,
+          kind: String(layer.kind),
+          opacity: layer.opacity,
+          blendMode: String(layer.blendMode),
+          visible: layer.visible,
+          locked: layer.allLocked
         };
-      } catch (e) {
-        // Bounds not available for some layer types
+        try {
+          context.activeLayer.isBackground = layer.isBackgroundLayer;
+        } catch (e) {
+          context.activeLayer.isBackground = false;
+        }
+        try {
+          var bounds = layer.bounds;
+          context.activeLayer.bounds = {
+            left: bounds[0].as('px'),
+            top: bounds[1].as('px'),
+            right: bounds[2].as('px'),
+            bottom: bounds[3].as('px')
+          };
+        } catch (e) {
+          // Bounds not available for some layer types
+        }
       }
+    } catch (e) {
+      context.activeLayer = null;
+    }
+    } catch (e) {
+      context.document = { error: e.message || String(e) };
     }
   }
   
@@ -1548,6 +1558,60 @@ export const ExtendScriptSnippets = {
       context: getContextInfo()
     };
     return result;
+  `,
+
+  /**
+   * Lightweight session state snapshot (read-only).
+   */
+  getState: () => `
+    ${getContextInfo}
+    return getContextInfo();
+  `,
+
+  /**
+   * Export a JPEG preview to the system temp folder. Returns filesystem path for Node to read.
+   */
+  exportPreview: (maxDimension = 1024, jpegQuality = 8) => `
+    ${getContextInfo}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+
+    var doc = app.activeDocument;
+    var w = doc.width.as('px');
+    var h = doc.height.as('px');
+    var maxDim = ${maxDimension};
+    var scale = 1;
+    if (w > maxDim || h > maxDim) {
+      scale = maxDim / Math.max(w, h);
+    }
+
+    var dup = doc.duplicate('__mcp_preview__', true);
+    if (scale < 1) {
+      dup.resizeImage(
+        UnitValue(Math.round(w * scale), 'px'),
+        UnitValue(Math.round(h * scale), 'px'),
+        doc.resolution,
+        ResampleMethod.BICUBIC
+      );
+    }
+
+    var tmpFile = new File(Folder.temp.fsName + '/ps-preview-' + (new Date().getTime()) + '.jpg');
+    var saveOptions = new JPEGSaveOptions();
+    saveOptions.quality = ${jpegQuality};
+    saveOptions.embedColorProfile = true;
+    saveOptions.formatOptions = FormatOptions.STANDARDBASELINE;
+    dup.flatten();
+    dup.saveAs(tmpFile, saveOptions, true);
+    dup.close(SaveOptions.DONOTSAVECHANGES);
+
+    return {
+      path: tmpFile.fsName,
+      width: Math.round(w * scale),
+      height: Math.round(h * scale),
+      mimeType: 'image/jpeg'
+    };
   `,
 };
 

--- a/src/core/prompt-registry.ts
+++ b/src/core/prompt-registry.ts
@@ -1,0 +1,48 @@
+import type { GetPromptResult, Prompt } from '@modelcontextprotocol/sdk/types.js';
+import { Logger } from '../utils/logger.js';
+import type { PromptDefinition } from '../prompts/_shared.js';
+
+export type { PromptDefinition };
+
+export interface PromptHandler {
+  (args: Record<string, string>): Promise<GetPromptResult> | GetPromptResult;
+}
+
+export class PromptRegistry {
+  private logger: Logger;
+  private prompts: Map<string, PromptDefinition>;
+
+  constructor() {
+    this.logger = new Logger('PromptRegistry');
+    this.prompts = new Map();
+  }
+
+  register(name: string, definition: PromptDefinition): void {
+    if (this.prompts.has(name)) {
+      this.logger.warn(`Prompt '${name}' already registered, overwriting`);
+    }
+    this.prompts.set(name, definition);
+    this.logger.debug(`Registered prompt: ${name}`);
+  }
+
+  has(name: string): boolean {
+    return this.prompts.has(name);
+  }
+
+  list(): Prompt[] {
+    return Array.from(this.prompts.values()).map((def) => def.prompt);
+  }
+
+  async get(name: string, args: Record<string, string>): Promise<GetPromptResult> {
+    const def = this.prompts.get(name);
+    if (!def) {
+      throw new Error(`Prompt not found: ${name}`);
+    }
+    this.logger.debug(`Resolving prompt: ${name}`);
+    return await def.handler(args);
+  }
+
+  count(): number {
+    return this.prompts.size;
+  }
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -23,6 +23,7 @@ import { createFilterTools } from '../tools/filter-tools.js';
 import { createAdjustmentTools } from '../tools/adjustment-tools.js';
 import { createTextTools } from '../tools/text-tools.js';
 import { createSelectionTools } from '../tools/selection-tools.js';
+import { createMaskTools } from '../tools/mask-tools.js';
 import { createActionTools } from '../tools/action-tools.js';
 import { createHistoryTools } from '../tools/history-tools.js';
 import { createLayerOrderingTools } from '../tools/layer-ordering-tools.js';
@@ -113,6 +114,7 @@ export class PhotoshopMCPServer {
     this.registerToolDefinitions(createAdjustmentTools(connection));
     this.registerToolDefinitions(createTextTools(connection));
     this.registerToolDefinitions(createSelectionTools(connection));
+    this.registerToolDefinitions(createMaskTools(connection));
     this.registerToolDefinitions(createActionTools(connection));
     this.registerToolDefinitions(createHistoryTools(connection));
     this.registerToolDefinitions(createLayerOrderingTools(connection));

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -3,10 +3,16 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { Logger } from '../utils/logger.js';
-import { ToolRegistry } from './tool-registry.js';
+import { ToolRegistry, ToolDefinition } from './tool-registry.js';
+import { PromptRegistry } from './prompt-registry.js';
 import { Session } from './session.js';
+import { wrapToolHandler } from '../errors/envelope.js';
+import { buildPhotoshopInstructions } from '../prompts/instructions.js';
+import { registerPhotoshopPrompts } from '../prompts/registry.js';
 import { createDocumentTools } from '../tools/document-tools.js';
 import { createLayerTools } from '../tools/layer-tools.js';
 import { createImageTools } from '../tools/image-tools.js';
@@ -20,164 +26,129 @@ import { createSelectionTools } from '../tools/selection-tools.js';
 import { createActionTools } from '../tools/action-tools.js';
 import { createHistoryTools } from '../tools/history-tools.js';
 import { createLayerOrderingTools } from '../tools/layer-ordering-tools.js';
+import { createStateTools } from '../tools/state-tools.js';
+import { createRecipeTools } from '../tools/recipes/index.js';
 
 export class PhotoshopMCPServer {
   private server: Server;
   private logger: Logger;
   private toolRegistry: ToolRegistry;
+  private promptRegistry: PromptRegistry;
   private session: Session;
 
   constructor() {
     this.logger = new Logger('PhotoshopMCPServer');
     this.toolRegistry = new ToolRegistry();
+    this.promptRegistry = new PromptRegistry();
     this.session = new Session();
 
     this.server = new Server(
       {
         name: 'photoshop-mcp',
-        version: '0.1.0',
+        version: '1.1.2',
       },
       {
         capabilities: {
           tools: {},
+          prompts: {},
         },
+        instructions: buildPhotoshopInstructions(),
       }
     );
 
+    registerPhotoshopPrompts(this.promptRegistry);
     this.registerTools();
     this.setupHandlers();
   }
 
+  private registerToolDefinition(definition: ToolDefinition): void {
+    this.toolRegistry.register(definition.tool.name, {
+      tool: definition.tool,
+      handler: wrapToolHandler(definition.handler),
+    });
+  }
+
+  private registerToolDefinitions(definitions: ToolDefinition[]): void {
+    definitions.forEach((def) => this.registerToolDefinition(def));
+  }
+
   private registerTools() {
-    // Register basic tools
-    this.toolRegistry.register('photoshop_ping', {
+    this.registerToolDefinition({
       tool: {
         name: 'photoshop_ping',
-        description: 'Test connection to Photoshop',
-        inputSchema: {
-          type: 'object',
-          properties: {},
-        },
+        description:
+          'Verify Photoshop is installed and reachable on this machine.\n\n' +
+          'Use when: once at session start if connection status is unknown.\n' +
+          'Do NOT use when: on every tool call — call once, then use photoshop_get_state.\n\n' +
+          'Returns: connection success or failure message.\n' +
+          'Preconditions: none. Side effects: may trigger Photoshop detection.',
+        inputSchema: { type: 'object', properties: {} },
       },
-      handler: async () => await this.pingPhotoshop(),
+      handler: async () => this.pingPhotoshop(),
     });
 
-    this.toolRegistry.register('photoshop_get_version', {
+    this.registerToolDefinition({
       tool: {
         name: 'photoshop_get_version',
-        description: 'Get Photoshop version information',
-        inputSchema: {
-          type: 'object',
-          properties: {},
-        },
+        description:
+          'Return the detected Photoshop version string.\n\n' +
+          'Use when: user asks about compatibility or before version-gated features.\n' +
+          'Do NOT use when: you need feature flags — prefer photoshop_get_capabilities.\n\n' +
+          'Returns: version string.\n' +
+          'Preconditions: none. Side effects: none.',
+        inputSchema: { type: 'object', properties: {} },
       },
-      handler: async () => await this.getVersion(),
+      handler: async () => this.getVersion(),
     });
 
-    // Register feature tools
     const connection = this.session.getConnection();
-    
-    const documentTools = createDocumentTools(connection);
-    documentTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
 
-    const layerTools = createLayerTools(connection);
-    layerTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
+    this.registerToolDefinitions(createDocumentTools(connection));
+    this.registerToolDefinitions(createLayerTools(connection));
+    this.registerToolDefinitions(createImageTools(connection));
+    this.registerToolDefinitions(createImagePlacementTools(connection));
+    this.registerToolDefinitions(createLayerTransformTools(connection));
+    this.registerToolDefinitions(createLayerPropertiesTools(connection));
+    this.registerToolDefinitions(createFilterTools(connection));
+    this.registerToolDefinitions(createAdjustmentTools(connection));
+    this.registerToolDefinitions(createTextTools(connection));
+    this.registerToolDefinitions(createSelectionTools(connection));
+    this.registerToolDefinitions(createActionTools(connection));
+    this.registerToolDefinitions(createHistoryTools(connection));
+    this.registerToolDefinitions(createLayerOrderingTools(connection));
+    this.registerToolDefinitions(createStateTools(connection));
+    this.registerToolDefinitions(createRecipeTools(connection));
 
-    const imageTools = createImageTools(connection);
-    imageTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const imagePlacementTools = createImagePlacementTools(connection);
-    imagePlacementTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const layerTransformTools = createLayerTransformTools(connection);
-    layerTransformTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const layerPropertiesTools = createLayerPropertiesTools(connection);
-    layerPropertiesTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const filterTools = createFilterTools(connection);
-    filterTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const adjustmentTools = createAdjustmentTools(connection);
-    adjustmentTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const textTools = createTextTools(connection);
-    textTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const selectionTools = createSelectionTools(connection);
-    selectionTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const actionTools = createActionTools(connection);
-    actionTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const historyTools = createHistoryTools(connection);
-    historyTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    const layerOrderingTools = createLayerOrderingTools(connection);
-    layerOrderingTools.forEach((tool) => {
-      this.toolRegistry.register(tool.tool.name, tool);
-    });
-
-    this.logger.info(`Registered ${this.toolRegistry.count()} tools`);
+    this.logger.info(
+      `Registered ${this.toolRegistry.count()} tools and ${this.promptRegistry.count()} prompts`
+    );
   }
 
   private setupHandlers() {
-    // List available tools
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       this.logger.debug('Listing available tools');
-      return {
-        tools: this.toolRegistry.list(),
-      };
+      return { tools: this.toolRegistry.list() };
     });
 
-    // Handle tool calls
+    this.server.setRequestHandler(ListPromptsRequestSchema, async () => {
+      this.logger.debug('Listing available prompts');
+      return { prompts: this.promptRegistry.list() };
+    });
+
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      const name = request.params.name;
+      const args = (request.params.arguments as Record<string, string>) || {};
+      this.logger.debug(`Prompt requested: ${name}`);
+      return await this.promptRegistry.get(name, args);
+    });
+
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       this.logger.debug(`Tool called: ${request.params.name}`);
-      
-      try {
-        const args = (request.params.arguments as Record<string, unknown>) || {};
-        const result = await this.toolRegistry.execute(request.params.name, args);
-        
-        // Update session activity
-        this.session.updateActivity();
-        
-        return result;
-      } catch (error) {
-        this.logger.error(`Tool execution failed: ${request.params.name}`, error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-          isError: true,
-        };
-      }
+
+      const args = (request.params.arguments as Record<string, unknown>) || {};
+      const result = await this.toolRegistry.execute(request.params.name, args);
+      this.session.updateActivity();
+      return result;
     });
   }
 
@@ -210,13 +181,11 @@ export class PhotoshopMCPServer {
   }
 
   async start() {
-    // Initialize session
     await this.session.initialize();
 
-    // Connect server transport
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    
+
     this.logger.info('MCP Server connected via stdio');
   }
 

--- a/src/errors/envelope.ts
+++ b/src/errors/envelope.ts
@@ -1,0 +1,107 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolHandler } from '../core/tool-registry.js';
+
+export type PhotoshopErrorCode =
+  | 'no_active_document'
+  | 'no_active_layer'
+  | 'layer_not_found'
+  | 'selection_required'
+  | 'version_unsupported'
+  | 'generative_unavailable'
+  | 'extendscript_runtime_error'
+  | 'file_not_found'
+  | 'unsupported_color_mode'
+  | 'unknown';
+
+export interface PhotoshopErrorEnvelope {
+  ok: false;
+  code: PhotoshopErrorCode;
+  message: string;
+  suggested_next_tool?: string;
+  suggested_args?: Record<string, unknown>;
+}
+
+const ERROR_PATTERNS: Array<{
+  pattern: RegExp;
+  code: PhotoshopErrorCode;
+  suggested_next_tool?: string;
+}> = [
+  { pattern: /no active document/i, code: 'no_active_document', suggested_next_tool: 'photoshop_get_state' },
+  { pattern: /no documents/i, code: 'no_active_document', suggested_next_tool: 'photoshop_get_state' },
+  { pattern: /no active layer/i, code: 'no_active_layer', suggested_next_tool: 'photoshop_get_layers' },
+  { pattern: /layer not found/i, code: 'layer_not_found', suggested_next_tool: 'photoshop_get_layers' },
+  { pattern: /selection/i, code: 'selection_required', suggested_next_tool: 'photoshop_get_state' },
+  { pattern: /version_unsupported|not supported.*version/i, code: 'version_unsupported', suggested_next_tool: 'photoshop_get_capabilities' },
+  { pattern: /generative/i, code: 'generative_unavailable', suggested_next_tool: 'photoshop_get_capabilities' },
+  { pattern: /file not found|does not exist/i, code: 'file_not_found' },
+  { pattern: /color mode/i, code: 'unsupported_color_mode', suggested_next_tool: 'photoshop_get_document_info' },
+];
+
+export function classifyError(message: string): PhotoshopErrorEnvelope {
+  for (const { pattern, code, suggested_next_tool } of ERROR_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        ok: false,
+        code,
+        message,
+        ...(suggested_next_tool ? { suggested_next_tool } : {}),
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    code: message.includes('ERROR:') ? 'extendscript_runtime_error' : 'unknown',
+    message,
+    suggested_next_tool: 'photoshop_get_state',
+  };
+}
+
+export function envelopeToToolResult(envelope: PhotoshopErrorEnvelope): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(envelope, null, 2) }],
+    isError: true,
+  };
+}
+
+export function enrichErrorResult(result: CallToolResult): CallToolResult {
+  const text = result.content
+    .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+    .map((c) => c.text)
+    .join('\n');
+
+  if (!text) return result;
+
+  try {
+    const parsed = JSON.parse(text) as { ok?: boolean; code?: string };
+    if (parsed.ok === false && parsed.code) return result;
+  } catch {
+    // not JSON — classify plain error text
+  }
+
+  if (text.startsWith('Error:') || text.toLowerCase().includes('error')) {
+    const message = text.replace(/^Error:\s*/i, '').trim();
+    return envelopeToToolResult(classifyError(message));
+  }
+
+  return result;
+}
+
+export function buildEnvelopeFromError(error: unknown): CallToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return envelopeToToolResult(classifyError(message));
+}
+
+export function wrapToolHandler(handler: ToolHandler): ToolHandler {
+  return async (args) => {
+    try {
+      const result = await handler(args);
+      if (result.isError) {
+        return enrichErrorResult(result);
+      }
+      return result;
+    } catch (error) {
+      return buildEnvelopeFromError(error);
+    }
+  };
+}

--- a/src/lib/export-paths.ts
+++ b/src/lib/export-paths.ts
@@ -1,0 +1,73 @@
+import { randomBytes } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute, join, normalize, relative, resolve } from 'node:path';
+
+const EXPORTS_SUBDIR = 'exports';
+
+/** Set by the UI chat runner so default exports land under ~/.photoshop-mcp/exports/<id>/. */
+export const PHOTOSHOP_EXPORT_CHAT_ID_ENV = 'PHOTOSHOP_EXPORT_CHAT_ID';
+
+export function sanitizeExportChatSegment(raw: string | undefined | null): string | null {
+  const t = (raw ?? '').trim();
+  if (!t) return null;
+  if (!/^[a-zA-Z0-9_-]+$/.test(t)) return null;
+  if (t === '.' || t === '..') return null;
+  return t;
+}
+
+export function getPhotoshopMcpHomeDir(): string {
+  const env = process.env.PHOTOSHOP_MCP_HOME?.trim();
+  if (env) return env;
+  return join(homedir(), '.photoshop-mcp');
+}
+
+export function getPhotoshopExportsDir(): string {
+  const dir = join(getPhotoshopMcpHomeDir(), EXPORTS_SUBDIR);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return dir;
+}
+
+export function getPhotoshopExportsWorkingDir(): string {
+  const root = getPhotoshopExportsDir();
+  const seg = sanitizeExportChatSegment(process.env[PHOTOSHOP_EXPORT_CHAT_ID_ENV]);
+  if (!seg) return root;
+  const dir = join(root, seg);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return dir;
+}
+
+function normalizeExt(ext: string): string {
+  const e = ext.replace(/^\.+/, '').toLowerCase();
+  return e || 'bin';
+}
+
+function assertResolvedUnderExports(exportsDir: string, resolved: string): void {
+  const rel = relative(exportsDir, resolved);
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error('Resolved path escapes Photoshop MCP exports directory');
+  }
+}
+
+/**
+ * Resolve a save/export path: optional user path, default file under
+ * ~/.photoshop-mcp/exports (or ~/.photoshop-mcp/exports/<chatId> in UI mode).
+ */
+export function resolveExportPath(userPath: string | undefined, ext: string): string {
+  const exportsDir = getPhotoshopExportsWorkingDir();
+  const dotExt = `.${normalizeExt(ext)}`;
+
+  const trimmed = userPath?.trim();
+  if (!trimmed) {
+    const base = `photoshop-export-${Date.now()}-${randomBytes(4).toString('hex')}${dotExt}`;
+    return join(exportsDir, base);
+  }
+
+  if (isAbsolute(trimmed)) {
+    return normalize(trimmed);
+  }
+
+  const resolved = resolve(exportsDir, trimmed);
+  assertResolvedUnderExports(exportsDir, resolved);
+  return resolved;
+}

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -1,0 +1,67 @@
+import { PhotoshopDetector } from './detector.js';
+
+export interface ParsedPhotoshopVersion {
+  major: number;
+  minor: number;
+  year?: number;
+  raw: string;
+}
+
+export interface PhotoshopCapabilities {
+  version: string;
+  features: {
+    select_subject_v2: boolean;
+    generative_fill: boolean;
+    generative_upscale: boolean;
+    execute_as_modal_timeout: boolean;
+    uxp_plugin_api: boolean;
+  };
+}
+
+export function parsePhotoshopVersion(version: string): ParsedPhotoshopVersion {
+  const numeric = version.match(/(\d+)\.?(\d*)/);
+  if (numeric) {
+    return {
+      major: parseInt(numeric[1], 10),
+      minor: numeric[2] ? parseInt(numeric[2], 10) : 0,
+      raw: version,
+    };
+  }
+
+  const yearMatch = version.match(/20(\d{2})/);
+  if (yearMatch) {
+    const year = parseInt(`20${yearMatch[1]}`, 10);
+    return {
+      major: year - 1990,
+      minor: 0,
+      year,
+      raw: version,
+    };
+  }
+
+  return { major: 0, minor: 0, raw: version };
+}
+
+export function getPhotoshopCapabilities(version: string): PhotoshopCapabilities {
+  const parsed = parsePhotoshopVersion(version);
+  const detector = new PhotoshopDetector();
+
+  const major = parsed.major;
+  const year = parsed.year ?? (major >= 13 ? 1990 + major : undefined);
+
+  const selectSubjectV2 = major >= 23 || (year !== undefined && year >= 2020);
+  const generativeFill = major >= 25 || (year !== undefined && year >= 2024);
+  const generativeUpscale = major >= 27 || (year !== undefined && year >= 2025);
+  const executeAsModal = major >= 25 || (year !== undefined && year >= 2024);
+
+  return {
+    version,
+    features: {
+      select_subject_v2: selectSubjectV2,
+      generative_fill: generativeFill,
+      generative_upscale: generativeUpscale,
+      execute_as_modal_timeout: executeAsModal,
+      uxp_plugin_api: detector.supportsUXP(version),
+    },
+  };
+}

--- a/src/platform/detector.ts
+++ b/src/platform/detector.ts
@@ -67,4 +67,19 @@ export class PhotoshopDetector {
   getRecommendedAPI(version: string): 'UXP' | 'ExtendScript' {
     return this.supportsUXP(version) ? 'UXP' : 'ExtendScript';
   }
+
+  /** Select Subject v2 ("autoCutout") shipped with PS 23.0 (2022). */
+  supportsSelectSubjectV2(version: string): boolean {
+    const versionMatch = version.match(/(\d+)\.?(\d*)/);
+    if (versionMatch) {
+      const major = parseInt(versionMatch[1], 10);
+      const minor = versionMatch[2] ? parseInt(versionMatch[2], 10) : 0;
+      return major > 23 || (major === 23 && minor >= 0);
+    }
+    const yearMatch = version.match(/20(\d{2})/);
+    if (yearMatch) {
+      return parseInt(`20${yearMatch[1]}`, 10) >= 2022;
+    }
+    return false;
+  }
 }

--- a/src/platform/macos-executor.ts
+++ b/src/platform/macos-executor.ts
@@ -4,6 +4,7 @@ import { writeFile, unlink } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Logger } from '../utils/logger.js';
+import { parseExtendScriptPayload } from '../utils/extendscript-result.js';
 import { ScriptExecutor } from './script-executor.js';
 
 const execAsync = promisify(exec);
@@ -120,11 +121,7 @@ end tell`;
       throw new Error(trimmed.substring(6).trim());
     }
 
-    try {
-      return JSON.parse(trimmed);
-    } catch {
-      return trimmed;
-    }
+    return parseExtendScriptPayload(trimmed);
   }
 
   async isPhotoshopRunning(): Promise<boolean> {

--- a/src/prompts/_shared.ts
+++ b/src/prompts/_shared.ts
@@ -1,0 +1,79 @@
+import type { GetPromptResult, PromptArgument } from '@modelcontextprotocol/sdk/types.js';
+
+export function argString(args: Record<string, string>, key: string, defaultValue: string): string {
+  const raw = args[key];
+  if (typeof raw !== 'string' || raw.trim() === '') return defaultValue;
+  return raw.trim();
+}
+
+export function argInt(args: Record<string, string>, key: string, defaultValue: number): number {
+  const raw = args[key];
+  if (typeof raw !== 'string' || raw.trim() === '') return defaultValue;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : defaultValue;
+}
+
+export function argBool(args: Record<string, string>, key: string, defaultValue: boolean): boolean {
+  const raw = args[key];
+  if (typeof raw !== 'string') return defaultValue;
+  const v = raw.trim().toLowerCase();
+  if (v === 'true' || v === '1' || v === 'yes' || v === 'y') return true;
+  if (v === 'false' || v === '0' || v === 'no' || v === 'n') return false;
+  return defaultValue;
+}
+
+export function argEnum<T extends string>(
+  args: Record<string, string>,
+  key: string,
+  options: readonly T[],
+  defaultValue: T
+): T {
+  const raw = args[key];
+  if (typeof raw !== 'string') return defaultValue;
+  const v = raw.trim().toLowerCase();
+  const hit = options.find((o) => o.toLowerCase() === v);
+  return hit ?? defaultValue;
+}
+
+export function argList(args: Record<string, string>, key: string, defaultValue: string[]): string[] {
+  const raw = args[key];
+  if (typeof raw !== 'string' || raw.trim() === '') return defaultValue;
+  return raw
+    .split(/[,\s]+/g)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function userPrompt(description: string, text: string): GetPromptResult {
+  return {
+    description,
+    messages: [{ role: 'user', content: { type: 'text', text } }],
+  };
+}
+
+export interface PhotoshopPromptTemplate {
+  name: string;
+  description: string;
+  arguments: PromptArgument[];
+  handler: (args: Record<string, string>) => GetPromptResult;
+}
+
+export interface PromptDefinition {
+  prompt: {
+    name: string;
+    description?: string;
+    arguments?: PromptArgument[];
+  };
+  handler: (args: Record<string, string>) => GetPromptResult;
+}
+
+export function toPromptDefinition(t: PhotoshopPromptTemplate): PromptDefinition {
+  return {
+    prompt: {
+      name: t.name,
+      description: t.description,
+      arguments: t.arguments,
+    },
+    handler: t.handler,
+  };
+}

--- a/src/prompts/instructions.ts
+++ b/src/prompts/instructions.ts
@@ -24,13 +24,19 @@ State before action
 
 Recipe tools over atomic chains
 - When the user's request matches a recipe purpose ("remove background",
-  "enhance portrait", "prepare for web", "export Instagram variants",
-  "apply cinematic color grade", "frequency separation", "replace mockup",
-  "organize layers"), prefer the matching \`photoshop_recipe_*\` tool over
-  composing 5+ atomic calls yourself. Recipes are wrapped in a single
-  history step and are deterministically reversible with one undo.
+  "cut out", "isolate subject", "enhance portrait", "smooth skin", "retouch",
+  "prepare for web", "export Instagram variants", "apply cinematic color grade",
+  "make it pop", "frequency separation", "replace mockup", "organize layers",
+  "replace sky", "fade into background", "gradient mask", "dodge and burn",
+  "remove that person", "erase distraction"), prefer the matching
+  \`photoshop_recipe_*\` tool over composing 5+ atomic calls yourself. Recipes
+  are wrapped in a single history step and are deterministically reversible
+  with one undo.
 - Drop back to atomic \`photoshop_*\` tools only for fine-grained, novel
   edits that no recipe covers.
+- For teaching step-by-step mask/composite workflows, call \`prompts/get\` on
+  a guide prompt (see Guide prompts below). Prefer the matching \`ps.*\`
+  **recipe** prompt when the user wants a one-undo outcome.
 
 Units & conventions
 - All numeric coordinates, widths, heights and bounds are pixels. The server
@@ -61,6 +67,66 @@ Multi-step etiquette
 - Group related atomic edits inside a recipe when possible. When you must
   chain atomics, name layers (\`photoshop_rename_layer\`) so future turns can
   re-target them deterministically.
+
+User intent glossary
+- Map colloquial phrases to the primary tool below.
+- bg.remove — "remove background", "cut out", "isolate subject", "transparent
+  background", "arka planı sil" → \`photoshop_recipe_remove_background\`
+- obj.remove — "remove that person", "erase distraction", "generative remove"
+  → \`photoshop_recipe_remove_distraction\` (content-aware; select region first);
+  fallback \`photoshop_content_aware_fill\` after manual selection
+- mask.gradient_fade — "fade into background", "gradient mask", "blend subject"
+  → \`photoshop_recipe_gradient_fade\`; guide \`ps.gradient_blend\` for atomic chain
+- sky.replace — "replace sky", "fix blown sky", "better clouds" →
+  \`photoshop_recipe_sky_blend\`; guide \`ps.composite_blend\` for manual composite
+- portrait.enhance — "smooth skin", "retouch portrait", "fix blemishes" →
+  \`photoshop_recipe_enhance_portrait\`
+- portrait.freq_sep — "frequency separation", "split texture and color" →
+  \`photoshop_recipe_frequency_separation\`
+- color.correct — "make it pop", "S-curve", "fix flat image", "auto tone" →
+  \`photoshop_adjust_curves\`; fallback \`photoshop_auto_levels\` then
+  \`photoshop_adjust_brightness_contrast\`; guide \`ps.color_correct\`
+- color.grade — "cinematic", "teal orange", "moody grade" →
+  \`photoshop_recipe_apply_color_grade\`
+- light.dodge_burn — "dodge and burn", "sculpt light", "lighten face" →
+  \`photoshop_recipe_dodge_burn\`; guide \`ps.dodge_burn_guide\` for atomic setup
+- export.social — "for Instagram", "web export" →
+  \`photoshop_recipe_export_social_variants\` or \`photoshop_recipe_prepare_for_web\`
+- layers.organize — "organize layers", "rename mess" → \`photoshop_recipe_organize_layers\`
+
+Degrade paths
+- Generative remove / distraction — ideal \`photoshop_generative_remove\` is not
+  available via ExtendScript. Degrade: user selects region →
+  \`photoshop_recipe_remove_distraction\` or \`photoshop_content_aware_fill\` →
+  ask user to refine manually.
+- Sky replacement menu — ideal \`photoshop_sky_replacement\` is not scriptable.
+  Degrade: \`photoshop_recipe_sky_blend\` when a sky file path is available;
+  otherwise \`photoshop_place_image\` + \`photoshop_create_layer_mask\` +
+  \`photoshop_apply_gradient_mask\` or guide \`ps.composite_blend\`.
+- Select Subject v2 missing — \`photoshop_recipe_remove_background\` returns
+  \`version_unsupported\` → manual selection tools + \`photoshop_create_layer_mask\`.
+- Curves unavailable — use \`photoshop_auto_levels\` then
+  \`photoshop_adjust_brightness_contrast\` before retrying stronger edits.
+
+Disambiguation
+- "gradient" — prefer linear gradient **on a layer mask** (blend/fade); not a
+  Gradient Fill layer unless the user explicitly asks for a fill layer.
+- "remove" — prefer mask or content-aware inpainting; not deleting the layer
+  unless the user explicitly wants pixels destroyed.
+- "sharpen" — web export sharpen pass → \`photoshop_recipe_prepare_for_web\`;
+  single-layer sharpen → \`photoshop_apply_sharpen\`.
+
+Guide prompts (MCP prompts/get)
+- Prefer matching \`ps.*\` **recipe** prompt when the user wants a one-undo outcome;
+  use guide prompts for teaching atomic chains.
+- Recipe prompts (1:1 with \`photoshop_recipe_*\`): \`ps.remove_background\`,
+  \`ps.enhance_portrait\`, \`ps.prepare_for_web\`, \`ps.export_social_variants\`,
+  \`ps.apply_color_grade\`, \`ps.frequency_separation\`, \`ps.batch_mockup_replace\`,
+  \`ps.organize_layers\`, \`ps.gradient_fade\`, \`ps.sky_blend\`, \`ps.dodge_burn\`,
+  \`ps.remove_distraction\`
+- Guide prompts (no recipe pair): \`ps.gradient_blend\` — fade via mask gradient;
+  \`ps.color_correct\` — tone / contrast fix chain; \`ps.dodge_burn_guide\` — 50% gray
+  overlay setup; \`ps.composite_blend\` — place asset + mask + blend mode
 `.trim();
 
 export function buildPhotoshopInstructions(): string {

--- a/src/prompts/instructions.ts
+++ b/src/prompts/instructions.ts
@@ -1,0 +1,68 @@
+/**
+ * Server-level guidance for host LLMs (Cursor, Claude Desktop, standalone UI).
+ * Advertised on MCP `initialize` via ServerOptions.instructions.
+ */
+export const PHOTOSHOP_MCP_INSTRUCTIONS = `
+Photoshop tools (photoshop-mcp server)
+=====================================
+
+Session bootstrap
+- Call \`photoshop_ping\` exactly once at the start of a session to verify the
+  connection. Do not repeat it on every turn.
+- Before suggesting AI-powered features (Generative Fill, Generative Upscale,
+  Select Subject v2, neural filters, etc.), call \`photoshop_get_capabilities\`
+  once to learn which features the user's installed Photoshop version exposes.
+
+State before action
+- Before any tool that needs an active document or active layer, call
+  \`photoshop_get_state\` to confirm what is currently open. Treat its output as
+  the source of truth for document dimensions, activeLayer, selection bounds and color
+  mode.
+- For visual confirmation after meaningful edits, call
+  \`photoshop_get_preview\` (cheap, side-effect free JPEG snapshot). Use it
+  sparingly — once per major step, not per atomic tool.
+
+Recipe tools over atomic chains
+- When the user's request matches a recipe purpose ("remove background",
+  "enhance portrait", "prepare for web", "export Instagram variants",
+  "apply cinematic color grade", "frequency separation", "replace mockup",
+  "organize layers"), prefer the matching \`photoshop_recipe_*\` tool over
+  composing 5+ atomic calls yourself. Recipes are wrapped in a single
+  history step and are deterministically reversible with one undo.
+- Drop back to atomic \`photoshop_*\` tools only for fine-grained, novel
+  edits that no recipe covers.
+
+Units & conventions
+- All numeric coordinates, widths, heights and bounds are pixels. The server
+  forces pixel/point units around every script — do not translate to inches/cm/percent.
+- Font sizes are points. Colors are 0–255 RGB triplets.
+- Output files default to \`~/.photoshop-mcp/exports[/<chat-id>]\`. Pass an absolute
+  path only when the user explicitly asks for one.
+
+Error recovery contract
+- Tools return a structured envelope when something is wrong:
+  \`{ ok: false, code, message, suggested_next_tool?, suggested_args?, context? }\`
+  along with MCP's \`isError: true\`. When you see this, follow the
+  \`suggested_next_tool\` hint instead of guessing or retrying blindly.
+- Common codes you should be ready to handle without asking the user:
+  - \`no_active_document\` — call \`photoshop_open_image\` or
+    \`photoshop_create_document\` first.
+  - \`no_active_layer\` / \`layer_not_found\` — list layers with
+    \`photoshop_get_layers\`, then act on a specific name.
+  - \`selection_required\` — make a selection before reusing the failed tool.
+  - \`version_unsupported\` / \`generative_unavailable\` — degrade gracefully
+    to a non-generative alternative; tell the user once which feature is
+    missing.
+
+Multi-step etiquette
+- After every tool result, decide: continue with the next planned tool, or
+  emit a short user-facing summary. Do not end a turn on a tool call when
+  the user asked for an outcome.
+- Group related atomic edits inside a recipe when possible. When you must
+  chain atomics, name layers (\`photoshop_rename_layer\`) so future turns can
+  re-target them deterministically.
+`.trim();
+
+export function buildPhotoshopInstructions(): string {
+  return PHOTOSHOP_MCP_INSTRUCTIONS;
+}

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -1,0 +1,27 @@
+import type { PromptRegistry } from '../core/prompt-registry.js';
+import { toPromptDefinition } from './_shared.js';
+import { enhancePortraitTemplate } from './templates/enhance-portrait.js';
+import { removeBackgroundTemplate } from './templates/remove-background.js';
+import { prepareForWebTemplate } from './templates/prepare-for-web.js';
+import { exportSocialVariantsTemplate } from './templates/export-social-variants.js';
+import { applyColorGradeTemplate } from './templates/apply-color-grade.js';
+import { frequencySeparationTemplate } from './templates/frequency-separation.js';
+import { batchMockupReplaceTemplate } from './templates/batch-mockup-replace.js';
+import { organizeLayersTemplate } from './templates/organize-layers.js';
+
+export const PHOTOSHOP_PROMPT_TEMPLATES = [
+  enhancePortraitTemplate,
+  removeBackgroundTemplate,
+  prepareForWebTemplate,
+  exportSocialVariantsTemplate,
+  applyColorGradeTemplate,
+  frequencySeparationTemplate,
+  batchMockupReplaceTemplate,
+  organizeLayersTemplate,
+] as const;
+
+export function registerPhotoshopPrompts(registry: PromptRegistry): void {
+  for (const template of PHOTOSHOP_PROMPT_TEMPLATES) {
+    registry.register(template.name, toPromptDefinition(template));
+  }
+}

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -8,6 +8,21 @@ import { applyColorGradeTemplate } from './templates/apply-color-grade.js';
 import { frequencySeparationTemplate } from './templates/frequency-separation.js';
 import { batchMockupReplaceTemplate } from './templates/batch-mockup-replace.js';
 import { organizeLayersTemplate } from './templates/organize-layers.js';
+import { gradientFadeTemplate } from './templates/gradient-fade.js';
+import { skyBlendTemplate } from './templates/sky-blend.js';
+import { dodgeBurnTemplate } from './templates/dodge-burn.js';
+import { removeDistractionTemplate } from './templates/remove-distraction.js';
+import { gradientBlendTemplate } from './templates/gradient-blend.js';
+import { colorCorrectTemplate } from './templates/color-correct.js';
+import { dodgeBurnGuideTemplate } from './templates/dodge-burn-guide.js';
+import { compositeBlendTemplate } from './templates/composite-blend.js';
+
+export const PHOTOSHOP_GUIDE_PROMPT_NAMES = [
+  'ps.gradient_blend',
+  'ps.color_correct',
+  'ps.dodge_burn_guide',
+  'ps.composite_blend',
+] as const;
 
 export const PHOTOSHOP_PROMPT_TEMPLATES = [
   enhancePortraitTemplate,
@@ -18,6 +33,14 @@ export const PHOTOSHOP_PROMPT_TEMPLATES = [
   frequencySeparationTemplate,
   batchMockupReplaceTemplate,
   organizeLayersTemplate,
+  gradientFadeTemplate,
+  skyBlendTemplate,
+  dodgeBurnTemplate,
+  removeDistractionTemplate,
+  gradientBlendTemplate,
+  colorCorrectTemplate,
+  compositeBlendTemplate,
+  dodgeBurnGuideTemplate,
 ] as const;
 
 export function registerPhotoshopPrompts(registry: PromptRegistry): void {

--- a/src/prompts/templates/apply-color-grade.ts
+++ b/src/prompts/templates/apply-color-grade.ts
@@ -26,7 +26,7 @@ const PRESET_BLURB: Record<Preset, string> = {
 export const applyColorGradeTemplate: PhotoshopPromptTemplate = {
   name: 'ps.apply_color_grade',
   description:
-    'Apply a named color grading preset (curves + hue/saturation + selective color) as a single non-destructive recipe.',
+    'Apply a named color grading preset (curves + hue/saturation + selective color) as a single non-destructive recipe. Users often say: cinematic, teal orange, moody grade, color grade.',
   arguments: [
     {
       name: 'preset',

--- a/src/prompts/templates/apply-color-grade.ts
+++ b/src/prompts/templates/apply-color-grade.ts
@@ -1,0 +1,57 @@
+import {
+  argEnum,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const PRESET_OPTIONS = [
+  'cinematic',
+  'vintage',
+  'teal_orange',
+  'bw',
+  'warm_film',
+  'cool_dusk',
+] as const;
+type Preset = (typeof PRESET_OPTIONS)[number];
+
+const PRESET_BLURB: Record<Preset, string> = {
+  cinematic: 'desaturated shadows, lifted blacks, slight S-curve contrast',
+  vintage: 'lifted blacks, warm highlights, mild magenta cast, lower saturation',
+  teal_orange: 'orange skin tones with teal shadows (classic Hollywood look)',
+  bw: 'black & white conversion with high local contrast',
+  warm_film: 'warm overall white balance, soft highlights, +5 saturation',
+  cool_dusk: 'cool blue shadows, slightly desaturated greens, mild green-magenta shift',
+};
+
+export const applyColorGradeTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.apply_color_grade',
+  description:
+    'Apply a named color grading preset (curves + hue/saturation + selective color) as a single non-destructive recipe.',
+  arguments: [
+    {
+      name: 'preset',
+      description:
+        'Preset name. One of: cinematic, vintage, teal_orange, bw, warm_film, cool_dusk. Default: cinematic.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const preset = argEnum<Preset>(args, 'preset', PRESET_OPTIONS, 'cinematic');
+
+    const text = [
+      `Goal: Apply the "${preset}" color grade to the active document.`,
+      `Style: ${PRESET_BLURB[preset]}.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document. Color mode must be RGB; if it is CMYK or Grayscale, warn the user and stop.`,
+      `2. Call \`photoshop_recipe_apply_color_grade\` with { preset: "${preset}" }.`,
+      `   - The recipe creates a layer group named "Color Grade · ${preset}" containing adjustment layers. All clipped to nothing so they affect the whole composition.`,
+      `3. Call \`photoshop_get_preview\` once to show the user the result.`,
+      `4. If the user asks to tweak, modify the adjustment layers individually (\`photoshop_set_layer_opacity\` on the Curves layer is the cheapest tweak) instead of rerunning the recipe.`,
+      ``,
+      `End state: one new layer group at the top of the stack; original layers untouched; one undo removes the grade.`,
+    ].join('\n');
+
+    return userPrompt(`Apply the "${preset}" color grade.`, text);
+  },
+};

--- a/src/prompts/templates/batch-mockup-replace.ts
+++ b/src/prompts/templates/batch-mockup-replace.ts
@@ -1,0 +1,47 @@
+import {
+  argString,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+export const batchMockupReplaceTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.batch_mockup_replace',
+  description:
+    'Iterate a directory of asset images, swap each one into the named Smart Object in the active mockup PSD, and export a flattened JPEG per asset.',
+  arguments: [
+    {
+      name: 'smart_object_layer_name',
+      description:
+        'Exact name of the Smart Object layer inside the active document whose contents will be replaced for each asset.',
+      required: true,
+    },
+    {
+      name: 'assets_dir',
+      description:
+        'Absolute path to the directory containing the source asset images (jpeg/png/psd). Subdirectories are not recursed.',
+      required: true,
+    },
+  ],
+  handler: (args) => {
+    const layerName = argString(args, 'smart_object_layer_name', '');
+    const assetsDir = argString(args, 'assets_dir', '');
+
+    const text = [
+      `Goal: Batch-render the active mockup once per asset by swapping the Smart Object contents.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document. Then call \`photoshop_get_layers\` and verify a Smart Object layer named exactly "${layerName}" exists. If not, stop and ask the user for the correct name.`,
+      `2. Call \`photoshop_recipe_batch_mockup_replace\` with { smart_object_layer_name: "${layerName}", assets_dir: "${assetsDir}" }.`,
+      `   - The recipe iterates every file in the directory, replaces Smart Object contents, lets the parent mockup update, then exports a flattened JPEG named after the asset to ~/.photoshop-mcp/exports[/<chat-id>].`,
+      `3. The recipe returns a JSON list of { source_asset, output_path }. Surface them as a Markdown table so the user can match exports to assets.`,
+      `4. Do NOT loop manually with atomic place_image calls — Smart Object replacement preserves the mockup's perspective/warp; placing a new layer does not.`,
+      ``,
+      `End state: the active mockup PSD is restored to its first asset; one JPEG per input asset exists in the export directory.`,
+    ].join('\n');
+
+    return userPrompt(
+      `Batch-replace Smart Object "${layerName}" with assets from ${assetsDir}.`,
+      text
+    );
+  },
+};

--- a/src/prompts/templates/color-correct.ts
+++ b/src/prompts/templates/color-correct.ts
@@ -1,0 +1,47 @@
+import {
+  argEnum,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const PRESET_OPTIONS = ['auto_levels', 'brightness_contrast'] as const;
+
+export const colorCorrectTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.color_correct',
+  description:
+    'Fix flat or dull tonality with auto levels or brightness/contrast — stepping stone until curves atomics ship.',
+  arguments: [
+    {
+      name: 'preset',
+      description:
+        'Correction approach: auto_levels (default, global tone stretch) or brightness_contrast (manual exposure tweak).',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const preset = argEnum(args, 'preset', PRESET_OPTIONS, 'auto_levels');
+
+    const correctionStep =
+      preset === 'auto_levels'
+        ? `3. Call \`photoshop_auto_levels\` on the active layer (or merged duplicate if the user wants non-destructive workflow — duplicate first with \`photoshop_duplicate_layer\`).`
+        : `3. Call \`photoshop_adjust_brightness_contrast\` with modest values (e.g. brightness +5 to +15, contrast +5 to +20) based on preview feedback.`;
+
+    const text = [
+      `Goal: Improve overall tone and contrast so the image looks less flat.`,
+      ``,
+      `Intent: make it pop, S-curve, fix flat image, auto tone, exposure fix`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document and raster layer.`,
+      `2. Call \`photoshop_get_preview\` if you have not seen the image this session.`,
+      correctionStep,
+      `4. Prefer \`photoshop_adjust_curves\` for S-curve / targeted tone; chain auto levels then brightness/contrast if curves is unavailable or still flat.`,
+      `5. Call \`photoshop_get_preview\` once after correction.`,
+      `6. For stylistic looks (cinematic, teal-orange), use \`photoshop_recipe_apply_color_grade\` instead — this guide is for neutral correction only.`,
+      ``,
+      `End state: active layer tonality is improved; one undo per atomic adjustment; original pixels preserved if adjustments were on duplicates or adjustment layers.`,
+    ].join('\n');
+
+    return userPrompt(`Color correct (${preset.replace(/_/g, ' ')}).`, text);
+  },
+};

--- a/src/prompts/templates/composite-blend.ts
+++ b/src/prompts/templates/composite-blend.ts
@@ -1,0 +1,76 @@
+import {
+  argEnum,
+  argString,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const BLEND_MODE_OPTIONS = [
+  'normal',
+  'multiply',
+  'screen',
+  'overlay',
+  'soft_light',
+] as const;
+type BlendModeArg = (typeof BLEND_MODE_OPTIONS)[number];
+
+const BLEND_MODE_BY_ARG: Record<BlendModeArg, string> = {
+  normal: 'NORMAL',
+  multiply: 'MULTIPLY',
+  screen: 'SCREEN',
+  overlay: 'OVERLAY',
+  soft_light: 'SOFTLIGHT',
+};
+
+export const compositeBlendTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.composite_blend',
+  description:
+    'Place an external image into the active document, mask it, and set blend mode — interim workflow for sky replacement and compositing.',
+  arguments: [
+    {
+      name: 'image_path',
+      description: 'Absolute path to the image file to place (sky, background, texture). Required.',
+      required: true,
+    },
+    {
+      name: 'blend_mode',
+      description: 'Layer blend mode after placement: normal (default), multiply, screen, overlay, soft_light.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const imagePath = argString(args, 'image_path', '');
+    const blendArg = argEnum(args, 'blend_mode', BLEND_MODE_OPTIONS, 'normal');
+    const blendMode = BLEND_MODE_BY_ARG[blendArg];
+
+    const pathWarning =
+      imagePath === ''
+        ? `   - WARNING: no image_path provided — ask the user for an absolute file path before placing.`
+        : `   - Place with { filePath: "${imagePath}" } at the correct offset (adjust x/y after preview).`;
+
+    const text = [
+      `Goal: Composite an external image into the active document with optional masking and blend mode.`,
+      ``,
+      `Intent: replace sky, composite in new background, blend layers, place and mask`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document.`,
+      `2. Call \`photoshop_place_image\`:`,
+      pathWarning,
+      `3. Reposition or scale if needed using transform tools after preview.`,
+      `4. Add a layer mask with \`photoshop_create_layer_mask\` when a selection defines the blend region (e.g. sky area).`,
+      `5. For sky replacement with a sky file, prefer \`photoshop_recipe_sky_blend\` or \`prompts/get\` on \`ps.sky_blend\` (one undo).`,
+      `6. For horizon fades on an existing mask, use \`photoshop_apply_gradient_mask\` or \`prompts/get\` on \`ps.gradient_blend\`.`,
+      `7. Call \`photoshop_set_layer_blend_mode\` with { blendMode: "${blendMode}" } on the placed layer if needed.`,
+      `8. Call \`photoshop_get_preview\` once.`,
+      `9. Note: Photoshop's Sky Replacement menu is not scriptable via ExtendScript — this composite path is the manual multi-step fallback.`,
+      ``,
+      `End state: placed layer is visible in the document with optional mask and blend mode; user can refine mask edges manually; one undo per atomic step.`,
+    ].join('\n');
+
+    return userPrompt(
+      `Composite blend${imagePath ? ` (${imagePath})` : ''} — ${blendArg.replace(/_/g, ' ')} mode.`,
+      text
+    );
+  },
+};

--- a/src/prompts/templates/dodge-burn-guide.ts
+++ b/src/prompts/templates/dodge-burn-guide.ts
@@ -1,0 +1,48 @@
+import {
+  argEnum,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const BLEND_MODE_OPTIONS = ['overlay', 'soft_light'] as const;
+type BlendModeArg = (typeof BLEND_MODE_OPTIONS)[number];
+
+const BLEND_MODE_BY_ARG: Record<BlendModeArg, string> = {
+  overlay: 'OVERLAY',
+  soft_light: 'SOFTLIGHT',
+};
+
+export const dodgeBurnGuideTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.dodge_burn_guide',
+  description:
+    'Set up a non-destructive dodge & burn layer (50% gray + Overlay or Soft Light) for manual light sculpting.',
+  arguments: [
+    {
+      name: 'blend_mode',
+      description: 'Retouch blend mode: overlay (default, stronger) or soft_light (gentler).',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const blendArg = argEnum(args, 'blend_mode', BLEND_MODE_OPTIONS, 'overlay');
+    const blendMode = BLEND_MODE_BY_ARG[blendArg];
+
+    const text = [
+      `Goal: Prepare a dodge & burn layer so the user can paint light and shadow non-destructively.`,
+      ``,
+      `Intent: dodge and burn, sculpt light, lighten face, darken shadows`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document with a portrait or subject layer.`,
+      `2. Call \`photoshop_create_layer\` with { name: "Dodge & Burn" } above the subject.`,
+      `3. Call \`photoshop_fill_layer\` with { red: 128, green: 128, blue: 128 } (50% gray).`,
+      `4. Call \`photoshop_set_layer_blend_mode\` with { blendMode: "${blendMode}" }.`,
+      `5. Tell the user to paint on this layer with white (dodge / lighten) and black (burn / darken) at low brush opacity (5–15%).`,
+      `6. Prefer \`photoshop_recipe_dodge_burn\` or \`prompts/get\` on \`ps.dodge_burn\` for a one-undo setup.`,
+      ``,
+      `End state: a gray "Dodge & Burn" layer sits above the subject in ${blendArg.replace(/_/g, ' ')} mode; painting is manual; undo removes the setup layer.`,
+    ].join('\n');
+
+    return userPrompt(`Dodge & burn setup (${blendArg.replace(/_/g, ' ')}).`, text);
+  },
+};

--- a/src/prompts/templates/dodge-burn.ts
+++ b/src/prompts/templates/dodge-burn.ts
@@ -1,0 +1,39 @@
+import {
+  argEnum,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const BLEND_MODE_OPTIONS = ['overlay', 'soft_light'] as const;
+
+export const dodgeBurnTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.dodge_burn',
+  description:
+    'One-shot dodge & burn setup: 50% gray layer in Overlay or Soft Light for non-destructive light sculpting. Users often say: dodge and burn, sculpt light, lighten face, darken shadows. User paints white (dodge) and black (burn) manually after setup.',
+  arguments: [
+    {
+      name: 'blend_mode',
+      description: 'Retouch blend mode: overlay (default, stronger) or soft_light (gentler).',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const blendMode = argEnum(args, 'blend_mode', BLEND_MODE_OPTIONS, 'overlay');
+
+    const text = [
+      `Goal: Prepare a dodge & burn layer so the user can paint light and shadow non-destructively.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document with a portrait or subject layer.`,
+      `2. Call \`photoshop_recipe_dodge_burn\` with { blend_mode: "${blendMode}" }.`,
+      `   - The recipe adds a "Dodge & Burn" layer filled with 50% gray (${blendMode.replace(/_/g, ' ')} mode) above the active layer.`,
+      `3. Tell the user to paint on this layer with white (dodge / lighten) and black (burn / darken) at low brush opacity (5–15%).`,
+      `4. Call \`photoshop_get_preview\` once after setup if helpful.`,
+      `5. For step-by-step atomic setup (create layer, fill, blend mode separately), use \`prompts/get\` on \`ps.dodge_burn_guide\`.`,
+      ``,
+      `End state: a gray "Dodge & Burn" layer in ${blendMode.replace(/_/g, ' ')} mode; painting is manual; one undo removes the setup.`,
+    ].join('\n');
+
+    return userPrompt(`Dodge & burn recipe (${blendMode.replace(/_/g, ' ')}).`, text);
+  },
+};

--- a/src/prompts/templates/enhance-portrait.ts
+++ b/src/prompts/templates/enhance-portrait.ts
@@ -1,0 +1,57 @@
+import {
+  argBool,
+  argEnum,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const INTENSITY_OPTIONS = ['low', 'medium', 'high'] as const;
+type Intensity = (typeof INTENSITY_OPTIONS)[number];
+
+const RADIUS_BY_INTENSITY: Record<Intensity, number> = {
+  low: 2,
+  medium: 4,
+  high: 7,
+};
+
+export const enhancePortraitTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.enhance_portrait',
+  description:
+    'Multi-step retouch plan for a portrait: non-destructive skin smoothing via frequency separation, mild dodge & burn, and auto-tone — wrapped in a single undoable history step.',
+  arguments: [
+    {
+      name: 'intensity',
+      description: 'Retouch strength: low (subtle), medium (default), or high (heavy smoothing).',
+      required: false,
+    },
+    {
+      name: 'skin_smoothing',
+      description: 'Whether to apply frequency separation skin smoothing. Default true.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const intensity = argEnum(args, 'intensity', INTENSITY_OPTIONS, 'medium');
+    const skinSmoothing = argBool(args, 'skin_smoothing', true);
+    const radius = RADIUS_BY_INTENSITY[intensity];
+
+    const skinLine = skinSmoothing
+      ? `   - Skin smoothing is ON. The recipe will apply frequency separation with radius ~${radius}px.`
+      : `   - Skin smoothing is OFF. The recipe will only do tone/contrast cleanup.`;
+
+    const text = [
+      `Goal: Retouch the currently open portrait at "${intensity}" intensity.`,
+      ``,
+      `Plan (call tools in order; stop after the recipe if the result looks right):`,
+      `1. Call \`photoshop_get_state\` to confirm there is an active document and an active layer that is a portrait photo.`,
+      `2. Call \`photoshop_recipe_enhance_portrait\` with { intensity: "${intensity}", skin_smoothing: ${skinSmoothing} }.`,
+      skinLine,
+      `3. Call \`photoshop_get_preview\` once to show the user the result.`,
+      `4. If the user asks for more/less smoothing, undo and rerun with a different \`intensity\`. Do NOT chain multiple recipes — they stack non-linearly.`,
+      ``,
+      `End state: one new layer group named "Enhance Portrait" sitting above the original; original pixels untouched; one undo reverts everything.`,
+    ].join('\n');
+
+    return userPrompt(`Enhance the active portrait at "${intensity}" intensity.`, text);
+  },
+};

--- a/src/prompts/templates/enhance-portrait.ts
+++ b/src/prompts/templates/enhance-portrait.ts
@@ -17,7 +17,7 @@ const RADIUS_BY_INTENSITY: Record<Intensity, number> = {
 export const enhancePortraitTemplate: PhotoshopPromptTemplate = {
   name: 'ps.enhance_portrait',
   description:
-    'Multi-step retouch plan for a portrait: non-destructive skin smoothing via frequency separation, mild dodge & burn, and auto-tone — wrapped in a single undoable history step.',
+    'Multi-step retouch plan for a portrait: non-destructive skin smoothing via frequency separation, mild dodge & burn, and auto-tone — wrapped in a single undoable history step. Users often say: smooth skin, retouch portrait, fix blemishes.',
   arguments: [
     {
       name: 'intensity',

--- a/src/prompts/templates/export-social-variants.ts
+++ b/src/prompts/templates/export-social-variants.ts
@@ -1,0 +1,55 @@
+import {
+  argList,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const KNOWN_PLATFORMS = new Set([
+  'instagram_post',
+  'instagram_story',
+  'instagram_reel',
+  'x_post',
+  'x_header',
+  'facebook_post',
+  'facebook_cover',
+  'linkedin_post',
+  'linkedin_banner',
+  'youtube_thumbnail',
+  'tiktok_vertical',
+  'pinterest_pin',
+]);
+
+const DEFAULT_PLATFORMS = ['instagram_post', 'instagram_story', 'x_post'];
+
+export const exportSocialVariantsTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.export_social_variants',
+  description:
+    "Generate one JPEG per social-media platform from the active document, each at the platform's recommended dimensions, with sensible center-crop fallback.",
+  arguments: [
+    {
+      name: 'platforms',
+      description:
+        'Comma-separated platform slugs. Known: instagram_post, instagram_story, instagram_reel, x_post, x_header, facebook_post, facebook_cover, linkedin_post, linkedin_banner, youtube_thumbnail, tiktok_vertical, pinterest_pin. Default: instagram_post,instagram_story,x_post.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const requested = argList(args, 'platforms', DEFAULT_PLATFORMS);
+    const valid = requested.filter((p) => KNOWN_PLATFORMS.has(p.toLowerCase()));
+    const final = valid.length > 0 ? valid : DEFAULT_PLATFORMS;
+
+    const text = [
+      `Goal: Produce one ready-to-post image file per requested social platform from the active document.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document. Note its dimensions.`,
+      `2. Call \`photoshop_recipe_export_social_variants\` with { platforms: ${JSON.stringify(final)} }.`,
+      `   - The recipe duplicates the document for each platform, resizes/center-crops to the platform spec (e.g. Instagram post = 1080×1080, Story = 1080×1920, X post = 1600×900, YouTube thumbnail = 1280×720), exports JPEG, and closes the duplicate.`,
+      `3. The recipe returns a list of absolute output paths. Present them grouped by platform so the user can grab the one they need.`,
+      ``,
+      `End state: the source document is unchanged; one new file per platform exists under ~/.photoshop-mcp/exports[/<chat-id>].`,
+    ].join('\n');
+
+    return userPrompt(`Export social variants for: ${final.join(', ')}.`, text);
+  },
+};

--- a/src/prompts/templates/export-social-variants.ts
+++ b/src/prompts/templates/export-social-variants.ts
@@ -24,7 +24,7 @@ const DEFAULT_PLATFORMS = ['instagram_post', 'instagram_story', 'x_post'];
 export const exportSocialVariantsTemplate: PhotoshopPromptTemplate = {
   name: 'ps.export_social_variants',
   description:
-    "Generate one JPEG per social-media platform from the active document, each at the platform's recommended dimensions, with sensible center-crop fallback.",
+    "Generate one JPEG per social-media platform from the active document, each at the platform's recommended dimensions, with sensible center-crop fallback. Users often say: for Instagram, social export, export variants.",
   arguments: [
     {
       name: 'platforms',

--- a/src/prompts/templates/frequency-separation.ts
+++ b/src/prompts/templates/frequency-separation.ts
@@ -7,7 +7,7 @@ import {
 export const frequencySeparationTemplate: PhotoshopPromptTemplate = {
   name: 'ps.frequency_separation',
   description:
-    'Set up a frequency separation stack on the active layer (Low Frequency + High Frequency layers) so the user can smooth tones and retouch texture independently — without applying any actual smoothing.',
+    'Set up a frequency separation stack on the active layer (Low Frequency + High Frequency layers) so the user can smooth tones and retouch texture independently — without applying any actual smoothing. Users often say: frequency separation, split texture and color.',
   arguments: [
     {
       name: 'radius_px',

--- a/src/prompts/templates/frequency-separation.ts
+++ b/src/prompts/templates/frequency-separation.ts
@@ -1,0 +1,37 @@
+import {
+  argInt,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+export const frequencySeparationTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.frequency_separation',
+  description:
+    'Set up a frequency separation stack on the active layer (Low Frequency + High Frequency layers) so the user can smooth tones and retouch texture independently — without applying any actual smoothing.',
+  arguments: [
+    {
+      name: 'radius_px',
+      description:
+        'Gaussian blur radius in pixels used for the low-frequency layer. 4-8 for portraits, 10-20 for products. Default 6.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const radius = Math.max(1, Math.min(50, argInt(args, 'radius_px', 6)));
+
+    const text = [
+      `Goal: Prepare the active layer for frequency separation retouching with a ${radius}px radius split.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document with a NORMAL (raster) active layer. If it is text/Smart Object/background, ask the user to rasterize first or pick a different layer.`,
+      `2. Call \`photoshop_recipe_frequency_separation\` with { radius_px: ${radius} }.`,
+      `   - The recipe duplicates the active layer twice, names them "FS · Low" (Gaussian blur ${radius}px) and "FS · High" (Apply Image to subtract the low, set to Linear Light), groups them as "Frequency Separation".`,
+      `3. Tell the user: "Paint with a soft brush on FS · Low to smooth tones, or on FS · High to repair texture. Do not edit pixels on the original layer."`,
+      `4. Do NOT call any blur or healing tools yourself — the user will retouch interactively. End the turn after the setup.`,
+      ``,
+      `End state: a "Frequency Separation" group on top of the stack containing two prepared layers; the original layer is unchanged.`,
+    ].join('\n');
+
+    return userPrompt(`Build frequency separation setup (radius ${radius}px).`, text);
+  },
+};

--- a/src/prompts/templates/gradient-blend.ts
+++ b/src/prompts/templates/gradient-blend.ts
@@ -1,0 +1,56 @@
+import {
+  argEnum,
+  argInt,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const DIRECTION_OPTIONS = ['top_to_bottom', 'bottom_to_top'] as const;
+
+export const gradientBlendTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.gradient_blend',
+  description:
+    'Fade the active layer into the background using a linear gradient on the layer mask — common for soft compositing and horizon blends.',
+  arguments: [
+    {
+      name: 'direction',
+      description:
+        'Gradient direction on the mask: top_to_bottom (fade downward) or bottom_to_top (fade upward, default for sky/horizon).',
+      required: false,
+    },
+    {
+      name: 'feather_px',
+      description: 'Optional edge feather in pixels (0-20) before masking. Default 0.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const direction = argEnum(args, 'direction', DIRECTION_OPTIONS, 'bottom_to_top');
+    const feather = Math.max(0, Math.min(20, argInt(args, 'feather_px', 0)));
+
+    const text = [
+      `Goal: Fade the active layer into the background using a gradient on the layer mask.`,
+      ``,
+      `Intent: fade into background, gradient mask, blend subject, soft edge fade, arka planı yumuşat`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document and an active layer with the subject or composite to fade.`,
+      feather > 0
+        ? `2. If the layer edge needs softening first, apply feather ${feather}px via selection tools before masking.`
+        : `2. Confirm whether the active layer already has a layer mask; if not, add one.`,
+      `3. If no mask exists: call \`photoshop_create_layer_mask\` after a reveal-all or existing selection, or use \`photoshop_recipe_remove_background\` when isolating a subject first.`,
+      `4. Apply the gradient fade:`,
+      `   - Prefer \`photoshop_recipe_gradient_fade\` with { direction: "${direction}" } for a single undo.`,
+      `   - Fallback: \`photoshop_apply_gradient_mask\` with { direction: "${direction}" } on an existing mask.`,
+      `   - Last resort: ask the user to paint a linear black→white gradient (${direction.replace(/_/g, ' ')}) on the mask with the Gradient tool.`,
+      `5. Call \`photoshop_get_preview\` once to confirm the fade.`,
+      ``,
+      `End state: the subject or composite remains visible while the background or lower layers fade in through the mask; each atomic step is individually undoable until a recipe wraps the chain.`,
+    ].join('\n');
+
+    return userPrompt(
+      `Gradient mask blend (${direction.replace(/_/g, ' ')}, feather ${feather}px).`,
+      text
+    );
+  },
+};

--- a/src/prompts/templates/gradient-fade.ts
+++ b/src/prompts/templates/gradient-fade.ts
@@ -1,0 +1,71 @@
+import {
+  argEnum,
+  argInt,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const DIRECTION_OPTIONS = [
+  'top_to_bottom',
+  'bottom_to_top',
+  'left_to_right',
+  'right_to_left',
+] as const;
+
+export const gradientFadeTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.gradient_fade',
+  description:
+    'One-shot gradient fade on the active layer mask — soft edge blending into the background. Users often say: fade into background, gradient mask, blend subject, soft edge fade, arka planı yumuşat. Applies a linear gradient on the layer mask, not a Gradient Fill layer.',
+  arguments: [
+    {
+      name: 'direction',
+      description:
+        'Gradient direction on the mask: top_to_bottom, bottom_to_top (default), left_to_right, or right_to_left.',
+      required: false,
+    },
+    {
+      name: 'start_pct',
+      description: 'Gradient start along the fade axis (0-100). Default 0.',
+      required: false,
+    },
+    {
+      name: 'end_pct',
+      description: 'Gradient end along the fade axis (0-100). Default 100.',
+      required: false,
+    },
+    {
+      name: 'angle_deg',
+      description: 'Optional gradient angle override in degrees.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const direction = argEnum(args, 'direction', DIRECTION_OPTIONS, 'bottom_to_top');
+    const startPct = Math.max(0, Math.min(100, argInt(args, 'start_pct', 0)));
+    const endPct = Math.max(0, Math.min(100, argInt(args, 'end_pct', 100)));
+    const angleRaw = args.angle_deg;
+    const angleLine =
+      typeof angleRaw === 'string' && angleRaw.trim() !== ''
+        ? `, angle_deg: ${argInt(args, 'angle_deg', 90)}`
+        : '';
+
+    const text = [
+      `Goal: Fade the active layer into the background using a linear gradient on its layer mask.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document and an active layer to fade.`,
+      `2. If the subject is not isolated (no mask, background still visible on the layer), call \`photoshop_recipe_remove_background\` first or ask the user to confirm the active layer.`,
+      `3. Call \`photoshop_recipe_gradient_fade\` with { direction: "${direction}", start_pct: ${startPct}, end_pct: ${endPct}${angleLine} }.`,
+      `   - The recipe creates a reveal-all mask if needed, then paints a linear black→white gradient (${direction.replace(/_/g, ' ')}) on the mask channel.`,
+      `4. Call \`photoshop_get_preview\` once to confirm the fade.`,
+      `5. For step-by-step mask education, \`prompts/get\` on \`ps.gradient_blend\` is an alternative; prefer this recipe for a single undo.`,
+      ``,
+      `End state: the active layer fades into layers below through its mask; one undo reverts mask creation and gradient paint.`,
+    ].join('\n');
+
+    return userPrompt(
+      `Gradient fade (${direction.replace(/_/g, ' ')}, ${startPct}–${endPct}%).`,
+      text
+    );
+  },
+};

--- a/src/prompts/templates/organize-layers.ts
+++ b/src/prompts/templates/organize-layers.ts
@@ -17,7 +17,7 @@ const NAMING_BLURB: Record<NamingScheme, string> = {
 export const organizeLayersTemplate: PhotoshopPromptTemplate = {
   name: 'ps.organize_layers',
   description:
-    'Clean up a messy PSD: rename layers using a consistent scheme and optionally auto-group them by kind or spatial proximity.',
+    'Clean up a messy PSD: rename layers using a consistent scheme and optionally auto-group them by kind or spatial proximity. Users often say: organize layers, rename mess, tidy layers.',
   arguments: [
     {
       name: 'naming_scheme',

--- a/src/prompts/templates/organize-layers.ts
+++ b/src/prompts/templates/organize-layers.ts
@@ -1,0 +1,56 @@
+import {
+  argBool,
+  argEnum,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const NAMING_OPTIONS = ['type_index', 'content_summary', 'preserve'] as const;
+type NamingScheme = (typeof NAMING_OPTIONS)[number];
+
+const NAMING_BLURB: Record<NamingScheme, string> = {
+  type_index: 'Rename layers to "<kind>_<n>" (e.g. text_01, image_02, shape_03).',
+  content_summary: 'Rename text layers to a slug of their content; keep other names.',
+  preserve: 'Keep existing names; only auto-group, do not rename.',
+};
+
+export const organizeLayersTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.organize_layers',
+  description:
+    'Clean up a messy PSD: rename layers using a consistent scheme and optionally auto-group them by kind or spatial proximity.',
+  arguments: [
+    {
+      name: 'naming_scheme',
+      description:
+        'How to rename layers. One of: type_index (default, e.g. text_01), content_summary (text layers get a slug of their content), preserve (do not rename, only group).',
+      required: false,
+    },
+    {
+      name: 'auto_group',
+      description:
+        'When true, group layers by kind (text / image / shape / adjustment) into folders. Default true.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const naming = argEnum<NamingScheme>(args, 'naming_scheme', NAMING_OPTIONS, 'type_index');
+    const autoGroup = argBool(args, 'auto_group', true);
+
+    const text = [
+      `Goal: Tidy the layer stack of the active document.`,
+      `Naming: ${NAMING_BLURB[naming]}`,
+      `Grouping: ${autoGroup ? 'on — layers will be grouped by kind into folders.' : 'off — only renaming, no folders.'}`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document.`,
+      `2. Call \`photoshop_get_layers\` to inspect the current mess. If the count is very low (< 3 layers), tell the user there is nothing to organize and stop.`,
+      `3. Call \`photoshop_recipe_organize_layers\` with { naming_scheme: "${naming}", auto_group: ${autoGroup} }.`,
+      `   - The recipe never deletes, merges or flattens. It only renames and groups, so visual output is unchanged.`,
+      `4. Summarize what changed (count of renames + count of new groups) instead of dumping the full new layer list.`,
+      ``,
+      `End state: the layer stack is cleaner; visual output is identical to before; one undo reverts everything.`,
+    ].join('\n');
+
+    return userPrompt(`Organize layers (${naming}, group=${autoGroup}).`, text);
+  },
+};

--- a/src/prompts/templates/prepare-for-web.ts
+++ b/src/prompts/templates/prepare-for-web.ts
@@ -11,7 +11,7 @@ type WebFormat = (typeof FORMAT_OPTIONS)[number];
 export const prepareForWebTemplate: PhotoshopPromptTemplate = {
   name: 'ps.prepare_for_web',
   description:
-    'Convert the active document to sRGB, downscale its longest edge, sharpen for screen, and export at the chosen format and quality. Does not mutate the source document.',
+    'Convert the active document to sRGB, downscale its longest edge, sharpen for screen, and export at the chosen format and quality. Does not mutate the source document. Users often say: for web, web export, optimize for web.',
   arguments: [
     {
       name: 'max_dimension_px',

--- a/src/prompts/templates/prepare-for-web.ts
+++ b/src/prompts/templates/prepare-for-web.ts
@@ -1,0 +1,55 @@
+import {
+  argEnum,
+  argInt,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+const FORMAT_OPTIONS = ['jpeg', 'png'] as const;
+type WebFormat = (typeof FORMAT_OPTIONS)[number];
+
+export const prepareForWebTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.prepare_for_web',
+  description:
+    'Convert the active document to sRGB, downscale its longest edge, sharpen for screen, and export at the chosen format and quality. Does not mutate the source document.',
+  arguments: [
+    {
+      name: 'max_dimension_px',
+      description: 'Longest-edge pixel cap. Default 2048. Common values: 1080, 1600, 2048, 2560.',
+      required: false,
+    },
+    {
+      name: 'format',
+      description: 'Output format: jpeg (default) or png.',
+      required: false,
+    },
+    {
+      name: 'quality',
+      description: 'JPEG quality 1-12 (Photoshop scale). Default 9. Ignored for png.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const maxDim = Math.max(64, Math.min(8192, argInt(args, 'max_dimension_px', 2048)));
+    const format = argEnum<WebFormat>(args, 'format', FORMAT_OPTIONS, 'jpeg');
+    const quality = Math.max(1, Math.min(12, argInt(args, 'quality', 9)));
+
+    const text = [
+      `Goal: Produce a web-optimized export of the active document.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document.`,
+      `2. Call \`photoshop_recipe_prepare_for_web\` with { max_dimension_px: ${maxDim}, format: "${format}", quality: ${quality} }.`,
+      `   - The recipe duplicates the document, converts to sRGB, downsizes the longest edge to ${maxDim}px (bicubic sharper), applies a mild unsharp mask, exports to disk, and closes the duplicate.`,
+      `3. The recipe returns the absolute output path; surface it to the user.`,
+      `4. Do NOT also call \`photoshop_save_document\` — the recipe already wrote the file.`,
+      ``,
+      `End state: the source document is unchanged; a new file exists at the returned path under ~/.photoshop-mcp/exports[/<chat-id>].`,
+    ].join('\n');
+
+    return userPrompt(
+      `Export the active document for web (${format}, max ${maxDim}px, q=${quality}).`,
+      text
+    );
+  },
+};

--- a/src/prompts/templates/remove-background.ts
+++ b/src/prompts/templates/remove-background.ts
@@ -8,7 +8,7 @@ import {
 export const removeBackgroundTemplate: PhotoshopPromptTemplate = {
   name: 'ps.remove_background',
   description:
-    'Remove the background from the active layer using Select Subject, with an optional feather radius and an option to keep a soft contact shadow.',
+    'Remove the background from the active layer using Select Subject, with an optional feather radius and an option to keep a soft contact shadow. Users often say: remove background, cut out, isolate subject, transparent background, arka planı sil.',
   arguments: [
     {
       name: 'feather_px',

--- a/src/prompts/templates/remove-background.ts
+++ b/src/prompts/templates/remove-background.ts
@@ -1,0 +1,46 @@
+import {
+  argBool,
+  argInt,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+export const removeBackgroundTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.remove_background',
+  description:
+    'Remove the background from the active layer using Select Subject, with an optional feather radius and an option to keep a soft contact shadow.',
+  arguments: [
+    {
+      name: 'feather_px',
+      description:
+        'Edge feather in pixels (0-20). 0 = hard edge (default for product shots), 1-3 = soft edge for portraits.',
+      required: false,
+    },
+    {
+      name: 'keep_shadow',
+      description:
+        'When true, duplicate the layer first, blur and darken it to simulate a contact shadow. Default false.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const feather = Math.max(0, Math.min(20, argInt(args, 'feather_px', 0)));
+    const keepShadow = argBool(args, 'keep_shadow', false);
+
+    const text = [
+      `Goal: Remove the background from the subject on the active layer using Select Subject.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document with a non-background active layer that contains a subject.`,
+      `2. Call \`photoshop_get_capabilities\` only if you have not yet this session; verify \`select_subject_v2\` is available.`,
+      `3. Call \`photoshop_recipe_remove_background\` with { feather_px: ${feather}, keep_shadow: ${keepShadow} }.`,
+      `   - The recipe internally runs Select Subject, inverts the selection, adds a layer mask, applies the feather, and (if keep_shadow) creates a shadow layer underneath.`,
+      `4. Call \`photoshop_get_preview\` to show the result against transparency.`,
+      `5. If the mask edge needs refinement, ask the user before adding a refine-edge pass — that step is destructive on the mask.`,
+      ``,
+      `End state: the subject layer carries a vector/pixel mask hiding the background; on-canvas background pixels are untouched (mask, not erase). One undo reverts the whole recipe.`,
+    ].join('\n');
+
+    return userPrompt(`Remove the background (feather ${feather}px, shadow=${keepShadow}).`, text);
+  },
+};

--- a/src/prompts/templates/remove-distraction.ts
+++ b/src/prompts/templates/remove-distraction.ts
@@ -1,0 +1,38 @@
+import {
+  argInt,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+export const removeDistractionTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.remove_distraction',
+  description:
+    'One-shot distraction removal via content-aware fill on the current selection. Users often say: remove that person, erase distraction, content aware remove, clone out object. Generative remove is not scriptable — content-aware only.',
+  arguments: [
+    {
+      name: 'feather_px',
+      description: 'Edge feather in pixels before fill (0-20). Default 0.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const feather = Math.max(0, Math.min(20, argInt(args, 'feather_px', 0)));
+
+    const text = [
+      `Goal: Remove the selected distraction or object via content-aware fill in one undoable step.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document and check whether a pixel selection exists.`,
+      `2. If no selection: call \`photoshop_select_rectangle\`, \`photoshop_select_subject\`, or ask the user to define the region to remove.`,
+      `3. Call \`photoshop_recipe_remove_distraction\` with { feather_px: ${feather} }.`,
+      `   - The recipe feathers the selection (if ${feather} > 0), runs content-aware fill, and deselects.`,
+      `4. If the result returns \`selection_required\`, go back to step 2.`,
+      `5. Call \`photoshop_get_preview\` once. If artifacts remain, ask the user to refine manually — generative remove is not available via ExtendScript.`,
+      `6. For generative-remove requests, explain the limitation and offer content-aware fill or manual clone/heal.`,
+      ``,
+      `End state: selected pixels are inpainted; selection cleared; one undo reverts the fill.`,
+    ].join('\n');
+
+    return userPrompt(`Remove distraction (feather ${feather}px).`, text);
+  },
+};

--- a/src/prompts/templates/sky-blend.ts
+++ b/src/prompts/templates/sky-blend.ts
@@ -1,0 +1,74 @@
+import {
+  argInt,
+  argString,
+  userPrompt,
+  type PhotoshopPromptTemplate,
+} from '../_shared.js';
+
+export const skyBlendTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.sky_blend',
+  description:
+    'Place an external sky image and blend it at the horizon with a gradient mask — one undo. Users often say: replace sky, fix blown sky, better clouds, swap sky background. Photoshop Sky Replacement menu is not scriptable via ExtendScript.',
+  arguments: [
+    {
+      name: 'sky_image_path',
+      description: 'Absolute path to the sky image file (JPEG, PNG, etc.). Required.',
+      required: true,
+    },
+    {
+      name: 'horizon_pct',
+      description: 'Document-height percentage where sky meets landscape (0-100). Default 50.',
+      required: false,
+    },
+    {
+      name: 'feather_pct',
+      description: 'Half-width of the transition zone around the horizon (0-50). Default 15.',
+      required: false,
+    },
+    {
+      name: 'x',
+      description: 'Placement X offset in pixels. Default 0.',
+      required: false,
+    },
+    {
+      name: 'y',
+      description: 'Placement Y offset in pixels. Default 0.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const skyPath = argString(args, 'sky_image_path', '');
+    const horizonPct = Math.max(0, Math.min(100, argInt(args, 'horizon_pct', 50)));
+    const featherPct = Math.max(0, Math.min(50, argInt(args, 'feather_pct', 15)));
+    const x = argInt(args, 'x', 0);
+    const y = argInt(args, 'y', 0);
+
+    const pathStep =
+      skyPath === ''
+        ? `2. Ask the user for an absolute \`sky_image_path\` before calling the recipe — do not invoke the recipe with an empty path.`
+        : `2. Call \`photoshop_recipe_sky_blend\` with { sky_image_path: "${skyPath}", horizon_pct: ${horizonPct}, feather_pct: ${featherPct}, x: ${x}, y: ${y} }.`;
+
+    const text = [
+      `Goal: Composite a sky image into the active document with a horizon gradient blend.`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document.`,
+      pathStep,
+      skyPath === ''
+        ? `   - After the user provides a path, call the recipe with horizon_pct ~${horizonPct} and feather_pct ~${featherPct}.`
+        : `   - The recipe places the sky file, names the layer "Sky Blend", adds a mask if needed, and applies a top-to-bottom gradient fade around the horizon.`,
+      `3. Call \`photoshop_get_preview\` once.`,
+      `4. If placement is off, undo and rerun with adjusted x/y or ask the user to nudge manually.`,
+      `5. For a manual multi-step composite (place + mask + blend mode), use \`prompts/get\` on \`ps.composite_blend\` instead.`,
+      ``,
+      `End state: a "Sky Blend" layer sits above the landscape with a gradient mask; one undo removes placement and mask.`,
+    ].join('\n');
+
+    return userPrompt(
+      skyPath
+        ? `Sky blend at horizon ${horizonPct}% (feather ${featherPct}%).`
+        : `Sky blend (path required, horizon ${horizonPct}%).`,
+      text
+    );
+  },
+};

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -29,7 +29,12 @@ export function createActionTools(connection: PhotoshopConnection): ToolDefiniti
     {
       tool: {
         name: 'photoshop_execute_script',
-        description: 'Execute custom ExtendScript code (advanced)',
+        description:
+          'Execute custom ExtendScript (JSX) code inside Photoshop (advanced escape hatch).\n\n' +
+          'Use when: no existing tool covers the operation and you can write safe JSX.\n' +
+          'Do NOT use when: a recipe or atomic tool exists — prefer photoshop_recipe_* or photoshop_* tools.\n\n' +
+          'Returns: script return value serialized as text/JSON.\n' +
+          'Preconditions: valid ExtendScript; active document if script expects one. Side effects: depends on code.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/tools/adjustment-tools.ts
+++ b/src/tools/adjustment-tools.ts
@@ -1,14 +1,31 @@
 import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
 import { PhotoshopConnection } from '../platform/connection.js';
 import { PhotoshopAPIFactory } from '../api/photoshop-api.js';
-import { ExtendScriptSnippets } from '../api/extendscript.js';
+import { ExtendScriptSnippets, type CurvesPreset } from '../api/extendscript.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+const CURVES_PRESETS: CurvesPreset[] = ['auto_tone', 'neutral'];
+
+function parseCurvesPreset(value: unknown): CurvesPreset {
+  if (typeof value === 'string' && CURVES_PRESETS.includes(value as CurvesPreset)) {
+    return value as CurvesPreset;
+  }
+  return 'auto_tone';
+}
 
 export function createAdjustmentTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
     {
       tool: {
         name: 'photoshop_adjust_brightness_contrast',
-        description: 'Adjust brightness and contrast of the active layer',
+        description:
+          'Adjust brightness and contrast of the active layer.\n\n' +
+          'Users often say: fix exposure, add contrast, brighten, darken.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -64,7 +81,9 @@ export function createAdjustmentTools(connection: PhotoshopConnection): ToolDefi
     {
       tool: {
         name: 'photoshop_auto_levels',
-        description: 'Apply auto levels adjustment to the active layer',
+        description:
+          'Apply auto levels adjustment to the active layer.\n\n' +
+          'Users often say: fix flat image, auto tone, make it pop (mild).',
         inputSchema: {
           type: 'object',
           properties: {},
@@ -82,6 +101,30 @@ export function createAdjustmentTools(connection: PhotoshopConnection): ToolDefi
         },
       },
       handler: async () => autoContrast(connection),
+    },
+    {
+      tool: {
+        name: 'photoshop_adjust_curves',
+        description:
+          'Create a Curves adjustment layer on the active document.\n\n' +
+          'Users often say: make it pop, S-curve, fix flat image, auto tone, improve contrast.\n\n' +
+          'Use when: global tonal correction via a non-destructive Curves adjustment layer.\n' +
+          'Do NOT use when: stylistic cinematic grade — use photoshop_recipe_apply_color_grade.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, preset } }.\n' +
+          'Preconditions: active document. Side effects: adds Curves adjustment layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            preset: {
+              type: 'string',
+              enum: CURVES_PRESETS,
+              description: 'auto_tone (S-curve) or neutral (identity curve)',
+              default: 'auto_tone',
+            },
+          },
+        },
+      },
+      handler: async (args) => adjustCurves(connection, args),
     },
     {
       tool: {
@@ -205,6 +248,31 @@ async function autoLevels(connection: PhotoshopConnection): Promise<ToolResult> 
       ],
       isError: true,
     };
+  }
+}
+
+async function adjustCurves(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const preset = parseCurvesPreset(args.preset);
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.adjustCurves(preset));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    const layerName =
+      typeof parsed.layer_name === 'string' ? parsed.layer_name : 'Curves adjustment layer';
+    return atomicSuccess(`Curves adjustment layer created (${preset})`, {
+      layer_name: layerName,
+      preset,
+      ...parsed,
+    });
+  } catch (error) {
+    return atomicFailureFromError(error);
   }
 }
 

--- a/src/tools/atomic-shared.ts
+++ b/src/tools/atomic-shared.ts
@@ -1,0 +1,65 @@
+import { ToolResult } from '../core/tool-registry.js';
+import { PhotoshopAPIFactory } from '../api/photoshop-api.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { classifyError, type PhotoshopErrorEnvelope } from '../errors/envelope.js';
+import { parseExtendScriptPayload } from '../utils/extendscript-result.js';
+
+export interface AtomicSuccess {
+  ok: true;
+  summary: string;
+  details?: Record<string, unknown>;
+  next_suggested_tool?: string;
+}
+
+export async function runSnippet(
+  connection: PhotoshopConnection,
+  script: string
+): Promise<unknown> {
+  const apiFactory = new PhotoshopAPIFactory(connection);
+  const api = await apiFactory.createAPI();
+  return api.executeScript(script);
+}
+
+export function parseSnippetResult(raw: unknown): Record<string, unknown> | null {
+  const payload = parseExtendScriptPayload(raw);
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+  return payload as Record<string, unknown>;
+}
+
+export function atomicSuccess(
+  summary: string,
+  details?: Record<string, unknown>,
+  nextSuggestedTool = 'photoshop_get_preview'
+): ToolResult {
+  const body: AtomicSuccess = {
+    ok: true,
+    summary,
+    ...(details ? { details } : {}),
+    next_suggested_tool: nextSuggestedTool,
+  };
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(body, null, 2) }],
+  };
+}
+
+export function atomicFailure(envelope: PhotoshopErrorEnvelope): ToolResult {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(envelope, null, 2) }],
+    isError: true,
+  };
+}
+
+export function atomicFailureFromError(
+  error: unknown,
+  overrides?: Partial<Pick<PhotoshopErrorEnvelope, 'code' | 'message' | 'suggested_next_tool'>>
+): ToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const base = classifyError(message);
+  return atomicFailure({
+    ...base,
+    ...overrides,
+    message: overrides?.message ?? base.message,
+  });
+}

--- a/src/tools/document-tools.ts
+++ b/src/tools/document-tools.ts
@@ -8,7 +8,12 @@ export function createDocumentTools(connection: PhotoshopConnection): ToolDefini
     {
       tool: {
         name: 'photoshop_create_document',
-        description: 'Create a new Photoshop document with specified dimensions',
+        description:
+          'Create a new empty Photoshop document with specified dimensions and color mode.\n\n' +
+          'Use when: starting a design from scratch or no document is open.\n' +
+          'Do NOT use when: opening an existing file — use photoshop_open_image.\n\n' +
+          'Returns: created document id and name.\n' +
+          'Preconditions: none. Side effects: creates a new document and makes it active.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -53,7 +58,12 @@ export function createDocumentTools(connection: PhotoshopConnection): ToolDefini
     {
       tool: {
         name: 'photoshop_save_document',
-        description: 'Save the active document in specified format',
+        description:
+          'Save the active document to disk in PSD, JPEG, or PNG format.\n\n' +
+          'Use when: user requests export/save with a specific path and format.\n' +
+          'Do NOT use when: web-optimized resize+sharpen pipeline is needed — use photoshop_recipe_prepare_for_web.\n\n' +
+          'Returns: confirmation with saved path and format.\n' +
+          'Preconditions: active document; path required. Side effects: writes file to disk.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/tools/image-placement-tools.ts
+++ b/src/tools/image-placement-tools.ts
@@ -8,7 +8,12 @@ export function createImagePlacementTools(connection: PhotoshopConnection): Tool
     {
       tool: {
         name: 'photoshop_place_image',
-        description: 'Place an image file as a layer in the active document',
+        description:
+          'Place an external image file as a new layer in the active document.\n\n' +
+          'Use when: compositing assets into an open document at a specific offset.\n' +
+          'Do NOT use when: opening a file as a new document — use photoshop_open_image.\n\n' +
+          'Returns: placed layer name, bounds, and context.\n' +
+          'Preconditions: active document; file must exist. Side effects: adds a new layer.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -35,7 +40,12 @@ export function createImagePlacementTools(connection: PhotoshopConnection): Tool
     {
       tool: {
         name: 'photoshop_open_image',
-        description: 'Open an image file as a new document',
+        description:
+          'Open an image file as a new Photoshop document.\n\n' +
+          'Use when: user provides a file path to edit or no document is open yet.\n' +
+          'Do NOT use when: adding to an existing composite — use photoshop_place_image.\n\n' +
+          'Returns: document id, name, width, height.\n' +
+          'Preconditions: file must exist on disk. Side effects: opens document as active.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/tools/layer-tools.ts
+++ b/src/tools/layer-tools.ts
@@ -8,7 +8,12 @@ export function createLayerTools(connection: PhotoshopConnection): ToolDefinitio
     {
       tool: {
         name: 'photoshop_create_layer',
-        description: 'Create a new layer in the active document',
+        description:
+          'Create a new empty layer above the active layer.\n\n' +
+          'Use when: user needs a blank layer for painting, fills, or stacking content.\n' +
+          'Do NOT use when: adding text — use photoshop_create_text_layer.\n\n' +
+          'Returns: created layer name and context.\n' +
+          'Preconditions: active document. Side effects: adds layer to history.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -35,7 +40,12 @@ export function createLayerTools(connection: PhotoshopConnection): ToolDefinitio
     {
       tool: {
         name: 'photoshop_create_text_layer',
-        description: 'Create a text layer with specified content',
+        description:
+          'Create a text layer with content, position, and font size.\n\n' +
+          'Use when: adding labels, titles, or typography to the design.\n' +
+          'Do NOT use when: editing existing text — use photoshop_update_text_content.\n\n' +
+          'Returns: layer name, text, position, fontSize, context.\n' +
+          'Preconditions: active document. Side effects: adds text layer.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -98,7 +108,12 @@ export function createLayerTools(connection: PhotoshopConnection): ToolDefinitio
     {
       tool: {
         name: 'photoshop_get_layers',
-        description: 'Get list of all layers in the active document',
+        description:
+          'List all layers in the active document with kind, visibility, and opacity.\n\n' +
+          'Use when: choosing a layer to edit, debugging structure, or after organize_layers.\n' +
+          'Do NOT use when: only session summary is needed — use photoshop_get_state (lighter).\n\n' +
+          'Returns: layerCount, layers array, context.\n' +
+          'Preconditions: active document. Side effects: none.',
         inputSchema: {
           type: 'object',
           properties: {},

--- a/src/tools/mask-tools.ts
+++ b/src/tools/mask-tools.ts
@@ -1,0 +1,130 @@
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { ExtendScriptSnippets, type GradientMaskDirection } from '../api/extendscript.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { clampInt } from './recipes/_shared.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+const GRADIENT_DIRECTIONS: GradientMaskDirection[] = [
+  'top_to_bottom',
+  'bottom_to_top',
+  'left_to_right',
+  'right_to_left',
+];
+
+function parseGradientDirection(value: unknown): GradientMaskDirection {
+  if (typeof value === 'string' && GRADIENT_DIRECTIONS.includes(value as GradientMaskDirection)) {
+    return value as GradientMaskDirection;
+  }
+  return 'bottom_to_top';
+}
+
+export function createMaskTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_apply_gradient_mask',
+        description:
+          'Apply a linear black-to-white gradient on the active layer mask channel (fade/blend).\n\n' +
+          'Users often say: fade into background, gradient mask, blend subject, soft edge fade.\n\n' +
+          'This paints on an existing layer mask — not a Gradient Fill layer.\n' +
+          'Use when: softening edges or fading a layer into the background through its mask.\n' +
+          'Do NOT use when: subject is not isolated — use photoshop_recipe_remove_background or photoshop_create_layer_mask first.\n\n' +
+          'Returns: JSON { ok, summary, details: { applied, direction, angle, mask_auto_created? } }.\n' +
+          'Preconditions: active document and active layer. Creates a reveal-all mask if none exists.\n' +
+          'Side effects: modifies layer mask pixels; two history steps when mask is auto-created.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            direction: {
+              type: 'string',
+              enum: GRADIENT_DIRECTIONS,
+              description: 'Gradient fade direction on the mask (default bottom_to_top)',
+              default: 'bottom_to_top',
+            },
+            start_pct: {
+              type: 'number',
+              description: 'Gradient start along fade axis (0-100)',
+              minimum: 0,
+              maximum: 100,
+              default: 0,
+            },
+            end_pct: {
+              type: 'number',
+              description: 'Gradient end along fade axis (0-100)',
+              minimum: 0,
+              maximum: 100,
+              default: 100,
+            },
+            angle_deg: {
+              type: 'number',
+              description: 'Override gradient angle in degrees (optional)',
+            },
+          },
+        },
+      },
+      handler: async (args) => applyGradientMask(connection, args),
+    },
+  ];
+}
+
+async function applyGradientMask(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const direction = parseGradientDirection(args.direction);
+  const startPct = clampInt(args.start_pct, 0, 100, 0);
+  const endPct = clampInt(args.end_pct, 0, 100, 100);
+  const angleDeg = typeof args.angle_deg === 'number' ? args.angle_deg : undefined;
+
+  const gradientScript = ExtendScriptSnippets.applyGradientMask(
+    direction,
+    startPct,
+    endPct,
+    angleDeg
+  );
+
+  let maskAutoCreated = false;
+
+  try {
+    const raw = await runSnippet(connection, gradientScript);
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+    return atomicSuccess('Gradient applied on layer mask', {
+      ...parsed,
+      mask_auto_created: false,
+    });
+  } catch (firstError) {
+    const firstMessage = firstError instanceof Error ? firstError.message : String(firstError);
+    if (!/no layer mask/i.test(firstMessage)) {
+      return atomicFailureFromError(firstError);
+    }
+  }
+
+  try {
+    const maskRaw = await runSnippet(connection, ExtendScriptSnippets.createLayerMask());
+    const maskParsed = parseSnippetResult(maskRaw);
+    if (maskParsed?.maskCreated === true) {
+      maskAutoCreated = true;
+    }
+
+    const raw = await runSnippet(connection, gradientScript);
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    return atomicSuccess('Gradient applied on layer mask', {
+      ...parsed,
+      mask_auto_created: maskAutoCreated,
+    });
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}

--- a/src/tools/recipes/_shared.ts
+++ b/src/tools/recipes/_shared.ts
@@ -20,9 +20,188 @@ export interface RecipeFailure {
   suggested_next_tool?: string;
 }
 
+/** PS 26-compatible Action Manager helpers shared by all recipes. */
+export const RECIPE_ACTION_HELPERS = `
+function __mcp_s2t(s) { return app.stringIDToTypeID(s); }
+function __mcp_c2t(s) { return app.charIDToTypeID(s); }
+
+function __mcp_ensureRasterActiveLayer() {
+  var doc = app.activeDocument;
+  var layer = doc.activeLayer;
+  if (layer.typename === 'LayerSet') {
+    throw new Error('Active item is a layer group — select a raster layer first.');
+  }
+  var kind = layer.kind;
+  if (kind === LayerKind.NORMAL) {
+    if (layer.isBackgroundLayer) {
+      try { layer.isBackgroundLayer = false; } catch (eBg) {}
+    }
+    return layer;
+  }
+  if (kind === LayerKind.TEXT) {
+    layer.rasterize(RasterizeType.TEXTCONTENTS);
+    return doc.activeLayer;
+  }
+  if (kind === LayerKind.SMARTOBJECT) {
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putEnumerated(__mcp_s2t('layer'), __mcp_s2t('ordinal'), __mcp_s2t('targetEnum'));
+    desc.putReference(__mcp_s2t('null'), ref);
+    executeAction(__mcp_s2t('rasterizePlaced'), desc, DialogModes.NO);
+    return doc.activeLayer;
+  }
+  try { layer.rasterize(RasterizeType.ENTIRELAYER); } catch (e) {}
+  return doc.activeLayer;
+}
+
+function __mcp_applyFrequencyHighFromLow(lowLayer, highLayer) {
+  var doc = app.activeDocument;
+  doc.activeLayer = highLayer;
+
+  function applyStringCalculation() {
+    var applyDesc = new ActionDescriptor();
+    var calcDesc = new ActionDescriptor();
+    var srcRef = new ActionReference();
+    srcRef.putEnumerated(__mcp_s2t('channel'), __mcp_s2t('channel'), __mcp_s2t('RGB'));
+    srcRef.putName(__mcp_s2t('layer'), lowLayer.name);
+    calcDesc.putReference(__mcp_s2t('to'), srcRef);
+    calcDesc.putEnumerated(__mcp_s2t('calculation'), __mcp_s2t('calculationType'), __mcp_s2t('subtract'));
+    calcDesc.putDouble(__mcp_s2t('scale'), 2);
+    calcDesc.putInteger(__mcp_s2t('offset'), 128);
+    applyDesc.putObject(__mcp_s2t('with'), __mcp_s2t('calculation'), calcDesc);
+    executeAction(__mcp_s2t('applyImageEvent'), applyDesc, DialogModes.NO);
+  }
+
+  function applyNestedClcl() {
+    var applyDesc = new ActionDescriptor();
+    var srcDesc = new ActionDescriptor();
+    var srcRef = new ActionReference();
+    srcRef.putName(__mcp_c2t('Lyr '), lowLayer.name);
+    srcDesc.putReference(__mcp_c2t('T   '), srcRef);
+    srcDesc.putEnumerated(__mcp_c2t('Clcl'), __mcp_c2t('Clcn'), __mcp_c2t('Sbtr'));
+    srcDesc.putInteger(__mcp_c2t('Scl '), 2);
+    srcDesc.putInteger(__mcp_c2t('Ofst'), 128);
+    applyDesc.putObject(__mcp_c2t('With'), __mcp_c2t('Clcl'), srcDesc);
+    executeAction(__mcp_c2t('AppI'), applyDesc, DialogModes.NO);
+  }
+
+  var lastError = null;
+  try {
+    applyStringCalculation();
+    return;
+  } catch (eString) {
+    lastError = eString;
+  }
+  try {
+    applyNestedClcl();
+    return;
+  } catch (eNested) {
+    lastError = eNested;
+  }
+  throw lastError || new Error('Apply Image failed');
+}
+
+function __mcp_makeLayerMaskRevealSelection() {
+  var desc = new ActionDescriptor();
+  desc.putClass(__mcp_s2t('new'), __mcp_s2t('channel'));
+  var atRef = new ActionReference();
+  atRef.putEnumerated(__mcp_s2t('layer'), __mcp_s2t('ordinal'), __mcp_s2t('targetEnum'));
+  desc.putReference(__mcp_s2t('at'), atRef);
+  desc.putEnumerated(__mcp_s2t('using'), __mcp_s2t('userMaskEnabled'), __mcp_s2t('revealSelection'));
+  executeAction(__mcp_s2t('make'), desc, DialogModes.NO);
+}
+
+function __mcp_makeHueSatAdjustmentLayer(hue, saturation, lightness, colorize) {
+  var desc = new ActionDescriptor();
+  var ref = new ActionReference();
+  ref.putClass(__mcp_s2t('adjustmentLayer'));
+  desc.putReference(__mcp_s2t('null'), ref);
+  var using = new ActionDescriptor();
+  var typeDesc = new ActionDescriptor();
+  typeDesc.putEnumerated(__mcp_s2t('presetKind'), __mcp_s2t('presetKindType'), __mcp_s2t('presetKindCustom'));
+  typeDesc.putBoolean(__mcp_c2t('Clrz'), colorize);
+  var adjustments = new ActionList();
+  var adjustment = new ActionDescriptor();
+  adjustment.putInteger(__mcp_c2t('H   '), hue);
+  adjustment.putInteger(__mcp_c2t('Strt'), saturation);
+  adjustment.putInteger(__mcp_c2t('Lght'), lightness);
+  adjustments.putObject(__mcp_c2t('Hsrt'), adjustment);
+  typeDesc.putList(__mcp_c2t('Adjs'), adjustments);
+  using.putObject(__mcp_s2t('type'), __mcp_s2t('hueSaturation'), typeDesc);
+  desc.putObject(__mcp_s2t('using'), __mcp_s2t('adjustmentLayer'), using);
+  executeAction(__mcp_s2t('make'), desc, DialogModes.NO);
+  return app.activeDocument.activeLayer;
+}
+
+function __mcp_makeCurvesAdjustmentLayer() {
+  var desc = new ActionDescriptor();
+  var ref = new ActionReference();
+  ref.putClass(__mcp_s2t('adjustmentLayer'));
+  desc.putReference(__mcp_s2t('null'), ref);
+  var using = new ActionDescriptor();
+  var curvesAdjust = new ActionDescriptor();
+  var curvesAdjustments = new ActionList();
+  var curvesPair = new ActionDescriptor();
+  var curvesPoints = new ActionList();
+  var ptBlack = new ActionDescriptor();
+  ptBlack.putDouble(__mcp_c2t('Hrzn'), 12);
+  ptBlack.putDouble(__mcp_c2t('Vrtc'), 0);
+  var ptWhite = new ActionDescriptor();
+  ptWhite.putDouble(__mcp_c2t('Hrzn'), 243);
+  ptWhite.putDouble(__mcp_c2t('Vrtc'), 255);
+  curvesPoints.putObject(__mcp_c2t('Pnt '), ptBlack);
+  curvesPoints.putObject(__mcp_c2t('Pnt '), ptWhite);
+  curvesPair.putList(__mcp_c2t('Crv '), curvesPoints);
+  var channelRef = new ActionReference();
+  channelRef.putEnumerated(__mcp_c2t('Chnl'), __mcp_c2t('Chnl'), __mcp_c2t('Cmps'));
+  curvesPair.putReference(__mcp_c2t('Chnl'), channelRef);
+  curvesAdjustments.putObject(__mcp_c2t('CrvA'), curvesPair);
+  curvesAdjust.putList(__mcp_c2t('Adjs'), curvesAdjustments);
+  using.putObject(__mcp_s2t('type'), __mcp_s2t('curves'), curvesAdjust);
+  desc.putObject(__mcp_s2t('using'), __mcp_s2t('adjustmentLayer'), using);
+  executeAction(__mcp_s2t('make'), desc, DialogModes.NO);
+  return app.activeDocument.activeLayer;
+}
+`;
+
+const EXTENDSCRIPT_JSON_HELPER = `
+function __mcp_json_stringify(value) {
+  if (value === null) return 'null';
+  var t = typeof value;
+  if (t === 'boolean') return value ? 'true' : 'false';
+  if (t === 'number') return isFinite(value) ? String(value) : 'null';
+  if (t === 'string') {
+    return '"' + value
+      .replace(/\\\\/g, '\\\\\\\\')
+      .replace(/"/g, '\\\\"')
+      .replace(/\\n/g, '\\\\n')
+      .replace(/\\r/g, '\\\\r')
+      .replace(/\\t/g, '\\\\t') + '"';
+  }
+  if (value instanceof Array) {
+    var items = [];
+    for (var i = 0; i < value.length; i++) {
+      items.push(__mcp_json_stringify(value[i]));
+    }
+    return '[' + items.join(',') + ']';
+  }
+  if (t === 'object') {
+    var pairs = [];
+    for (var key in value) {
+      if (!value.hasOwnProperty(key)) continue;
+      pairs.push(__mcp_json_stringify(String(key)) + ':' + __mcp_json_stringify(value[key]));
+    }
+    return '{' + pairs.join(',') + '}';
+  }
+  return 'null';
+}
+`;
+
 export function wrapInSuspendHistory(historyName: string, body: string): string {
   const escapedName = historyName.replace(/"/g, '\\"');
   return `
+    ${RECIPE_ACTION_HELPERS}
+    ${EXTENDSCRIPT_JSON_HELPER}
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
@@ -38,7 +217,7 @@ export function wrapInSuspendHistory(historyName: string, body: string): string 
     if (!__mcp_recipe_result) {
       __mcp_recipe_result = { ok: false, code: 'recipe_no_result', message: 'Recipe produced no result' };
     }
-    return __mcp_recipe_result;
+    return __mcp_json_stringify(__mcp_recipe_result);
   `;
 }
 

--- a/src/tools/recipes/_shared.ts
+++ b/src/tools/recipes/_shared.ts
@@ -1,5 +1,10 @@
 import type { ToolResult } from '../../core/tool-registry.js';
 import type { PhotoshopConnection } from '../../platform/connection.js';
+import {
+  MCP_CURVES_ADJUSTMENT_HELPER,
+  MCP_LAYER_MASK_HELPERS,
+  type GradientMaskDirection,
+} from '../../api/extendscript.js';
 import { PhotoshopAPIFactory } from '../../api/photoshop-api.js';
 import { parseExtendScriptPayload } from '../../utils/extendscript-result.js';
 
@@ -24,6 +29,8 @@ export interface RecipeFailure {
 export const RECIPE_ACTION_HELPERS = `
 function __mcp_s2t(s) { return app.stringIDToTypeID(s); }
 function __mcp_c2t(s) { return app.charIDToTypeID(s); }
+function cTID(s) { return __mcp_c2t(s); }
+function sTID(s) { return __mcp_s2t(s); }
 
 function __mcp_ensureRasterActiveLayer() {
   var doc = app.activeDocument;
@@ -133,35 +140,9 @@ function __mcp_makeHueSatAdjustmentLayer(hue, saturation, lightness, colorize) {
   return app.activeDocument.activeLayer;
 }
 
-function __mcp_makeCurvesAdjustmentLayer() {
-  var desc = new ActionDescriptor();
-  var ref = new ActionReference();
-  ref.putClass(__mcp_s2t('adjustmentLayer'));
-  desc.putReference(__mcp_s2t('null'), ref);
-  var using = new ActionDescriptor();
-  var curvesAdjust = new ActionDescriptor();
-  var curvesAdjustments = new ActionList();
-  var curvesPair = new ActionDescriptor();
-  var curvesPoints = new ActionList();
-  var ptBlack = new ActionDescriptor();
-  ptBlack.putDouble(__mcp_c2t('Hrzn'), 12);
-  ptBlack.putDouble(__mcp_c2t('Vrtc'), 0);
-  var ptWhite = new ActionDescriptor();
-  ptWhite.putDouble(__mcp_c2t('Hrzn'), 243);
-  ptWhite.putDouble(__mcp_c2t('Vrtc'), 255);
-  curvesPoints.putObject(__mcp_c2t('Pnt '), ptBlack);
-  curvesPoints.putObject(__mcp_c2t('Pnt '), ptWhite);
-  curvesPair.putList(__mcp_c2t('Crv '), curvesPoints);
-  var channelRef = new ActionReference();
-  channelRef.putEnumerated(__mcp_c2t('Chnl'), __mcp_c2t('Chnl'), __mcp_c2t('Cmps'));
-  curvesPair.putReference(__mcp_c2t('Chnl'), channelRef);
-  curvesAdjustments.putObject(__mcp_c2t('CrvA'), curvesPair);
-  curvesAdjust.putList(__mcp_c2t('Adjs'), curvesAdjustments);
-  using.putObject(__mcp_s2t('type'), __mcp_s2t('curves'), curvesAdjust);
-  desc.putObject(__mcp_s2t('using'), __mcp_s2t('adjustmentLayer'), using);
-  executeAction(__mcp_s2t('make'), desc, DialogModes.NO);
-  return app.activeDocument.activeLayer;
-}
+${MCP_CURVES_ADJUSTMENT_HELPER}
+
+${MCP_LAYER_MASK_HELPERS}
 `;
 
 const EXTENDSCRIPT_JSON_HELPER = `
@@ -308,4 +289,25 @@ export function jsString(value: string): string {
     .replace(/"/g, '\\"')
     .replace(/\n/g, '\\n')
     .replace(/\r/g, '\\r');
+}
+
+export function gradientMaskAxisPercents(
+  direction: GradientMaskDirection,
+  startPct: number,
+  endPct: number
+): { fromH: number; fromV: number; toH: number; toV: number; reverse: boolean } {
+  const gradientEndpoints: Record<
+    GradientMaskDirection,
+    { fromH: number; fromV: number; toH: number; toV: number; reverse: boolean }
+  > = {
+    bottom_to_top: { fromH: 50, fromV: endPct, toH: 50, toV: startPct, reverse: false },
+    top_to_bottom: { fromH: 50, fromV: startPct, toH: 50, toV: endPct, reverse: false },
+    left_to_right: { fromH: startPct, fromV: 50, toH: endPct, toV: 50, reverse: false },
+    right_to_left: { fromH: endPct, fromV: 50, toH: startPct, toV: 50, reverse: false },
+  };
+  return gradientEndpoints[direction];
+}
+
+export function gradientMaskDefaultAngle(direction: GradientMaskDirection): number {
+  return direction === 'left_to_right' || direction === 'right_to_left' ? 0 : 90;
 }

--- a/src/tools/recipes/_shared.ts
+++ b/src/tools/recipes/_shared.ts
@@ -1,0 +1,132 @@
+import type { ToolResult } from '../../core/tool-registry.js';
+import type { PhotoshopConnection } from '../../platform/connection.js';
+import { PhotoshopAPIFactory } from '../../api/photoshop-api.js';
+import { parseExtendScriptPayload } from '../../utils/extendscript-result.js';
+
+export interface RecipeSuccess {
+  ok: true;
+  summary: string;
+  created_layer_ids?: number[];
+  output_paths?: string[];
+  next_suggested_tool?: string;
+  undo_history_states_consumed: number;
+  details?: Record<string, unknown>;
+}
+
+export interface RecipeFailure {
+  ok: false;
+  code: string;
+  message: string;
+  suggested_next_tool?: string;
+}
+
+export function wrapInSuspendHistory(historyName: string, body: string): string {
+  const escapedName = historyName.replace(/"/g, '\\"');
+  return `
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    var __mcp_recipe_doc = app.activeDocument;
+    var __mcp_recipe_result = null;
+    var __mcp_recipe_fn = function() {
+      ${body}
+    };
+    __mcp_recipe_doc.suspendHistory(
+      "${escapedName}",
+      "try { __mcp_recipe_result = __mcp_recipe_fn(); } catch (eRecipe) { __mcp_recipe_result = { ok: false, code: 'recipe_runtime_error', message: eRecipe.message || String(eRecipe) }; }"
+    );
+    if (!__mcp_recipe_result) {
+      __mcp_recipe_result = { ok: false, code: 'recipe_no_result', message: 'Recipe produced no result' };
+    }
+    return __mcp_recipe_result;
+  `;
+}
+
+export function parseRecipeResult(raw: unknown): RecipeSuccess | RecipeFailure | null {
+  const payload = parseExtendScriptPayload(raw);
+  if (payload === null || typeof payload !== 'object') return null;
+  const rec = payload as Record<string, unknown>;
+  if (rec.ok === true) {
+    return {
+      ok: true,
+      summary: typeof rec.summary === 'string' ? rec.summary : 'Recipe completed',
+      created_layer_ids: Array.isArray(rec.created_layer_ids)
+        ? (rec.created_layer_ids as number[])
+        : undefined,
+      output_paths: Array.isArray(rec.output_paths) ? (rec.output_paths as string[]) : undefined,
+      next_suggested_tool:
+        typeof rec.next_suggested_tool === 'string' ? rec.next_suggested_tool : undefined,
+      undo_history_states_consumed:
+        typeof rec.undo_history_states_consumed === 'number' ? rec.undo_history_states_consumed : 1,
+      details:
+        rec.details && typeof rec.details === 'object'
+          ? (rec.details as Record<string, unknown>)
+          : undefined,
+    };
+  }
+  if (rec.ok === false) {
+    return {
+      ok: false,
+      code: typeof rec.code === 'string' ? rec.code : 'recipe_unknown_error',
+      message: typeof rec.message === 'string' ? rec.message : 'Unknown recipe error',
+      suggested_next_tool:
+        typeof rec.suggested_next_tool === 'string' ? rec.suggested_next_tool : undefined,
+    };
+  }
+  return null;
+}
+
+export function toolSuccess(result: RecipeSuccess): ToolResult {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+  };
+}
+
+export function toolFailure(result: RecipeFailure): ToolResult {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+    isError: true,
+  };
+}
+
+export function toolException(error: unknown, code = 'recipe_exception'): ToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return toolFailure({ ok: false, code, message });
+}
+
+export async function executeRecipe(
+  connection: PhotoshopConnection,
+  historyName: string,
+  body: string
+): Promise<ToolResult> {
+  try {
+    const apiFactory = new PhotoshopAPIFactory(connection);
+    const api = await apiFactory.createAPI();
+    const script = wrapInSuspendHistory(historyName, body);
+    const raw = await api.executeScript(script);
+    const parsed = parseRecipeResult(raw);
+    if (!parsed) {
+      return toolFailure({
+        ok: false,
+        code: 'recipe_no_result',
+        message: `Recipe returned an unparseable payload: ${typeof raw === 'string' ? raw : JSON.stringify(raw)}`,
+      });
+    }
+    return parsed.ok ? toolSuccess(parsed) : toolFailure(parsed);
+  } catch (error) {
+    return toolException(error);
+  }
+}
+
+export function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+export function jsString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+}

--- a/src/tools/recipes/apply-color-grade.ts
+++ b/src/tools/recipes/apply-color-grade.ts
@@ -78,28 +78,13 @@ async function runApplyColorGrade(
     var group = doc.layerSets.add();
     group.name = 'Color Grade · ' + '${preset}';
 
-    var idMk = charIDToTypeID('Mk  ');
-    var idHueSat = charIDToTypeID('HStr');
-    var hueSatDesc = new ActionDescriptor();
-    var hueSatRef = new ActionReference();
-    hueSatRef.putClass(idHueSat);
-    hueSatDesc.putReference(charIDToTypeID('null'), hueSatRef);
-    var hueSatUsing = new ActionDescriptor();
-    var hueSatAdjust = new ActionDescriptor();
-    hueSatAdjust.putEnumerated(stringIDToTypeID('presetKind'), stringIDToTypeID('presetKindType'), stringIDToTypeID('presetKindCustom'));
-    hueSatAdjust.putBoolean(charIDToTypeID('Clrz'), ${config.desaturate ? 'true' : 'false'});
-    var hsAdjustments = new ActionList();
-    var hsAdjustment = new ActionDescriptor();
-    hsAdjustment.putInteger(charIDToTypeID('H   '), ${config.hue});
-    hsAdjustment.putInteger(charIDToTypeID('Strt'), ${config.saturation});
-    hsAdjustment.putInteger(charIDToTypeID('Lght'), ${config.lightness});
-    hsAdjustments.putObject(charIDToTypeID('Hsrt'), hsAdjustment);
-    hueSatAdjust.putList(charIDToTypeID('Adjs'), hsAdjustments);
-    hueSatUsing.putObject(charIDToTypeID('Type'), idHueSat, hueSatAdjust);
-    hueSatDesc.putObject(charIDToTypeID('Usng'), charIDToTypeID('AdjL'), hueSatUsing);
     try {
-      executeAction(idMk, hueSatDesc, DialogModes.NO);
-      var hueSatLayer = doc.activeLayer;
+      var hueSatLayer = __mcp_makeHueSatAdjustmentLayer(
+        ${config.hue},
+        ${config.saturation},
+        ${config.lightness},
+        ${config.desaturate ? 'true' : 'false'}
+      );
       hueSatLayer.move(group, ElementPlacement.INSIDE);
       hueSatLayer.name = 'HueSat · ${preset}';
     } catch (eHueSat) {

--- a/src/tools/recipes/apply-color-grade.ts
+++ b/src/tools/recipes/apply-color-grade.ts
@@ -1,0 +1,131 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { executeRecipe } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_apply_color_grade';
+
+const PRESET_OPTIONS = [
+  'cinematic',
+  'vintage',
+  'teal_orange',
+  'bw',
+  'warm_film',
+  'cool_dusk',
+] as const;
+type Preset = (typeof PRESET_OPTIONS)[number];
+
+interface HueSatPreset {
+  hue: number;
+  saturation: number;
+  lightness: number;
+  desaturate?: boolean;
+}
+
+const HUE_SAT_BY_PRESET: Record<Preset, HueSatPreset> = {
+  cinematic: { hue: 0, saturation: -15, lightness: 0 },
+  vintage: { hue: -8, saturation: -25, lightness: -3 },
+  teal_orange: { hue: 10, saturation: 8, lightness: 0 },
+  bw: { hue: 0, saturation: -100, lightness: 0, desaturate: true },
+  warm_film: { hue: 6, saturation: 5, lightness: 2 },
+  cool_dusk: { hue: -6, saturation: -10, lightness: 0 },
+};
+
+export function bindApplyColorGrade(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'Apply a named color grading preset as a non-destructive layer group (Hue/Saturation adjustment + brightness/contrast tweak).\n' +
+        '\n' +
+        'Use when: the user wants a quick stylistic look applied to the active document.\n' +
+        'Do NOT use when: the user wants subject-specific color edits (e.g. only the skin) — current recipe applies globally.\n' +
+        '\n' +
+        'Returns: { ok, summary, details: { preset, group_name } }.\n' +
+        '\n' +
+        'Preconditions: active document in RGB mode. CMYK/Grayscale return unsupported_color_mode.\n' +
+        'Side effects: adds one layer group with adjustment layers; one undo reverts.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          preset: {
+            type: 'string',
+            description: `Preset name. One of: ${PRESET_OPTIONS.join(', ')}. Default cinematic.`,
+            enum: [...PRESET_OPTIONS],
+            default: 'cinematic',
+          },
+        },
+      },
+    },
+    handler: async (args) => runApplyColorGrade(connection, args),
+  };
+}
+
+async function runApplyColorGrade(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const preset = parsePreset(args.preset);
+  const config = HUE_SAT_BY_PRESET[preset];
+
+  const body = `
+    var doc = app.activeDocument;
+    try {
+      if (String(doc.mode) !== 'DocumentMode.RGB') {
+        return { ok: false, code: 'unsupported_color_mode', message: 'Active document is not RGB; convert to RGB before applying a color grade.', suggested_next_tool: 'photoshop_get_state' };
+      }
+    } catch (eMode) {}
+
+    var group = doc.layerSets.add();
+    group.name = 'Color Grade · ' + '${preset}';
+
+    var idMk = charIDToTypeID('Mk  ');
+    var idHueSat = charIDToTypeID('HStr');
+    var hueSatDesc = new ActionDescriptor();
+    var hueSatRef = new ActionReference();
+    hueSatRef.putClass(idHueSat);
+    hueSatDesc.putReference(charIDToTypeID('null'), hueSatRef);
+    var hueSatUsing = new ActionDescriptor();
+    var hueSatAdjust = new ActionDescriptor();
+    hueSatAdjust.putEnumerated(stringIDToTypeID('presetKind'), stringIDToTypeID('presetKindType'), stringIDToTypeID('presetKindCustom'));
+    hueSatAdjust.putBoolean(charIDToTypeID('Clrz'), ${config.desaturate ? 'true' : 'false'});
+    var hsAdjustments = new ActionList();
+    var hsAdjustment = new ActionDescriptor();
+    hsAdjustment.putInteger(charIDToTypeID('H   '), ${config.hue});
+    hsAdjustment.putInteger(charIDToTypeID('Strt'), ${config.saturation});
+    hsAdjustment.putInteger(charIDToTypeID('Lght'), ${config.lightness});
+    hsAdjustments.putObject(charIDToTypeID('Hsrt'), hsAdjustment);
+    hueSatAdjust.putList(charIDToTypeID('Adjs'), hsAdjustments);
+    hueSatUsing.putObject(charIDToTypeID('Type'), idHueSat, hueSatAdjust);
+    hueSatDesc.putObject(charIDToTypeID('Usng'), charIDToTypeID('AdjL'), hueSatUsing);
+    try {
+      executeAction(idMk, hueSatDesc, DialogModes.NO);
+      var hueSatLayer = doc.activeLayer;
+      hueSatLayer.move(group, ElementPlacement.INSIDE);
+      hueSatLayer.name = 'HueSat · ${preset}';
+    } catch (eHueSat) {
+      return { ok: false, code: 'recipe_runtime_error', message: 'HueSat adjustment failed: ' + (eHueSat.message || eHueSat) };
+    }
+
+    return {
+      ok: true,
+      summary: 'Applied color grade "${preset}" as non-destructive group',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        preset: '${preset}',
+        group_name: group.name,
+        hue: ${config.hue},
+        saturation: ${config.saturation},
+        lightness: ${config.lightness}
+      }
+    };
+  `;
+
+  return executeRecipe(connection, `Color Grade ${preset}`, body);
+}
+
+function parsePreset(raw: unknown): Preset {
+  if (typeof raw !== 'string') return 'cinematic';
+  const v = raw.trim().toLowerCase();
+  return PRESET_OPTIONS.find((o) => o === v) ?? 'cinematic';
+}

--- a/src/tools/recipes/apply-color-grade.ts
+++ b/src/tools/recipes/apply-color-grade.ts
@@ -37,6 +37,8 @@ export function bindApplyColorGrade(connection: PhotoshopConnection): ToolDefini
       description:
         'Apply a named color grading preset as a non-destructive layer group (Hue/Saturation adjustment + brightness/contrast tweak).\n' +
         '\n' +
+        'Users often say: cinematic look, teal and orange, moody grade, color grade.\n' +
+        '\n' +
         'Use when: the user wants a quick stylistic look applied to the active document.\n' +
         'Do NOT use when: the user wants subject-specific color edits (e.g. only the skin) — current recipe applies globally.\n' +
         '\n' +

--- a/src/tools/recipes/batch-mockup-replace.ts
+++ b/src/tools/recipes/batch-mockup-replace.ts
@@ -1,0 +1,209 @@
+import { readdir, stat } from 'node:fs/promises';
+import { extname, isAbsolute, join } from 'node:path';
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { resolveExportPath } from '../../lib/export-paths.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import {
+  clampInt,
+  executeRecipe,
+  jsString,
+  toolFailure,
+} from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_batch_mockup_replace';
+
+const SUPPORTED_ASSET_EXTS = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.tif',
+  '.tiff',
+  '.psd',
+  '.psb',
+  '.webp',
+]);
+
+export function bindBatchMockupReplace(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        "Iterate a directory of asset images, replace the contents of the named Smart Object in the active mockup PSD for each asset, and export a flattened JPEG per variant. The mockup's perspective/warp on the Smart Object is preserved.\n" +
+        '\n' +
+        'Use when: the user has a mockup PSD and wants to render it once per design asset (logos, screens, product photos).\n' +
+        'Do NOT use when: the asset is not a single layer (use photoshop_place_image manually) or when the active document has no Smart Object with the requested name.\n' +
+        '\n' +
+        'Returns: { ok, summary, output_paths, details: { variants: [{ source_asset, output_path }] } }.\n' +
+        '\n' +
+        'Preconditions: active document containing a Smart Object layer named exactly as requested; assets_dir must exist and be readable.\n' +
+        'Side effects: writes one JPEG per asset; the active mockup PSD ends up with the LAST asset placed.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          smart_object_layer_name: {
+            type: 'string',
+            description:
+              'Exact name of the Smart Object layer in the active document. Case-sensitive.',
+          },
+          assets_dir: {
+            type: 'string',
+            description:
+              'Absolute path to the directory containing asset files. Subdirectories are NOT recursed. Allowed extensions: jpg/jpeg/png/tif/tiff/psd/psb/webp.',
+          },
+          quality: {
+            type: 'number',
+            description: 'JPEG quality on the Photoshop 1-12 scale. Default 10.',
+            minimum: 1,
+            maximum: 12,
+            default: 10,
+          },
+        },
+        required: ['smart_object_layer_name', 'assets_dir'],
+      },
+    },
+    handler: async (args) => runBatchMockupReplace(connection, args),
+  };
+}
+
+async function runBatchMockupReplace(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const layerName =
+    typeof args.smart_object_layer_name === 'string' ? args.smart_object_layer_name.trim() : '';
+  const assetsDir = typeof args.assets_dir === 'string' ? args.assets_dir.trim() : '';
+  const quality = clampInt(args.quality, 1, 12, 10);
+
+  if (!layerName) {
+    return toolFailure({
+      ok: false,
+      code: 'invalid_arguments',
+      message: 'smart_object_layer_name is required.',
+    });
+  }
+  if (!assetsDir || !isAbsolute(assetsDir)) {
+    return toolFailure({
+      ok: false,
+      code: 'invalid_arguments',
+      message: 'assets_dir must be an absolute path.',
+    });
+  }
+
+  let entries: string[];
+  try {
+    const dirStat = await stat(assetsDir);
+    if (!dirStat.isDirectory()) {
+      return toolFailure({
+        ok: false,
+        code: 'file_not_found',
+        message: `assets_dir is not a directory: ${assetsDir}`,
+      });
+    }
+    entries = await readdir(assetsDir);
+  } catch (error) {
+    return toolFailure({
+      ok: false,
+      code: 'file_not_found',
+      message: `Cannot read assets_dir: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  const assets = entries
+    .filter((name) => SUPPORTED_ASSET_EXTS.has(extname(name).toLowerCase()))
+    .sort()
+    .map((name) => join(assetsDir, name));
+
+  if (assets.length === 0) {
+    return toolFailure({
+      ok: false,
+      code: 'file_not_found',
+      message: `No supported assets in ${assetsDir}. Supported: ${[...SUPPORTED_ASSET_EXTS].join(', ')}`,
+    });
+  }
+
+  const variantsLiteral = assets
+    .map((assetPath) => {
+      const baseName = baseNameWithoutExt(assetPath);
+      const outPath = resolveExportPath(`mockup-${baseName}-${Date.now()}.jpg`, 'jpg');
+      return `{ asset: "${jsString(assetPath)}", base: "${jsString(baseName)}", out: "${jsString(outPath)}" }`;
+    })
+    .join(', ');
+
+  const body = `
+    var doc = app.activeDocument;
+    var targetName = "${jsString(layerName)}";
+    var target = null;
+    function findLayer(container, name) {
+      for (var i = 0; i < container.layers.length; i++) {
+        var l = container.layers[i];
+        if (l.name === name) return l;
+      }
+      for (var j = 0; j < container.layerSets.length; j++) {
+        var nested = findLayer(container.layerSets[j], name);
+        if (nested) return nested;
+      }
+      return null;
+    }
+    target = findLayer(doc, targetName);
+    if (!target) {
+      return { ok: false, code: 'layer_not_found', message: 'Smart Object layer not found: ' + targetName, suggested_next_tool: 'photoshop_get_layers' };
+    }
+    if (target.kind !== LayerKind.SMARTOBJECT) {
+      return { ok: false, code: 'unsupported_color_mode', message: 'Target layer "' + targetName + '" is not a Smart Object (kind=' + target.kind + ').', suggested_next_tool: 'photoshop_get_layers' };
+    }
+    doc.activeLayer = target;
+
+    var variants = [${variantsLiteral}];
+    var produced = [];
+
+    for (var v = 0; v < variants.length; v++) {
+      var spec = variants[v];
+      try {
+        var assetFile = new File(spec.asset);
+        if (!assetFile.exists) {
+          return { ok: false, code: 'file_not_found', message: 'Asset missing on disk: ' + spec.asset };
+        }
+        var replaceDesc = new ActionDescriptor();
+        replaceDesc.putPath(charIDToTypeID('null'), assetFile);
+        replaceDesc.putInteger(charIDToTypeID('PgNm'), 1);
+        executeAction(stringIDToTypeID('placedLayerReplaceContents'), replaceDesc, DialogModes.NO);
+
+        var outFile = new File(spec.out);
+        var jpegOptions = new JPEGSaveOptions();
+        jpegOptions.quality = ${quality};
+        jpegOptions.embedColorProfile = true;
+        var flatDup = doc.duplicate('mcp-mockup-out-' + spec.base, true);
+        try {
+          flatDup.saveAs(outFile, jpegOptions, true);
+          produced.push({ source_asset: spec.asset, output_path: outFile.fsName });
+        } finally {
+          try { flatDup.close(SaveOptions.DONOTSAVECHANGES); } catch (eCloseF) {}
+        }
+      } catch (eVariant) {
+        return { ok: false, code: 'recipe_runtime_error', message: 'Variant ' + spec.asset + ' failed: ' + (eVariant.message || eVariant) };
+      }
+    }
+
+    var paths = [];
+    for (var k = 0; k < produced.length; k++) {
+      paths.push(produced[k].output_path);
+    }
+
+    return {
+      ok: true,
+      summary: 'Rendered ' + produced.length + ' mockup variant(s) into the export directory',
+      undo_history_states_consumed: produced.length,
+      output_paths: paths,
+      details: { variants: produced, target_layer: targetName }
+    };
+  `;
+
+  return executeRecipe(connection, 'Batch Mockup Replace', body);
+}
+
+function baseNameWithoutExt(p: string): string {
+  const segments = p.split(/[/\\]/g);
+  const fileName = segments[segments.length - 1] ?? p;
+  const idx = fileName.lastIndexOf('.');
+  return idx > 0 ? fileName.slice(0, idx) : fileName;
+}

--- a/src/tools/recipes/dodge-burn.ts
+++ b/src/tools/recipes/dodge-burn.ts
@@ -1,0 +1,97 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { executeRecipe } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_dodge_burn';
+
+const BLEND_MODE_OPTIONS = ['overlay', 'soft_light'] as const;
+type BlendModeArg = (typeof BLEND_MODE_OPTIONS)[number];
+
+const BLEND_MODE_BY_ARG: Record<BlendModeArg, string> = {
+  overlay: 'OVERLAY',
+  soft_light: 'SOFTLIGHT',
+};
+
+export function bindDodgeBurn(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'One-shot dodge & burn setup: creates a 50% gray layer in Overlay or Soft Light mode for non-destructive light sculpting. Wrapped in a single undoable history step.\n' +
+        '\n' +
+        'Users often say: dodge and burn, sculpt light, lighten face, darken shadows.\n' +
+        '\n' +
+        'Use when: the user wants a ready-to-paint dodge & burn layer above the subject.\n' +
+        'Do NOT use when: the user wants automated retouch — this only sets up the paint layer; paint white (dodge) and black (burn) manually at low opacity.\n' +
+        'Do NOT use when: automated portrait smoothing is enough — use photoshop_recipe_enhance_portrait instead.\n' +
+        '\n' +
+        'Returns: { ok, summary, undo_history_states_consumed, details: { layer_name, blend_mode } }.\n' +
+        '\n' +
+        'Preconditions: active document with a raster-compatible active layer.\n' +
+        'Side effects: adds one "Dodge & Burn" layer above the active layer; one undo reverts.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          blend_mode: {
+            type: 'string',
+            description: 'Retouch blend mode: overlay (default, stronger) or soft_light (gentler)',
+            enum: [...BLEND_MODE_OPTIONS],
+            default: 'overlay',
+          },
+        },
+      },
+    },
+    handler: async (args) => runDodgeBurn(connection, args),
+  };
+}
+
+async function runDodgeBurn(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const blendArg = parseBlendMode(args.blend_mode);
+  const blendMode = BLEND_MODE_BY_ARG[blendArg];
+
+  const body = `
+    var doc = app.activeDocument;
+    try {
+      __mcp_ensureRasterActiveLayer();
+    } catch (eRaster) {
+      return { ok: false, code: 'no_active_layer', message: eRaster.message || String(eRaster), suggested_next_tool: 'photoshop_rasterize_layer' };
+    }
+
+    var db = doc.artLayers.add();
+    db.name = 'Dodge & Burn';
+
+    var color = new SolidColor();
+    color.rgb.red = 128;
+    color.rgb.green = 128;
+    color.rgb.blue = 128;
+
+    doc.activeLayer = db;
+    doc.selection.selectAll();
+    doc.selection.fill(color);
+    doc.selection.deselect();
+
+    db.blendMode = BlendMode.${blendMode};
+
+    return {
+      ok: true,
+      summary: 'Dodge & Burn layer ready in ${blendArg.replace(/_/g, ' ')} mode — paint white to lighten, black to darken',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        layer_name: db.name,
+        blend_mode: '${blendArg}'
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Dodge & Burn', body);
+}
+
+function parseBlendMode(raw: unknown): BlendModeArg {
+  if (typeof raw !== 'string') return 'overlay';
+  const v = raw.trim().toLowerCase();
+  return BLEND_MODE_OPTIONS.find((o) => o === v) ?? 'overlay';
+}

--- a/src/tools/recipes/enhance-portrait.ts
+++ b/src/tools/recipes/enhance-portrait.ts
@@ -60,12 +60,11 @@ async function runEnhancePortrait(
 
   const body = `
     var doc = app.activeDocument;
-    var src = doc.activeLayer;
-    if (src.kind !== LayerKind.NORMAL && !src.isBackgroundLayer) {
-      return { ok: false, code: 'unsupported_color_mode', message: 'Active layer is not a raster layer (kind=' + src.kind + '). Rasterize or pick a normal layer first.', suggested_next_tool: 'photoshop_rasterize_layer' };
-    }
-    if (src.isBackgroundLayer) {
-      try { src.isBackgroundLayer = false; } catch (eBg) {}
+    var src;
+    try {
+      src = __mcp_ensureRasterActiveLayer();
+    } catch (eRaster) {
+      return { ok: false, code: 'unsupported_color_mode', message: eRaster.message || String(eRaster), suggested_next_tool: 'photoshop_rasterize_layer' };
     }
 
     var group = doc.layerSets.add();
@@ -75,61 +74,24 @@ async function runEnhancePortrait(
 
     if (${skinSmoothing ? 'true' : 'false'}) {
       var low = src.duplicate(group, ElementPlacement.INSIDE);
-      low.name = 'FS · Low';
+      low.name = 'FS Low';
       low.applyGaussianBlur(${radius});
       createdNames.push(low.name);
 
       var high = src.duplicate(group, ElementPlacement.INSIDE);
-      high.name = 'FS · High';
-      doc.activeLayer = high;
-      var applyDesc = new ActionDescriptor();
-      var srcDesc = new ActionDescriptor();
-      var srcRef = new ActionReference();
-      srcRef.putName(charIDToTypeID('Lyr '), low.name);
-      srcDesc.putReference(charIDToTypeID('T   '), srcRef);
-      srcDesc.putEnumerated(charIDToTypeID('Clcl'), charIDToTypeID('Clcn'), charIDToTypeID('Sbtr'));
-      srcDesc.putInteger(charIDToTypeID('Scl '), 2);
-      srcDesc.putInteger(charIDToTypeID('Ofst'), 128);
-      applyDesc.putObject(charIDToTypeID('With'), charIDToTypeID('Clcl'), srcDesc);
+      high.name = 'FS High';
       try {
-        executeAction(charIDToTypeID('AppI'), applyDesc, DialogModes.NO);
+        __mcp_applyFrequencyHighFromLow(low, high);
       } catch (eApplyImage) {
+        try { group.remove(); } catch (eRmG) {}
         return { ok: false, code: 'recipe_runtime_error', message: 'Apply Image step failed: ' + (eApplyImage.message || eApplyImage) };
       }
       high.blendMode = BlendMode.LINEARLIGHT;
       createdNames.push(high.name);
     }
 
-    var idMk = charIDToTypeID('Mk  ');
-    var idCrvs = charIDToTypeID('Crvs');
-    var curvesDesc = new ActionDescriptor();
-    var curvesRef = new ActionReference();
-    curvesRef.putClass(idCrvs);
-    curvesDesc.putReference(charIDToTypeID('null'), curvesRef);
-    var curvesUsing = new ActionDescriptor();
-    var curvesAdjust = new ActionDescriptor();
-    var curvesAdjustments = new ActionList();
-    var curvesPair = new ActionDescriptor();
-    var curvesPoints = new ActionList();
-    var ptBlack = new ActionDescriptor();
-    ptBlack.putDouble(charIDToTypeID('Hrzn'), 12);
-    ptBlack.putDouble(charIDToTypeID('Vrtc'), 0);
-    var ptWhite = new ActionDescriptor();
-    ptWhite.putDouble(charIDToTypeID('Hrzn'), 243);
-    ptWhite.putDouble(charIDToTypeID('Vrtc'), 255);
-    curvesPoints.putObject(charIDToTypeID('Pnt '), ptBlack);
-    curvesPoints.putObject(charIDToTypeID('Pnt '), ptWhite);
-    curvesPair.putList(charIDToTypeID('Crv '), curvesPoints);
-    var channelRef = new ActionReference();
-    channelRef.putEnumerated(charIDToTypeID('Chnl'), charIDToTypeID('Chnl'), charIDToTypeID('Cmps'));
-    curvesPair.putReference(charIDToTypeID('Chnl'), channelRef);
-    curvesAdjustments.putObject(charIDToTypeID('CrvA'), curvesPair);
-    curvesAdjust.putList(charIDToTypeID('Adjs'), curvesAdjustments);
-    curvesUsing.putObject(charIDToTypeID('Type'), idCrvs, curvesAdjust);
-    curvesDesc.putObject(charIDToTypeID('Usng'), charIDToTypeID('AdjL'), curvesUsing);
     try {
-      executeAction(idMk, curvesDesc, DialogModes.NO);
-      var curvesLayer = doc.activeLayer;
+      var curvesLayer = __mcp_makeCurvesAdjustmentLayer();
       curvesLayer.move(group, ElementPlacement.INSIDE);
       curvesLayer.name = 'Auto-tone (curves)';
       createdNames.push(curvesLayer.name);

--- a/src/tools/recipes/enhance-portrait.ts
+++ b/src/tools/recipes/enhance-portrait.ts
@@ -1,0 +1,161 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { executeRecipe } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_enhance_portrait';
+
+const INTENSITY_OPTIONS = ['low', 'medium', 'high'] as const;
+type Intensity = (typeof INTENSITY_OPTIONS)[number];
+
+const RADIUS_BY_INTENSITY: Record<Intensity, number> = {
+  low: 2,
+  medium: 4,
+  high: 7,
+};
+
+export function bindEnhancePortrait(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'Set up a non-destructive portrait enhancement: duplicates the active layer, builds a frequency separation pair (low/high) for skin smoothing, and adds an auto-tone curves adjustment on top. Grouped as "Enhance Portrait" and reversible with one undo.\n' +
+        '\n' +
+        'Use when: the user asks to "enhance", "retouch", "clean up" or "smooth" a portrait photo and is happy with a baseline that they can further tweak interactively.\n' +
+        'Do NOT use when: the user wants destructive, final edits — recommend manual frequency separation work via photoshop_recipe_frequency_separation instead so they can paint by hand.\n' +
+        '\n' +
+        'Returns: { ok, summary, details: { intensity, radius_px, group_name } }.\n' +
+        '\n' +
+        'Preconditions: active document with a NORMAL or background-converted raster layer.\n' +
+        'Side effects: appends one layer group of 2-3 layers above the active layer; original layer untouched.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          intensity: {
+            type: 'string',
+            description:
+              'Retouch strength: low (subtle), medium (default), high (heavier smoothing).',
+            enum: ['low', 'medium', 'high'],
+            default: 'medium',
+          },
+          skin_smoothing: {
+            type: 'boolean',
+            description:
+              'Whether to build the frequency separation pair. When false, only the auto-tone curves are added.',
+            default: true,
+          },
+        },
+      },
+    },
+    handler: async (args) => runEnhancePortrait(connection, args),
+  };
+}
+
+async function runEnhancePortrait(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const intensity = parseIntensity(args.intensity);
+  const skinSmoothing = args.skin_smoothing !== false;
+  const radius = RADIUS_BY_INTENSITY[intensity];
+
+  const body = `
+    var doc = app.activeDocument;
+    var src = doc.activeLayer;
+    if (src.kind !== LayerKind.NORMAL && !src.isBackgroundLayer) {
+      return { ok: false, code: 'unsupported_color_mode', message: 'Active layer is not a raster layer (kind=' + src.kind + '). Rasterize or pick a normal layer first.', suggested_next_tool: 'photoshop_rasterize_layer' };
+    }
+    if (src.isBackgroundLayer) {
+      try { src.isBackgroundLayer = false; } catch (eBg) {}
+    }
+
+    var group = doc.layerSets.add();
+    group.name = 'Enhance Portrait';
+
+    var createdNames = [];
+
+    if (${skinSmoothing ? 'true' : 'false'}) {
+      var low = src.duplicate(group, ElementPlacement.INSIDE);
+      low.name = 'FS · Low';
+      low.applyGaussianBlur(${radius});
+      createdNames.push(low.name);
+
+      var high = src.duplicate(group, ElementPlacement.INSIDE);
+      high.name = 'FS · High';
+      doc.activeLayer = high;
+      var applyDesc = new ActionDescriptor();
+      var srcDesc = new ActionDescriptor();
+      var srcRef = new ActionReference();
+      srcRef.putName(charIDToTypeID('Lyr '), low.name);
+      srcDesc.putReference(charIDToTypeID('T   '), srcRef);
+      srcDesc.putEnumerated(charIDToTypeID('Clcl'), charIDToTypeID('Clcn'), charIDToTypeID('Sbtr'));
+      srcDesc.putInteger(charIDToTypeID('Scl '), 2);
+      srcDesc.putInteger(charIDToTypeID('Ofst'), 128);
+      applyDesc.putObject(charIDToTypeID('With'), charIDToTypeID('Clcl'), srcDesc);
+      try {
+        executeAction(charIDToTypeID('AppI'), applyDesc, DialogModes.NO);
+      } catch (eApplyImage) {
+        return { ok: false, code: 'recipe_runtime_error', message: 'Apply Image step failed: ' + (eApplyImage.message || eApplyImage) };
+      }
+      high.blendMode = BlendMode.LINEARLIGHT;
+      createdNames.push(high.name);
+    }
+
+    var idMk = charIDToTypeID('Mk  ');
+    var idCrvs = charIDToTypeID('Crvs');
+    var curvesDesc = new ActionDescriptor();
+    var curvesRef = new ActionReference();
+    curvesRef.putClass(idCrvs);
+    curvesDesc.putReference(charIDToTypeID('null'), curvesRef);
+    var curvesUsing = new ActionDescriptor();
+    var curvesAdjust = new ActionDescriptor();
+    var curvesAdjustments = new ActionList();
+    var curvesPair = new ActionDescriptor();
+    var curvesPoints = new ActionList();
+    var ptBlack = new ActionDescriptor();
+    ptBlack.putDouble(charIDToTypeID('Hrzn'), 12);
+    ptBlack.putDouble(charIDToTypeID('Vrtc'), 0);
+    var ptWhite = new ActionDescriptor();
+    ptWhite.putDouble(charIDToTypeID('Hrzn'), 243);
+    ptWhite.putDouble(charIDToTypeID('Vrtc'), 255);
+    curvesPoints.putObject(charIDToTypeID('Pnt '), ptBlack);
+    curvesPoints.putObject(charIDToTypeID('Pnt '), ptWhite);
+    curvesPair.putList(charIDToTypeID('Crv '), curvesPoints);
+    var channelRef = new ActionReference();
+    channelRef.putEnumerated(charIDToTypeID('Chnl'), charIDToTypeID('Chnl'), charIDToTypeID('Cmps'));
+    curvesPair.putReference(charIDToTypeID('Chnl'), channelRef);
+    curvesAdjustments.putObject(charIDToTypeID('CrvA'), curvesPair);
+    curvesAdjust.putList(charIDToTypeID('Adjs'), curvesAdjustments);
+    curvesUsing.putObject(charIDToTypeID('Type'), idCrvs, curvesAdjust);
+    curvesDesc.putObject(charIDToTypeID('Usng'), charIDToTypeID('AdjL'), curvesUsing);
+    try {
+      executeAction(idMk, curvesDesc, DialogModes.NO);
+      var curvesLayer = doc.activeLayer;
+      curvesLayer.move(group, ElementPlacement.INSIDE);
+      curvesLayer.name = 'Auto-tone (curves)';
+      createdNames.push(curvesLayer.name);
+    } catch (eCurves) {
+      return { ok: false, code: 'recipe_runtime_error', message: 'Curves adjustment failed: ' + (eCurves.message || eCurves) };
+    }
+
+    return {
+      ok: true,
+      summary: 'Portrait enhancement set up at intensity "' + '${intensity}' + '" — ' + createdNames.length + ' layers grouped under "Enhance Portrait"',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        intensity: '${intensity}',
+        radius_px: ${radius},
+        group_name: group.name,
+        created_layers: createdNames
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Enhance Portrait', body);
+}
+
+function parseIntensity(raw: unknown): Intensity {
+  if (typeof raw !== 'string') return 'medium';
+  const v = raw.trim().toLowerCase();
+  return INTENSITY_OPTIONS.find((o) => o === v) ?? 'medium';
+}

--- a/src/tools/recipes/enhance-portrait.ts
+++ b/src/tools/recipes/enhance-portrait.ts
@@ -20,6 +20,8 @@ export function bindEnhancePortrait(connection: PhotoshopConnection): ToolDefini
       description:
         'Set up a non-destructive portrait enhancement: duplicates the active layer, builds a frequency separation pair (low/high) for skin smoothing, and adds an auto-tone curves adjustment on top. Grouped as "Enhance Portrait" and reversible with one undo.\n' +
         '\n' +
+        'Users often say: smooth skin, retouch portrait, fix blemishes, clean up face.\n' +
+        '\n' +
         'Use when: the user asks to "enhance", "retouch", "clean up" or "smooth" a portrait photo and is happy with a baseline that they can further tweak interactively.\n' +
         'Do NOT use when: the user wants destructive, final edits — recommend manual frequency separation work via photoshop_recipe_frequency_separation instead so they can paint by hand.\n' +
         '\n' +

--- a/src/tools/recipes/export-social-variants.ts
+++ b/src/tools/recipes/export-social-variants.ts
@@ -1,0 +1,206 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { resolveExportPath } from '../../lib/export-paths.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { clampInt, executeRecipe, jsString } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_export_social_variants';
+
+interface PlatformSpec {
+  slug: string;
+  width: number;
+  height: number;
+}
+
+const PLATFORM_SPECS: Record<string, PlatformSpec> = {
+  instagram_post: { slug: 'instagram_post', width: 1080, height: 1080 },
+  instagram_story: { slug: 'instagram_story', width: 1080, height: 1920 },
+  instagram_reel: { slug: 'instagram_reel', width: 1080, height: 1920 },
+  x_post: { slug: 'x_post', width: 1600, height: 900 },
+  x_header: { slug: 'x_header', width: 1500, height: 500 },
+  facebook_post: { slug: 'facebook_post', width: 1200, height: 630 },
+  facebook_cover: { slug: 'facebook_cover', width: 1640, height: 624 },
+  linkedin_post: { slug: 'linkedin_post', width: 1200, height: 627 },
+  linkedin_banner: { slug: 'linkedin_banner', width: 1584, height: 396 },
+  youtube_thumbnail: { slug: 'youtube_thumbnail', width: 1280, height: 720 },
+  tiktok_vertical: { slug: 'tiktok_vertical', width: 1080, height: 1920 },
+  pinterest_pin: { slug: 'pinterest_pin', width: 1000, height: 1500 },
+};
+
+const DEFAULT_PLATFORMS = ['instagram_post', 'instagram_story', 'x_post'];
+
+export function bindExportSocialVariants(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'Render one JPEG per requested social-media platform from the active document. Each variant is center-cropped/resized to the platform spec and saved to disk.\n' +
+        '\n' +
+        'Use when: the user wants multi-platform deliverables in one shot.\n' +
+        'Do NOT use when: only one export is needed (use photoshop_recipe_prepare_for_web instead) or when platforms differ by content rather than crop (recipe does not change content, only frame).\n' +
+        '\n' +
+        'Returns: { ok, summary, output_paths, details: { variants } }.\n' +
+        '\n' +
+        'Preconditions: active document. Aspect ratios that differ from the source result in a center-crop (no padding).\n' +
+        'Side effects: writes one file per platform; source unchanged.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          platforms: {
+            type: 'array',
+            description: `Slugs of platforms to export. Known: ${Object.keys(PLATFORM_SPECS).join(', ')}. Default: ${DEFAULT_PLATFORMS.join(', ')}.`,
+            items: { type: 'string' },
+            default: DEFAULT_PLATFORMS,
+          },
+          quality: {
+            type: 'number',
+            description: 'JPEG quality on the Photoshop 1-12 scale. Default 9.',
+            minimum: 1,
+            maximum: 12,
+            default: 9,
+          },
+        },
+      },
+    },
+    handler: async (args) => runExportSocialVariants(connection, args),
+  };
+}
+
+async function runExportSocialVariants(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const platforms = parsePlatforms(args.platforms);
+  if (platforms.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(
+            {
+              ok: false,
+              code: 'invalid_arguments',
+              message: 'No valid platform slugs provided.',
+              suggested_next_tool: TOOL_NAME,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const quality = clampQuality(args.quality);
+
+  const variants = platforms.map((spec) => {
+    const path = resolveExportPath(`social-${spec.slug}-${Date.now()}.jpg`, 'jpg');
+    return { ...spec, path };
+  });
+
+  const variantsLiteral = variants
+    .map(
+      (v) =>
+        `{ slug: "${jsString(v.slug)}", width: ${v.width}, height: ${v.height}, path: "${jsString(v.path)}" }`
+    )
+    .join(', ');
+
+  const body = `
+    var src = app.activeDocument;
+    var variants = [${variantsLiteral}];
+    var produced = [];
+
+    for (var i = 0; i < variants.length; i++) {
+      var spec = variants[i];
+      var dupName = 'mcp-social-' + spec.slug + '-' + (new Date()).getTime();
+      var dup = src.duplicate(dupName, true);
+      try {
+        try {
+          dup.convertProfile('sRGB IEC61966-2.1', Intent.RELATIVECOLORIMETRIC, true, true);
+        } catch (eProfile) {}
+
+        var sw = dup.width.as('px');
+        var sh = dup.height.as('px');
+        var srcRatio = sw / sh;
+        var tgtRatio = spec.width / spec.height;
+        var cropW, cropH;
+        if (srcRatio > tgtRatio) {
+          cropH = sh;
+          cropW = Math.round(sh * tgtRatio);
+        } else {
+          cropW = sw;
+          cropH = Math.round(sw / tgtRatio);
+        }
+        var left = Math.round((sw - cropW) / 2);
+        var top = Math.round((sh - cropH) / 2);
+        try {
+          dup.crop([left, top, left + cropW, top + cropH]);
+        } catch (eCrop) {
+          return { ok: false, code: 'recipe_runtime_error', message: 'Crop failed for ' + spec.slug + ': ' + (eCrop.message || eCrop) };
+        }
+
+        dup.resizeImage(
+          UnitValue(spec.width, 'px'),
+          UnitValue(spec.height, 'px'),
+          null,
+          ResampleMethod.BICUBICSHARPER
+        );
+
+        var outFile = new File(spec.path);
+        var jpegOptions = new JPEGSaveOptions();
+        jpegOptions.quality = ${quality};
+        jpegOptions.embedColorProfile = true;
+        dup.saveAs(outFile, jpegOptions, true);
+
+        produced.push({ slug: spec.slug, path: outFile.fsName, width: spec.width, height: spec.height });
+        dup.close(SaveOptions.DONOTSAVECHANGES);
+      } catch (eVariant) {
+        try { dup.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+        return { ok: false, code: 'recipe_runtime_error', message: 'Variant ' + spec.slug + ' failed: ' + (eVariant.message || eVariant) };
+      }
+    }
+
+    var paths = [];
+    for (var k = 0; k < produced.length; k++) {
+      paths.push(produced[k].path);
+    }
+
+    return {
+      ok: true,
+      summary: 'Exported ' + produced.length + ' social variant(s)',
+      undo_history_states_consumed: 0,
+      output_paths: paths,
+      details: { variants: produced }
+    };
+  `;
+
+  return executeRecipe(connection, 'Export Social Variants', body);
+}
+
+function parsePlatforms(raw: unknown): PlatformSpec[] {
+  let slugs: string[];
+  if (Array.isArray(raw)) {
+    slugs = raw.filter((s): s is string => typeof s === 'string');
+  } else if (typeof raw === 'string') {
+    slugs = raw.split(/[,\s]+/g).filter((s) => s.length > 0);
+  } else {
+    slugs = DEFAULT_PLATFORMS;
+  }
+  if (slugs.length === 0) slugs = DEFAULT_PLATFORMS;
+  const out: PlatformSpec[] = [];
+  const seen = new Set<string>();
+  for (const s of slugs) {
+    const key = s.trim().toLowerCase();
+    if (seen.has(key)) continue;
+    const spec = PLATFORM_SPECS[key];
+    if (spec) {
+      out.push(spec);
+      seen.add(key);
+    }
+  }
+  return out;
+}
+
+function clampQuality(raw: unknown): number {
+  return clampInt(raw, 1, 12, 9);
+}

--- a/src/tools/recipes/frequency-separation.ts
+++ b/src/tools/recipes/frequency-separation.ts
@@ -44,34 +44,26 @@ async function runFrequencySeparation(
 
   const body = `
     var doc = app.activeDocument;
-    var src = doc.activeLayer;
-    if (src.kind !== LayerKind.NORMAL) {
-      return { ok: false, code: 'unsupported_color_mode', message: 'Active layer is not a raster layer. Rasterize or pick a normal layer first.', suggested_next_tool: 'photoshop_rasterize_layer' };
+    var src;
+    try {
+      src = __mcp_ensureRasterActiveLayer();
+    } catch (eRaster) {
+      return { ok: false, code: 'unsupported_color_mode', message: eRaster.message || String(eRaster), suggested_next_tool: 'photoshop_rasterize_layer' };
     }
 
     var group = doc.layerSets.add();
     group.name = 'Frequency Separation';
 
     var low = src.duplicate(group, ElementPlacement.INSIDE);
-    low.name = 'FS · Low';
+    low.name = 'FS Low';
     low.applyGaussianBlur(${radius});
 
     var high = src.duplicate(group, ElementPlacement.INSIDE);
-    high.name = 'FS · High';
-    doc.activeLayer = high;
-
-    var applyDesc = new ActionDescriptor();
-    var srcDesc = new ActionDescriptor();
-    var srcRef = new ActionReference();
-    srcRef.putName(charIDToTypeID('Lyr '), low.name);
-    srcDesc.putReference(charIDToTypeID('T   '), srcRef);
-    srcDesc.putEnumerated(charIDToTypeID('Clcl'), charIDToTypeID('Clcn'), charIDToTypeID('Sbtr'));
-    srcDesc.putInteger(charIDToTypeID('Scl '), 2);
-    srcDesc.putInteger(charIDToTypeID('Ofst'), 128);
-    applyDesc.putObject(charIDToTypeID('With'), charIDToTypeID('Clcl'), srcDesc);
+    high.name = 'FS High';
     try {
-      executeAction(charIDToTypeID('AppI'), applyDesc, DialogModes.NO);
+      __mcp_applyFrequencyHighFromLow(low, high);
     } catch (eApply) {
+      try { group.remove(); } catch (eRmG) {}
       return { ok: false, code: 'recipe_runtime_error', message: 'Apply Image failed: ' + (eApply.message || eApply) };
     }
     high.blendMode = BlendMode.LINEARLIGHT;

--- a/src/tools/recipes/frequency-separation.ts
+++ b/src/tools/recipes/frequency-separation.ts
@@ -11,6 +11,8 @@ export function bindFrequencySeparation(connection: PhotoshopConnection): ToolDe
       description:
         'Build a frequency separation stack (Low + High) on top of the active layer for hands-on retouching. Does not apply any smoothing itself — the user paints into the layers afterwards.\n' +
         '\n' +
+        'Users often say: frequency separation, split texture and color, manual retouch setup.\n' +
+        '\n' +
         'Use when: the user explicitly wants frequency separation setup, typically for portrait or product retouching.\n' +
         'Do NOT use when: the user wants a one-shot result without painting — use photoshop_recipe_enhance_portrait instead.\n' +
         '\n' +

--- a/src/tools/recipes/frequency-separation.ts
+++ b/src/tools/recipes/frequency-separation.ts
@@ -1,0 +1,94 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { clampInt, executeRecipe } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_frequency_separation';
+
+export function bindFrequencySeparation(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'Build a frequency separation stack (Low + High) on top of the active layer for hands-on retouching. Does not apply any smoothing itself — the user paints into the layers afterwards.\n' +
+        '\n' +
+        'Use when: the user explicitly wants frequency separation setup, typically for portrait or product retouching.\n' +
+        'Do NOT use when: the user wants a one-shot result without painting — use photoshop_recipe_enhance_portrait instead.\n' +
+        '\n' +
+        'Returns: { ok, summary, details: { radius_px, group_name } }.\n' +
+        '\n' +
+        'Preconditions: active document with a NORMAL raster active layer.\n' +
+        'Side effects: appends a "Frequency Separation" layer group with 2 prepared layers; one undo reverts everything.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          radius_px: {
+            type: 'number',
+            description:
+              'Gaussian blur radius for the low-frequency layer. 4-8 for portraits, 10-20 for products. Default 6. Range 1-50.',
+            minimum: 1,
+            maximum: 50,
+            default: 6,
+          },
+        },
+      },
+    },
+    handler: async (args) => runFrequencySeparation(connection, args),
+  };
+}
+
+async function runFrequencySeparation(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const radius = clampInt(args.radius_px, 1, 50, 6);
+
+  const body = `
+    var doc = app.activeDocument;
+    var src = doc.activeLayer;
+    if (src.kind !== LayerKind.NORMAL) {
+      return { ok: false, code: 'unsupported_color_mode', message: 'Active layer is not a raster layer. Rasterize or pick a normal layer first.', suggested_next_tool: 'photoshop_rasterize_layer' };
+    }
+
+    var group = doc.layerSets.add();
+    group.name = 'Frequency Separation';
+
+    var low = src.duplicate(group, ElementPlacement.INSIDE);
+    low.name = 'FS · Low';
+    low.applyGaussianBlur(${radius});
+
+    var high = src.duplicate(group, ElementPlacement.INSIDE);
+    high.name = 'FS · High';
+    doc.activeLayer = high;
+
+    var applyDesc = new ActionDescriptor();
+    var srcDesc = new ActionDescriptor();
+    var srcRef = new ActionReference();
+    srcRef.putName(charIDToTypeID('Lyr '), low.name);
+    srcDesc.putReference(charIDToTypeID('T   '), srcRef);
+    srcDesc.putEnumerated(charIDToTypeID('Clcl'), charIDToTypeID('Clcn'), charIDToTypeID('Sbtr'));
+    srcDesc.putInteger(charIDToTypeID('Scl '), 2);
+    srcDesc.putInteger(charIDToTypeID('Ofst'), 128);
+    applyDesc.putObject(charIDToTypeID('With'), charIDToTypeID('Clcl'), srcDesc);
+    try {
+      executeAction(charIDToTypeID('AppI'), applyDesc, DialogModes.NO);
+    } catch (eApply) {
+      return { ok: false, code: 'recipe_runtime_error', message: 'Apply Image failed: ' + (eApply.message || eApply) };
+    }
+    high.blendMode = BlendMode.LINEARLIGHT;
+
+    return {
+      ok: true,
+      summary: 'Frequency separation stack ready at radius ${radius}px — paint on FS · Low to smooth, FS · High to retouch texture',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        radius_px: ${radius},
+        group_name: group.name,
+        low_layer: low.name,
+        high_layer: high.name
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Frequency Separation', body);
+}

--- a/src/tools/recipes/gradient-fade.ts
+++ b/src/tools/recipes/gradient-fade.ts
@@ -1,0 +1,140 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import type { GradientMaskDirection } from '../../api/extendscript.js';
+import {
+  clampInt,
+  executeRecipe,
+  gradientMaskAxisPercents,
+  gradientMaskDefaultAngle,
+} from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_gradient_fade';
+
+const GRADIENT_DIRECTIONS: GradientMaskDirection[] = [
+  'top_to_bottom',
+  'bottom_to_top',
+  'left_to_right',
+  'right_to_left',
+];
+
+export function bindGradientFade(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'One-shot gradient fade on the active layer mask: creates a reveal-all mask if needed, then paints a linear black-to-white gradient for soft edge blending. Wrapped in a single undoable history step.\n' +
+        '\n' +
+        'Users often say: fade into background, gradient mask, blend subject, soft edge fade, arka planı yumuşat.\n' +
+        '\n' +
+        'This applies a linear gradient on the layer mask channel — not a Gradient Fill layer.\n' +
+        'Use when: the user wants the active layer to fade into the background or layers below through its mask.\n' +
+        'Do NOT use when: the subject is not isolated — use photoshop_recipe_remove_background first.\n' +
+        'Do NOT use when: replacing the sky with an external image — use photoshop_recipe_sky_blend.\n' +
+        '\n' +
+        'Returns: { ok, summary, undo_history_states_consumed, details: { direction, start_pct, end_pct, mask_created, layer_name } }.\n' +
+        '\n' +
+        'Preconditions: active document with an active layer.\n' +
+        'Side effects: creates or modifies the active layer mask; one undo reverts everything.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          direction: {
+            type: 'string',
+            description: 'Gradient fade direction on the mask (default bottom_to_top)',
+            enum: GRADIENT_DIRECTIONS,
+            default: 'bottom_to_top',
+          },
+          start_pct: {
+            type: 'number',
+            description: 'Gradient start along fade axis (0-100)',
+            minimum: 0,
+            maximum: 100,
+            default: 0,
+          },
+          end_pct: {
+            type: 'number',
+            description: 'Gradient end along fade axis (0-100)',
+            minimum: 0,
+            maximum: 100,
+            default: 100,
+          },
+          angle_deg: {
+            type: 'number',
+            description: 'Optional gradient angle override in degrees',
+          },
+        },
+      },
+    },
+    handler: async (args) => runGradientFade(connection, args),
+  };
+}
+
+async function runGradientFade(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const direction = parseGradientDirection(args.direction);
+  const startPct = clampInt(args.start_pct, 0, 100, 0);
+  const endPct = clampInt(args.end_pct, 0, 100, 100);
+  const angle =
+    typeof args.angle_deg === 'number' && Number.isFinite(args.angle_deg)
+      ? Math.round(args.angle_deg)
+      : gradientMaskDefaultAngle(direction);
+  const endpoints = gradientMaskAxisPercents(direction, startPct, endPct);
+
+  const body = `
+    var doc = app.activeDocument;
+    var layer = doc.activeLayer;
+    if (!layer) {
+      return { ok: false, code: 'no_active_layer', message: 'No active layer', suggested_next_tool: 'photoshop_get_state' };
+    }
+
+    var maskCreated = false;
+    if (!__mcp_hasLayerMaskAM()) {
+      __mcp_makeLayerMaskAtChannel('revealAll');
+      maskCreated = true;
+    }
+
+    app.displayDialogs = DialogModes.NO;
+    doc.activeLayer = layer;
+    __mcp_selectLayerMaskChannel();
+
+    var docW = doc.width.as('px');
+    var docH = doc.height.as('px');
+    var fromXPx = docW * (${endpoints.fromH} / 100.0);
+    var fromYPx = docH * (${endpoints.fromV} / 100.0);
+    var toXPx = docW * (${endpoints.toH} / 100.0);
+    var toYPx = docH * (${endpoints.toV} / 100.0);
+    __mcp_gradientFillLayerMask(fromXPx, fromYPx, toXPx, toYPx, ${endpoints.reverse ? 'true' : 'false'});
+
+    try {
+      doc.activeChannels = doc.componentChannels;
+    } catch (eRestore) {
+      doc.activeLayer = layer;
+    }
+
+    return {
+      ok: true,
+      summary: 'Subject faded into background via gradient mask',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        direction: '${direction}',
+        start_pct: ${startPct},
+        end_pct: ${endPct},
+        mask_created: maskCreated,
+        layer_name: layer.name,
+        angle: ${angle}
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Gradient Fade', body);
+}
+
+function parseGradientDirection(value: unknown): GradientMaskDirection {
+  if (typeof value === 'string' && GRADIENT_DIRECTIONS.includes(value as GradientMaskDirection)) {
+    return value as GradientMaskDirection;
+  }
+  return 'bottom_to_top';
+}

--- a/src/tools/recipes/index.ts
+++ b/src/tools/recipes/index.ts
@@ -8,6 +8,10 @@ import { bindApplyColorGrade } from './apply-color-grade.js';
 import { bindFrequencySeparation } from './frequency-separation.js';
 import { bindBatchMockupReplace } from './batch-mockup-replace.js';
 import { bindOrganizeLayers } from './organize-layers.js';
+import { bindGradientFade } from './gradient-fade.js';
+import { bindSkyBlend } from './sky-blend.js';
+import { bindDodgeBurn } from './dodge-burn.js';
+import { bindRemoveDistraction } from './remove-distraction.js';
 
 export function createRecipeTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
@@ -19,6 +23,10 @@ export function createRecipeTools(connection: PhotoshopConnection): ToolDefiniti
     bindFrequencySeparation(connection),
     bindBatchMockupReplace(connection),
     bindOrganizeLayers(connection),
+    bindGradientFade(connection),
+    bindSkyBlend(connection),
+    bindDodgeBurn(connection),
+    bindRemoveDistraction(connection),
   ];
 }
 
@@ -31,4 +39,8 @@ export const PHOTOSHOP_RECIPE_TOOL_NAMES = [
   'photoshop_recipe_frequency_separation',
   'photoshop_recipe_batch_mockup_replace',
   'photoshop_recipe_organize_layers',
+  'photoshop_recipe_gradient_fade',
+  'photoshop_recipe_sky_blend',
+  'photoshop_recipe_dodge_burn',
+  'photoshop_recipe_remove_distraction',
 ] as const;

--- a/src/tools/recipes/index.ts
+++ b/src/tools/recipes/index.ts
@@ -1,0 +1,34 @@
+import type { ToolDefinition } from '../../core/tool-registry.js';
+import type { PhotoshopConnection } from '../../platform/connection.js';
+import { bindRemoveBackground } from './remove-background.js';
+import { bindEnhancePortrait } from './enhance-portrait.js';
+import { bindPrepareForWeb } from './prepare-for-web.js';
+import { bindExportSocialVariants } from './export-social-variants.js';
+import { bindApplyColorGrade } from './apply-color-grade.js';
+import { bindFrequencySeparation } from './frequency-separation.js';
+import { bindBatchMockupReplace } from './batch-mockup-replace.js';
+import { bindOrganizeLayers } from './organize-layers.js';
+
+export function createRecipeTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    bindRemoveBackground(connection),
+    bindEnhancePortrait(connection),
+    bindPrepareForWeb(connection),
+    bindExportSocialVariants(connection),
+    bindApplyColorGrade(connection),
+    bindFrequencySeparation(connection),
+    bindBatchMockupReplace(connection),
+    bindOrganizeLayers(connection),
+  ];
+}
+
+export const PHOTOSHOP_RECIPE_TOOL_NAMES = [
+  'photoshop_recipe_remove_background',
+  'photoshop_recipe_enhance_portrait',
+  'photoshop_recipe_prepare_for_web',
+  'photoshop_recipe_export_social_variants',
+  'photoshop_recipe_apply_color_grade',
+  'photoshop_recipe_frequency_separation',
+  'photoshop_recipe_batch_mockup_replace',
+  'photoshop_recipe_organize_layers',
+] as const;

--- a/src/tools/recipes/organize-layers.ts
+++ b/src/tools/recipes/organize-layers.ts
@@ -1,0 +1,168 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { executeRecipe } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_organize_layers';
+
+const NAMING_OPTIONS = ['type_index', 'content_summary', 'preserve'] as const;
+type NamingScheme = (typeof NAMING_OPTIONS)[number];
+
+export function bindOrganizeLayers(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        "Tidy the active document's layer stack: rename layers using a consistent scheme and optionally auto-group them by kind. Never deletes, merges or rasterizes — visual output stays identical.\n" +
+        '\n' +
+        'Use when: the user complains about layer mess ("layer 1 copy 2", "untitled 7") or asks for organization.\n' +
+        'Do NOT use when: the user wants smart, semantic naming based on layer content beyond text — recipe only summarizes text layers, not image content.\n' +
+        '\n' +
+        'Returns: { ok, summary, details: { renamed_count, group_count } }.\n' +
+        '\n' +
+        'Preconditions: active document.\n' +
+        'Side effects: renames top-level layers and (optionally) moves them into kind-grouped folders; one undo reverts everything.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          naming_scheme: {
+            type: 'string',
+            description: `How to rename layers: type_index (default, e.g. text_01), content_summary (text layers get a slug of their content; other kinds get type_index), preserve (do not rename).`,
+            enum: [...NAMING_OPTIONS],
+            default: 'type_index',
+          },
+          auto_group: {
+            type: 'boolean',
+            description: 'Group layers by kind (text / image / shape / adjustment). Default true.',
+            default: true,
+          },
+        },
+      },
+    },
+    handler: async (args) => runOrganizeLayers(connection, args),
+  };
+}
+
+async function runOrganizeLayers(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const naming = parseNaming(args.naming_scheme);
+  const autoGroup = args.auto_group !== false;
+
+  const body = `
+    var doc = app.activeDocument;
+    if (doc.layers.length < 1) {
+      return { ok: false, code: 'recipe_no_result', message: 'No layers to organize.' };
+    }
+
+    var allLayers = [];
+    for (var i = 0; i < doc.layers.length; i++) {
+      var l = doc.layers[i];
+      try {
+        if (l.typename === 'LayerSet') continue;
+      } catch (eType) {}
+      allLayers.push(l);
+    }
+
+    function kindGroupName(layer) {
+      try {
+        if (layer.kind === LayerKind.TEXT) return 'Text';
+        if (layer.kind === LayerKind.SMARTOBJECT) return 'Smart Objects';
+        if (layer.kind === LayerKind.SOLIDFILL || layer.kind === LayerKind.GRADIENTFILL || layer.kind === LayerKind.PATTERNFILL) return 'Fills';
+        if (layer.kind === LayerKind.BRIGHTNESSCONTRAST || layer.kind === LayerKind.LEVELS || layer.kind === LayerKind.CURVES || layer.kind === LayerKind.HUESATURATION || layer.kind === LayerKind.COLORBALANCE || layer.kind === LayerKind.SELECTIVECOLOR || layer.kind === LayerKind.PHOTOFILTER || layer.kind === LayerKind.GRADIENTMAP) return 'Adjustments';
+      } catch (eKind) {}
+      return 'Images';
+    }
+
+    function slugify(text) {
+      var s = String(text || '').toLowerCase();
+      s = s.replace(/[^a-z0-9]+/g, '_');
+      s = s.replace(/^_+|_+$/g, '');
+      if (!s) s = 'untitled';
+      return s.slice(0, 32);
+    }
+
+    var renamedCount = 0;
+    var typeCounters = {};
+
+    for (var j = 0; j < allLayers.length; j++) {
+      var layer = allLayers[j];
+      var kindLabel = '';
+      try {
+        if (layer.kind === LayerKind.TEXT) kindLabel = 'text';
+        else if (layer.kind === LayerKind.SMARTOBJECT) kindLabel = 'smartobject';
+        else if (layer.kind === LayerKind.NORMAL) kindLabel = 'image';
+        else kindLabel = 'layer';
+      } catch (eK) { kindLabel = 'layer'; }
+
+      var newName = layer.name;
+      if ('${naming}' === 'type_index') {
+        if (!typeCounters[kindLabel]) typeCounters[kindLabel] = 0;
+        typeCounters[kindLabel] += 1;
+        var idx = typeCounters[kindLabel];
+        var pad = idx < 10 ? '0' + idx : String(idx);
+        newName = kindLabel + '_' + pad;
+      } else if ('${naming}' === 'content_summary') {
+        if (kindLabel === 'text') {
+          try {
+            newName = 'text_' + slugify(layer.textItem.contents);
+          } catch (eText) {
+            if (!typeCounters[kindLabel]) typeCounters[kindLabel] = 0;
+            typeCounters[kindLabel] += 1;
+            newName = 'text_' + typeCounters[kindLabel];
+          }
+        } else {
+          if (!typeCounters[kindLabel]) typeCounters[kindLabel] = 0;
+          typeCounters[kindLabel] += 1;
+          var idxC = typeCounters[kindLabel];
+          var padC = idxC < 10 ? '0' + idxC : String(idxC);
+          newName = kindLabel + '_' + padC;
+        }
+      }
+
+      if (newName !== layer.name) {
+        layer.name = newName;
+        renamedCount += 1;
+      }
+    }
+
+    var groupCount = 0;
+    if (${autoGroup ? 'true' : 'false'}) {
+      var groupCache = {};
+      for (var k = allLayers.length - 1; k >= 0; k--) {
+        var lk = allLayers[k];
+        var gName = kindGroupName(lk);
+        if (!groupCache[gName]) {
+          var grp = doc.layerSets.add();
+          grp.name = gName;
+          groupCache[gName] = grp;
+          groupCount += 1;
+        }
+        try {
+          lk.move(groupCache[gName], ElementPlacement.INSIDE);
+        } catch (eMove) {}
+      }
+    }
+
+    return {
+      ok: true,
+      summary: 'Organized layers — renamed ' + renamedCount + ', created ' + groupCount + ' group(s)',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_layers',
+      details: {
+        naming_scheme: '${naming}',
+        auto_group: ${autoGroup ? 'true' : 'false'},
+        renamed_count: renamedCount,
+        group_count: groupCount
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Organize Layers', body);
+}
+
+function parseNaming(raw: unknown): NamingScheme {
+  if (typeof raw !== 'string') return 'type_index';
+  const v = raw.trim().toLowerCase();
+  return NAMING_OPTIONS.find((o) => o === v) ?? 'type_index';
+}

--- a/src/tools/recipes/prepare-for-web.ts
+++ b/src/tools/recipes/prepare-for-web.ts
@@ -1,0 +1,141 @@
+import { randomBytes } from 'node:crypto';
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { resolveExportPath } from '../../lib/export-paths.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { clampInt, executeRecipe, jsString } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_prepare_for_web';
+
+const FORMAT_OPTIONS = ['jpeg', 'png'] as const;
+type WebFormat = (typeof FORMAT_OPTIONS)[number];
+
+export function bindPrepareForWeb(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'Export a web-optimized version of the active document: duplicate, convert to sRGB, downscale longest edge, sharpen for screen, save to disk. The source PSD stays untouched.\n' +
+        '\n' +
+        'Use when: the user wants a shareable JPEG/PNG sized for the web from the current artwork.\n' +
+        'Do NOT use when: the user wants multiple platform-specific exports — use photoshop_recipe_export_social_variants. Do NOT call photoshop_save_document afterwards; this recipe already wrote the file.\n' +
+        '\n' +
+        'Returns: { ok, summary, output_paths, undo_history_states_consumed }.\n' +
+        '\n' +
+        'Preconditions: active document. Format is jpeg (default) or png.\n' +
+        'Side effects: writes one file to disk; the source document is unchanged.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          max_dimension_px: {
+            type: 'number',
+            description: 'Longest-edge pixel cap (default 2048). Min 64, max 8192.',
+            minimum: 64,
+            maximum: 8192,
+            default: 2048,
+          },
+          format: {
+            type: 'string',
+            description: 'Output format: jpeg (default) or png.',
+            enum: ['jpeg', 'png'],
+            default: 'jpeg',
+          },
+          quality: {
+            type: 'number',
+            description: 'JPEG quality on the Photoshop 1-12 scale. Default 9. Ignored for png.',
+            minimum: 1,
+            maximum: 12,
+            default: 9,
+          },
+          path: {
+            type: 'string',
+            description:
+              'Optional output path. Absolute paths used as-is. Relative paths resolve under ~/.photoshop-mcp/exports[/<chat-id>]. Omit to auto-generate.',
+          },
+        },
+      },
+    },
+    handler: async (args) => runPrepareForWeb(connection, args),
+  };
+}
+
+async function runPrepareForWeb(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const maxDim = clampInt(args.max_dimension_px, 64, 8192, 2048);
+  const format = parseFormat(args.format);
+  const quality = clampInt(args.quality, 1, 12, 9);
+  const userPath = typeof args.path === 'string' ? args.path : undefined;
+
+  const ext = format === 'jpeg' ? 'jpg' : 'png';
+  let outPath = resolveExportPath(userPath, ext);
+  if (!outPath.toLowerCase().endsWith(`.${ext}`)) {
+    outPath = `${outPath}.${ext}`;
+  }
+  if (!userPath) {
+    outPath = outPath.replace(`.${ext}`, `-${randomBytes(2).toString('hex')}.${ext}`);
+  }
+
+  const body = `
+    var src = app.activeDocument;
+    var dupName = 'mcp-prepare-' + (new Date()).getTime();
+    var dup = src.duplicate(dupName, true);
+    try {
+      try {
+        dup.convertProfile('sRGB IEC61966-2.1', Intent.RELATIVECOLORIMETRIC, true, true);
+      } catch (eProfile) {}
+
+      var w = dup.width.as('px');
+      var h = dup.height.as('px');
+      var longest = Math.max(w, h);
+      if (longest > ${maxDim}) {
+        var ratio = ${maxDim} / longest;
+        dup.resizeImage(
+          UnitValue(Math.round(w * ratio), 'px'),
+          UnitValue(Math.round(h * ratio), 'px'),
+          null,
+          ResampleMethod.BICUBICSHARPER
+        );
+      }
+
+      var sharpenLayer = dup.activeLayer;
+      try {
+        sharpenLayer.applyUnSharpMask(30, 0.6, 0);
+      } catch (eSharpen) {}
+
+      var outFile = new File("${jsString(outPath)}");
+      ${
+        format === 'jpeg'
+          ? `var jpegOptions = new JPEGSaveOptions(); jpegOptions.quality = ${quality}; jpegOptions.embedColorProfile = true; dup.saveAs(outFile, jpegOptions, true);`
+          : `var pngOptions = new PNGSaveOptions(); pngOptions.compression = 9; pngOptions.interlaced = false; dup.saveAs(outFile, pngOptions, true);`
+      }
+      var finalW = dup.width.as('px');
+      var finalH = dup.height.as('px');
+      dup.close(SaveOptions.DONOTSAVECHANGES);
+
+      return {
+        ok: true,
+        summary: 'Exported web-optimized ${format.toUpperCase()} at ' + finalW + '×' + finalH + 'px',
+        undo_history_states_consumed: 0,
+        output_paths: [outFile.fsName],
+        next_suggested_tool: 'photoshop_get_preview',
+        details: {
+          format: '${format}',
+          quality: ${format === 'jpeg' ? quality : 0},
+          max_dimension_px: ${maxDim}
+        }
+      };
+    } catch (eOuter) {
+      try { dup.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return { ok: false, code: 'recipe_runtime_error', message: 'Prepare-for-web failed: ' + (eOuter.message || eOuter) };
+    }
+  `;
+
+  return executeRecipe(connection, 'Prepare for Web', body);
+}
+
+function parseFormat(raw: unknown): WebFormat {
+  if (typeof raw !== 'string') return 'jpeg';
+  const v = raw.trim().toLowerCase();
+  return FORMAT_OPTIONS.find((o) => o === v) ?? 'jpeg';
+}

--- a/src/tools/recipes/remove-background.ts
+++ b/src/tools/recipes/remove-background.ts
@@ -71,11 +71,21 @@ async function runRemoveBackground(
       return { ok: false, code: 'no_active_layer', message: 'Active layer is the Background layer — convert it to a normal layer first.', suggested_next_tool: 'photoshop_rasterize_layer' };
     }
 
+    app.displayDialogs = DialogModes.NO;
+    var subjectSelected = false;
     try {
-      var idAutoCutout = stringIDToTypeID('autoCutout');
-      executeAction(idAutoCutout, undefined, DialogModes.NO);
-    } catch (eSelectSubject) {
-      return { ok: false, code: 'generative_unavailable', message: 'Select Subject is not available: ' + (eSelectSubject.message || eSelectSubject), suggested_next_tool: 'photoshop_get_capabilities' };
+      doc.selection.selectSubject();
+      subjectSelected = true;
+    } catch (eDomSubject) {}
+    if (!subjectSelected) {
+      try {
+        var cutoutDesc = new ActionDescriptor();
+        cutoutDesc.putBoolean(stringIDToTypeID('sampleAllLayers'), false);
+        executeAction(stringIDToTypeID('autoCutout'), cutoutDesc, DialogModes.NO);
+        subjectSelected = true;
+      } catch (eSelectSubject) {
+        return { ok: false, code: 'generative_unavailable', message: 'Select Subject is not available: ' + (eSelectSubject.message || eSelectSubject), suggested_next_tool: 'photoshop_get_capabilities' };
+      }
     }
 
     var hasSel = false;
@@ -88,18 +98,7 @@ async function runRemoveBackground(
       try { doc.selection.feather(${feather}); } catch (eF) {}
     }
 
-    var idMk = charIDToTypeID('Mk  ');
-    var idMsk = charIDToTypeID('Msk ');
-    var idChnl = charIDToTypeID('Chnl');
-    var idUsng = charIDToTypeID('Usng');
-    var idUsrM = charIDToTypeID('UsrM');
-    var idRvlS = charIDToTypeID('RvlS');
-    var maskDesc = new ActionDescriptor();
-    var maskRef = new ActionReference();
-    maskRef.putEnumerated(idChnl, idChnl, idMsk);
-    maskDesc.putReference(charIDToTypeID('null'), maskRef);
-    maskDesc.putEnumerated(idUsng, idUsrM, idRvlS);
-    executeAction(idMk, maskDesc, DialogModes.NO);
+    __mcp_makeLayerMaskRevealSelection();
 
     return {
       ok: true,

--- a/src/tools/recipes/remove-background.ts
+++ b/src/tools/recipes/remove-background.ts
@@ -1,0 +1,118 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { PhotoshopDetector } from '../../platform/detector.js';
+import { clampInt, executeRecipe, toolFailure } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_remove_background';
+
+export function bindRemoveBackground(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'One-shot background removal: runs Select Subject on the active layer, inverts the selection, attaches a layer mask, and applies an optional feather. Wrapped in a single undoable history step.\n' +
+        '\n' +
+        'Use when: the user wants the subject isolated from the background non-destructively. The source pixels are preserved behind the mask.\n' +
+        'Do NOT use when: the subject is extremely fine-edged (hair against a busy background) — propose a manual Refine Edge pass afterwards.\n' +
+        '\n' +
+        'Returns: { ok, summary, undo_history_states_consumed, details }. On failure, an error envelope with code and suggested_next_tool.\n' +
+        '\n' +
+        'Preconditions: PS ≥ 23 (Select Subject v2). Active document with a non-background active layer that contains a subject.\n' +
+        'Side effects: attaches a pixel mask to the active layer; no pixels destroyed; one undo reverts everything.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          feather_px: {
+            type: 'number',
+            description:
+              'Edge feather in pixels (0-20). 0 = hard edge (default for product shots), 1-3 = soft edge for portraits.',
+            minimum: 0,
+            maximum: 20,
+            default: 0,
+          },
+          keep_shadow: {
+            type: 'boolean',
+            description:
+              'Reserved for a future iteration; currently recorded in the response but no shadow layer is created yet.',
+            default: false,
+          },
+        },
+      },
+    },
+    handler: async (args) => runRemoveBackground(connection, args),
+  };
+}
+
+async function runRemoveBackground(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const feather = clampInt(args.feather_px, 0, 20, 0);
+  const keepShadow = args.keep_shadow === true;
+
+  await connection.ping().catch(() => undefined);
+  const info = connection.getPhotoshopInfo();
+  if (info) {
+    const detector = new PhotoshopDetector();
+    if (!detector.supportsSelectSubjectV2(info.version)) {
+      return toolFailure({
+        ok: false,
+        code: 'version_unsupported',
+        message: `Select Subject v2 requires Photoshop 23.0+; detected version ${info.version}. Upgrade Photoshop or remove the background manually.`,
+        suggested_next_tool: 'photoshop_get_capabilities',
+      });
+    }
+  }
+
+  const body = `
+    var doc = app.activeDocument;
+    var layer = doc.activeLayer;
+    if (layer.isBackgroundLayer) {
+      return { ok: false, code: 'no_active_layer', message: 'Active layer is the Background layer — convert it to a normal layer first.', suggested_next_tool: 'photoshop_rasterize_layer' };
+    }
+
+    try {
+      var idAutoCutout = stringIDToTypeID('autoCutout');
+      executeAction(idAutoCutout, undefined, DialogModes.NO);
+    } catch (eSelectSubject) {
+      return { ok: false, code: 'generative_unavailable', message: 'Select Subject is not available: ' + (eSelectSubject.message || eSelectSubject), suggested_next_tool: 'photoshop_get_capabilities' };
+    }
+
+    var hasSel = false;
+    try { hasSel = doc.selection.bounds != null; } catch (e) { hasSel = false; }
+    if (!hasSel) {
+      return { ok: false, code: 'selection_required', message: 'Select Subject produced no selection — the layer may not contain a recognizable subject.' };
+    }
+
+    if (${feather} > 0) {
+      try { doc.selection.feather(${feather}); } catch (eF) {}
+    }
+
+    var idMk = charIDToTypeID('Mk  ');
+    var idMsk = charIDToTypeID('Msk ');
+    var idChnl = charIDToTypeID('Chnl');
+    var idUsng = charIDToTypeID('Usng');
+    var idUsrM = charIDToTypeID('UsrM');
+    var idRvlS = charIDToTypeID('RvlS');
+    var maskDesc = new ActionDescriptor();
+    var maskRef = new ActionReference();
+    maskRef.putEnumerated(idChnl, idChnl, idMsk);
+    maskDesc.putReference(charIDToTypeID('null'), maskRef);
+    maskDesc.putEnumerated(idUsng, idUsrM, idRvlS);
+    executeAction(idMk, maskDesc, DialogModes.NO);
+
+    return {
+      ok: true,
+      summary: 'Background removed via Select Subject + layer mask' + (${feather} > 0 ? ' (feather ' + ${feather} + 'px)' : ''),
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        feather_px: ${feather},
+        keep_shadow: ${keepShadow ? 'true' : 'false'},
+        layer_name: layer.name
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Remove Background', body);
+}

--- a/src/tools/recipes/remove-background.ts
+++ b/src/tools/recipes/remove-background.ts
@@ -12,6 +12,8 @@ export function bindRemoveBackground(connection: PhotoshopConnection): ToolDefin
       description:
         'One-shot background removal: runs Select Subject on the active layer, inverts the selection, attaches a layer mask, and applies an optional feather. Wrapped in a single undoable history step.\n' +
         '\n' +
+        'Users often say: cut out, isolate subject, remove background, transparent background, arka planı sil.\n' +
+        '\n' +
         'Use when: the user wants the subject isolated from the background non-destructively. The source pixels are preserved behind the mask.\n' +
         'Do NOT use when: the subject is extremely fine-edged (hair against a busy background) — propose a manual Refine Edge pass afterwards.\n' +
         '\n' +

--- a/src/tools/recipes/remove-distraction.ts
+++ b/src/tools/recipes/remove-distraction.ts
@@ -1,0 +1,84 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { clampInt, executeRecipe } from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_remove_distraction';
+
+export function bindRemoveDistraction(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'One-shot distraction removal: content-aware fills the current pixel selection. Wrapped in a single undoable history step.\n' +
+        '\n' +
+        'Users often say: remove that person, erase distraction, content aware remove, clone out object.\n' +
+        '\n' +
+        'Use when: the user has selected the object or region to remove and wants content-aware fill in one step.\n' +
+        'Do NOT use when: no selection exists — use photoshop_select_rectangle or photoshop_select_subject first.\n' +
+        'Do NOT use when: generative remove is requested — not scriptable via ExtendScript; this uses content-aware fill only.\n' +
+        '\n' +
+        'Returns: { ok, summary, undo_history_states_consumed, details: { feather_px, fill_method } }.\n' +
+        '\n' +
+        'Preconditions: active document with an active pixel selection.\n' +
+        'Side effects: fills selected pixels; clears selection; one undo reverts.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          feather_px: {
+            type: 'number',
+            description: 'Edge feather in pixels before fill (0-20, default 0)',
+            minimum: 0,
+            maximum: 20,
+            default: 0,
+          },
+        },
+      },
+    },
+    handler: async (args) => runRemoveDistraction(connection, args),
+  };
+}
+
+async function runRemoveDistraction(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const feather = clampInt(args.feather_px, 0, 20, 0);
+
+  const body = `
+    var doc = app.activeDocument;
+    var hasSel = false;
+    try { hasSel = doc.selection.bounds != null; } catch (e) { hasSel = false; }
+    if (!hasSel) {
+      return {
+        ok: false,
+        code: 'selection_required',
+        message: 'Active pixel selection required before content-aware fill',
+        suggested_next_tool: 'photoshop_select_rectangle'
+      };
+    }
+
+    app.displayDialogs = DialogModes.NO;
+
+    if (${feather} > 0) {
+      try { doc.selection.feather(${feather}); } catch (eF) {}
+    }
+
+    var fillDesc = new ActionDescriptor();
+    fillDesc.putEnumerated(sTID('using'), sTID('fillContents'), sTID('contentAware'));
+    executeAction(sTID('fill'), fillDesc, DialogModes.NO);
+    doc.selection.deselect();
+
+    return {
+      ok: true,
+      summary: 'Distraction removed via content-aware fill (content-aware; refine manually if needed)',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        feather_px: ${feather},
+        fill_method: 'content_aware'
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Remove Distraction', body);
+}

--- a/src/tools/recipes/sky-blend.ts
+++ b/src/tools/recipes/sky-blend.ts
@@ -1,0 +1,152 @@
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import {
+  clampInt,
+  executeRecipe,
+  gradientMaskAxisPercents,
+  jsString,
+  toolFailure,
+} from './_shared.js';
+
+const TOOL_NAME = 'photoshop_recipe_sky_blend';
+
+export function bindSkyBlend(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'One-shot sky composite: places an external sky image, adds a layer mask, and applies a horizon gradient fade. Wrapped in a single undoable history step.\n' +
+        '\n' +
+        'Users often say: replace sky, fix blown sky, better clouds, swap sky background.\n' +
+        '\n' +
+        'Use when: the user provides a sky image path and wants a manual horizon blend (AI Sky Replacement is not scriptable via ExtendScript).\n' +
+        'Do NOT use when: no sky_image_path is available — ask the user for an absolute file path first.\n' +
+        'Do NOT use when: fading the active subject layer only — use photoshop_recipe_gradient_fade.\n' +
+        '\n' +
+        'Returns: { ok, summary, undo_history_states_consumed, details: { sky_image_path, layer_name, horizon_pct, feather_pct, direction } }.\n' +
+        '\n' +
+        'Preconditions: active document; sky image file must exist on disk.\n' +
+        'Side effects: adds a placed sky layer with gradient mask; one undo reverts everything.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sky_image_path: {
+            type: 'string',
+            description: 'Absolute path to the sky image file (JPEG, PNG, etc.)',
+          },
+          horizon_pct: {
+            type: 'number',
+            description: 'Document-height percentage where sky meets landscape (0-100, default 50)',
+            minimum: 0,
+            maximum: 100,
+            default: 50,
+          },
+          feather_pct: {
+            type: 'number',
+            description: 'Half-width of the transition zone around the horizon (0-50, default 15)',
+            minimum: 0,
+            maximum: 50,
+            default: 15,
+          },
+          x: {
+            type: 'number',
+            description: 'Placement X offset in pixels (default 0)',
+            default: 0,
+          },
+          y: {
+            type: 'number',
+            description: 'Placement Y offset in pixels (default 0)',
+            default: 0,
+          },
+        },
+        required: ['sky_image_path'],
+      },
+    },
+    handler: async (args) => runSkyBlend(connection, args),
+  };
+}
+
+async function runSkyBlend(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const skyPath = typeof args.sky_image_path === 'string' ? args.sky_image_path.trim() : '';
+  if (!skyPath) {
+    return toolFailure({
+      ok: false,
+      code: 'invalid_argument',
+      message: 'sky_image_path is required',
+    });
+  }
+
+  const horizonPct = clampInt(args.horizon_pct, 0, 100, 50);
+  const featherPct = clampInt(args.feather_pct, 0, 50, 15);
+  const x = typeof args.x === 'number' && Number.isFinite(args.x) ? Math.round(args.x) : 0;
+  const y = typeof args.y === 'number' && Number.isFinite(args.y) ? Math.round(args.y) : 0;
+  const startPct = Math.max(0, horizonPct - featherPct);
+  const endPct = Math.min(100, horizonPct + featherPct);
+  const endpoints = gradientMaskAxisPercents('top_to_bottom', startPct, endPct);
+  const escapedPath = jsString(skyPath);
+
+  const body = `
+    var imageFile = new File("${escapedPath}");
+    if (!imageFile.exists) {
+      return { ok: false, code: 'file_not_found', message: 'Image file not found: ${escapedPath}' };
+    }
+
+    app.displayDialogs = DialogModes.NO;
+
+    var placeDesc = new ActionDescriptor();
+    placeDesc.putPath(cTID('null'), imageFile);
+    placeDesc.putEnumerated(cTID('FTcs'), cTID('QCSt'), cTID('Qcsa'));
+    var offsetDesc = new ActionDescriptor();
+    offsetDesc.putUnitDouble(cTID('Hrzn'), cTID('#Pxl'), ${x});
+    offsetDesc.putUnitDouble(cTID('Vrtc'), cTID('#Pxl'), ${y});
+    placeDesc.putObject(cTID('Ofst'), cTID('Ofst'), offsetDesc);
+    executeAction(cTID('Plc '), placeDesc, DialogModes.NO);
+
+    var doc = app.activeDocument;
+    var skyLayer = doc.activeLayer;
+    skyLayer.name = 'Sky Blend';
+
+    var maskCreated = false;
+    if (!__mcp_hasLayerMaskAM()) {
+      __mcp_makeLayerMaskAtChannel('revealAll');
+      maskCreated = true;
+    }
+
+    doc.activeLayer = skyLayer;
+    __mcp_selectLayerMaskChannel();
+
+    var docW = doc.width.as('px');
+    var docH = doc.height.as('px');
+    var fromXPx = docW * (${endpoints.fromH} / 100.0);
+    var fromYPx = docH * (${endpoints.fromV} / 100.0);
+    var toXPx = docW * (${endpoints.toH} / 100.0);
+    var toYPx = docH * (${endpoints.toV} / 100.0);
+    __mcp_gradientFillLayerMask(fromXPx, fromYPx, toXPx, toYPx, ${endpoints.reverse ? 'true' : 'false'});
+
+    try {
+      doc.activeChannels = doc.componentChannels;
+    } catch (eRestore) {
+      doc.activeLayer = skyLayer;
+    }
+
+    return {
+      ok: true,
+      summary: 'Sky image placed and blended at horizon (${horizonPct}%)',
+      undo_history_states_consumed: 1,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        sky_image_path: '${escapedPath}',
+        layer_name: skyLayer.name,
+        horizon_pct: ${horizonPct},
+        feather_pct: ${featherPct},
+        direction: 'top_to_bottom',
+        mask_created: maskCreated
+      }
+    };
+  `;
+
+  return executeRecipe(connection, 'Sky Blend', body);
+}

--- a/src/tools/selection-tools.ts
+++ b/src/tools/selection-tools.ts
@@ -8,7 +8,12 @@ export function createSelectionTools(connection: PhotoshopConnection): ToolDefin
     {
       tool: {
         name: 'photoshop_select_rectangle',
-        description: 'Create a rectangular selection',
+        description:
+          'Create a rectangular pixel selection from corner coordinates.\n\n' +
+          'Use when: masking, cropping a region, or preparing for layer mask.\n' +
+          'Do NOT use when: subject isolation is needed — use photoshop_recipe_remove_background.\n\n' +
+          'Returns: selection bounds [left, top, right, bottom].\n' +
+          'Preconditions: active document. Side effects: replaces current selection.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -70,7 +75,12 @@ export function createSelectionTools(connection: PhotoshopConnection): ToolDefin
     {
       tool: {
         name: 'photoshop_create_layer_mask',
-        description: 'Create a layer mask from the current selection',
+        description:
+          'Create a layer mask on the active layer from the current selection (reveal selection).\n\n' +
+          'Use when: non-destructive hide/show after a selection exists.\n' +
+          'Do NOT use when: no selection exists — create selection first or use remove_background recipe.\n\n' +
+          'Returns: maskCreated confirmation.\n' +
+          'Preconditions: active document and active selection. Side effects: adds mask to active layer.',
         inputSchema: {
           type: 'object',
           properties: {},

--- a/src/tools/selection-tools.ts
+++ b/src/tools/selection-tools.ts
@@ -2,6 +2,14 @@ import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
 import { PhotoshopConnection } from '../platform/connection.js';
 import { PhotoshopAPIFactory } from '../api/photoshop-api.js';
 import { ExtendScriptSnippets } from '../api/extendscript.js';
+import { PhotoshopDetector } from '../platform/detector.js';
+import {
+  atomicFailure,
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
 
 export function createSelectionTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
@@ -77,6 +85,7 @@ export function createSelectionTools(connection: PhotoshopConnection): ToolDefin
         name: 'photoshop_create_layer_mask',
         description:
           'Create a layer mask on the active layer from the current selection (reveal selection).\n\n' +
+          'Users often say: mask this, hide the background, non-destructive cutout (after selection).\n\n' +
           'Use when: non-destructive hide/show after a selection exists.\n' +
           'Do NOT use when: no selection exists — create selection first or use remove_background recipe.\n\n' +
           'Returns: maskCreated confirmation.\n' +
@@ -109,6 +118,49 @@ export function createSelectionTools(connection: PhotoshopConnection): ToolDefin
         },
       },
       handler: async () => applyLayerMask(connection),
+    },
+    {
+      tool: {
+        name: 'photoshop_select_subject',
+        description:
+          'Run Select Subject on the active layer (creates a pixel selection only, no mask).\n\n' +
+          'Users often say: cut out, isolate subject, select person, select object.\n\n' +
+          'Use when: you need a subject selection for masking, fill, or further edits.\n' +
+          'Do NOT use when: full background removal with mask — use photoshop_recipe_remove_background.\n\n' +
+          'Returns: JSON { ok, summary, details: { selected, method } }.\n' +
+          'Preconditions: PS ≥ 23, active document, non-Background active layer with a recognizable subject.\n' +
+          'Side effects: replaces current selection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            sample_all_layers: {
+              type: 'boolean',
+              description: 'Sample all layers for autoCutout fallback (default false)',
+              default: false,
+            },
+          },
+        },
+      },
+      handler: async (args) => selectSubject(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_content_aware_fill',
+        description:
+          'Fill the current pixel selection using Content-Aware Fill.\n\n' +
+          'Users often say: remove distraction, erase object, content aware fill, inpaint selection.\n\n' +
+          'Use when: a rectangular or other selection covers the area to remove/replace.\n' +
+          'Do NOT use when: no selection exists — use photoshop_select_rectangle first.\n' +
+          'Do NOT use when: generative remove is requested — not scriptable; use this fill or manual touch-up.\n\n' +
+          'Returns: JSON { ok, summary, details: { filled } }.\n' +
+          'Preconditions: active document and active pixel selection.\n' +
+          'Side effects: modifies pixels inside selection; deselects afterward.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      handler: async () => contentAwareFill(connection),
     },
   ];
 }
@@ -321,5 +373,62 @@ async function applyLayerMask(connection: PhotoshopConnection): Promise<ToolResu
       ],
       isError: true,
     };
+  }
+}
+
+async function selectSubject(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const sampleAllLayers = args.sample_all_layers === true;
+
+  await connection.ping().catch(() => undefined);
+  const info = connection.getPhotoshopInfo();
+  if (info) {
+    const detector = new PhotoshopDetector();
+    if (!detector.supportsSelectSubjectV2(info.version)) {
+      return atomicFailure({
+        ok: false,
+        code: 'version_unsupported',
+        message: `Select Subject v2 requires Photoshop 23.0+; detected version ${info.version}. Upgrade Photoshop or select manually.`,
+        suggested_next_tool: 'photoshop_get_capabilities',
+      });
+    }
+  }
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.selectSubject(sampleAllLayers));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    const method = typeof parsed.method === 'string' ? parsed.method : 'selectSubject';
+    return atomicSuccess(`Subject selected via ${method}`, parsed);
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function contentAwareFill(connection: PhotoshopConnection): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.contentAwareFill());
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    return atomicSuccess('Content-aware fill applied', parsed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/selection_required/i.test(message)) {
+      return atomicFailure({
+        ok: false,
+        code: 'selection_required',
+        message: 'Active pixel selection required before content-aware fill',
+        suggested_next_tool: 'photoshop_select_rectangle',
+      });
+    }
+    return atomicFailureFromError(error);
   }
 }

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -1,0 +1,165 @@
+import { readFile, unlink } from 'node:fs/promises';
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { ExtendScriptSnippets } from '../api/extendscript.js';
+import { PhotoshopAPIFactory } from '../api/photoshop-api.js';
+import { getPhotoshopCapabilities } from '../platform/capabilities.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { envelopeToToolResult, classifyError } from '../errors/envelope.js';
+import { parseExtendScriptPayload } from '../utils/extendscript-result.js';
+
+const PREVIEW_MAX_BYTES = 4 * 1024 * 1024;
+
+async function runScript(connection: PhotoshopConnection, script: string): Promise<unknown> {
+  const apiFactory = new PhotoshopAPIFactory(connection);
+  const api = await apiFactory.createAPI();
+  return api.executeScript(script);
+}
+
+export function createStateTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_get_state',
+        description:
+          'Return a cheap read-only snapshot of Photoshop session state (active document, layer, selection).\n\n' +
+          'Use when: before any tool that needs an active document/layer, or after an error to recover context.\n' +
+          'Do NOT use when: you only need a visual preview — use photoshop_get_preview instead.\n\n' +
+          'Returns: JSON with hasDocument, document dimensions/colorMode, activeLayer kind/name, hasSelection.\n' +
+          'Preconditions: none (safe on empty session). Side effects: none.',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      handler: async () => getState(connection),
+    },
+    {
+      tool: {
+        name: 'photoshop_get_preview',
+        description:
+          'Export the active document as a base64 JPEG preview for visual verification.\n\n' +
+          'Use when: after visual edits to confirm result before reporting success to the user.\n' +
+          'Do NOT use when: you only need numeric state — use photoshop_get_state (much cheaper).\n\n' +
+          'Returns: MCP image content block (JPEG) plus metadata text.\n' +
+          'Preconditions: active document required. Side effects: creates and deletes a temp file; does not modify the document.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            max_dimension_px: {
+              type: 'number',
+              description: 'Maximum long edge in pixels (default 1024)',
+              default: 1024,
+            },
+            quality: {
+              type: 'number',
+              description: 'JPEG quality 1–12 (default 8)',
+              minimum: 1,
+              maximum: 12,
+              default: 8,
+            },
+          },
+        },
+      },
+      handler: async (args) => getPreview(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_get_capabilities',
+        description:
+          'Return version-aware feature flags for the installed Photoshop (Select Subject v2, Generative Fill, etc.).\n\n' +
+          'Use when: once per session before suggesting AI-powered features or gated recipes.\n' +
+          'Do NOT use when: Photoshop version is already known from photoshop_get_version.\n\n' +
+          'Returns: JSON { version, features: { select_subject_v2, generative_fill, ... } }.\n' +
+          'Preconditions: none. Side effects: none.',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      handler: async () => getCapabilities(connection),
+    },
+  ];
+}
+
+async function getState(connection: PhotoshopConnection): Promise<ToolResult> {
+  try {
+    const raw = await runScript(connection, ExtendScriptSnippets.getState());
+    const result = parseExtendScriptPayload(raw);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  } catch (error) {
+    return envelopeToToolResult(
+      classifyError(error instanceof Error ? error.message : String(error))
+    );
+  }
+}
+
+async function getPreview(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const maxDimension = (args.max_dimension_px as number) || 1024;
+  const quality = (args.quality as number) || 8;
+
+  let tempPath: string | undefined;
+
+  try {
+    const result = (await runScript(
+      connection,
+      ExtendScriptSnippets.exportPreview(maxDimension, quality)
+    )) as { path: string; width: number; height: number; mimeType: string };
+
+    tempPath = result.path;
+    const buffer = await readFile(tempPath);
+
+    if (buffer.byteLength > PREVIEW_MAX_BYTES) {
+      return envelopeToToolResult(
+        classifyError(
+          `Preview exceeds ${PREVIEW_MAX_BYTES} byte limit (${buffer.byteLength} bytes). Lower max_dimension_px or quality.`
+        )
+      );
+    }
+
+    const base64 = buffer.toString('base64');
+
+    return {
+      content: [
+        {
+          type: 'image',
+          data: base64,
+          mimeType: result.mimeType || 'image/jpeg',
+        },
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              ok: true,
+              width: result.width,
+              height: result.height,
+              bytes: buffer.byteLength,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  } catch (error) {
+    return envelopeToToolResult(
+      classifyError(error instanceof Error ? error.message : String(error))
+    );
+  } finally {
+    if (tempPath) {
+      await unlink(tempPath).catch(() => undefined);
+    }
+  }
+}
+
+async function getCapabilities(connection: PhotoshopConnection): Promise<ToolResult> {
+  try {
+    const version = await connection.getVersion();
+    const capabilities = getPhotoshopCapabilities(version);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(capabilities, null, 2) }],
+    };
+  } catch (error) {
+    return envelopeToToolResult(
+      classifyError(error instanceof Error ? error.message : String(error))
+    );
+  }
+}

--- a/src/ui/agent.ts
+++ b/src/ui/agent.ts
@@ -4,6 +4,8 @@ import { stepCountIs, streamText, type LanguageModelUsage, type ModelMessage } f
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ModelPricing, ProviderAdapter, UsageCost } from './providers/registry.js';
+import { buildPhotoshopInstructions } from '../prompts/instructions.js';
+import { PHOTOSHOP_EXPORT_CHAT_ID_ENV } from '../lib/export-paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -44,6 +46,7 @@ export interface RunChatOptions {
   provider: ProviderAdapter;
   apiKey: string;
   modelId: string;
+  chatId?: string;
   abortSignal: AbortSignal;
   onAssistantBuffer?: (buf: AssistantBuffer) => void;
   onFinish?: (info: RunChatFinishInfo) => void;
@@ -51,16 +54,16 @@ export interface RunChatOptions {
 
 export const PHOTOSHOP_SYSTEM_PROMPT = `
 You are an assistant that controls Adobe Photoshop on the user's machine through
-the "photoshop" MCP server. Use the photoshop_* tools to fulfill the user's
-request: open documents, manage layers, place images, apply filters, write text,
-save files, and so on.
+the photoshop-mcp server. Use photoshop_* tools and photoshop_recipe_* recipes
+to fulfill requests: open documents, manage layers, place images, apply filters,
+write text, save files, and run multi-step workflows.
 
-Guidelines:
-- Start with photoshop_ping when you are unsure whether Photoshop is reachable.
-- Prefer single, well-scoped tool calls instead of long combined operations.
+${buildPhotoshopInstructions()}
+
+Additional UI constraints:
 - After meaningful state changes, briefly describe in plain language what you did.
-- If a tool call fails, surface the error to the user and ask for confirmation
-  before retrying or trying an alternative.
+- If a tool call fails, surface the error envelope to the user and follow
+  suggested_next_tool when present before asking the user to retry.
 - Only Photoshop MCP tools are available. Do not attempt shell, filesystem,
   web, or general coding operations; respond in natural language instead.
 `.trim();
@@ -77,7 +80,11 @@ export async function* runChat(opts: RunChatOptions): AsyncGenerator<RunChatStre
       transport: new Experimental_StdioMCPTransport({
         command: process.execPath,
         args: spawnArgs,
-        env: { ...sanitizedEnv(), LOG_LEVEL: process.env.LOG_LEVEL ?? '2' },
+        env: {
+          ...sanitizedEnv(),
+          LOG_LEVEL: process.env.LOG_LEVEL ?? '2',
+          ...(opts.chatId ? { [PHOTOSHOP_EXPORT_CHAT_ID_ENV]: opts.chatId } : {}),
+        },
       }),
     });
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -290,6 +290,7 @@ export async function startUIServer(opts: UIServerOptions): Promise<UIServer> {
           provider,
           apiKey,
           modelId: chat.model,
+          chatId: chat.id,
           abortSignal: controller.signal,
           onAssistantBuffer: (b) => {
             buffer = b;

--- a/src/utils/extendscript-result.ts
+++ b/src/utils/extendscript-result.ts
@@ -1,0 +1,42 @@
+/**
+ * Normalize values returned from ExtendScript via AppleScript stdout.
+ * Objects are serialized with toSource() (e.g. "({ok:true,summary:\"...\"})"),
+ * which is not valid JSON but is valid JavaScript object literal syntax.
+ */
+export function parseExtendScriptPayload(raw: unknown): unknown {
+  if (raw === null || raw === undefined) return raw;
+  if (typeof raw !== 'string') return raw;
+
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    // Fall through to toSource parsing.
+  }
+
+  if (looksLikeExtendScriptObjectLiteral(trimmed)) {
+    try {
+      return new Function(`return ${trimmed}`)() as unknown;
+    } catch {
+      if (trimmed.startsWith('(') && trimmed.endsWith(')')) {
+        try {
+          return new Function(`return ${trimmed.slice(1, -1)}`)() as unknown;
+        } catch {
+          // Keep raw string below.
+        }
+      }
+    }
+  }
+
+  return trimmed;
+}
+
+function looksLikeExtendScriptObjectLiteral(value: string): boolean {
+  return (
+    (value.startsWith('(') && value.endsWith(')')) ||
+    (value.startsWith('{') && value.endsWith('}')) ||
+    (value.startsWith('[') && value.endsWith(']'))
+  );
+}


### PR DESCRIPTION
## Summary

Merges `develop` into `master` for **v1.1.2**, introducing the AI/Prompt Layer and a major expansion of Photoshop automation capabilities.

### AI / Prompt Layer
- Server-level **`instructions`** on MCP `initialize` — workflow contract (ping once, state-before-action, prefer recipes, error recovery)
- **16 MCP prompt templates** (`prompts/list`, `prompts/get`): 12 recipe prompts + 4 guide prompts (`ps.enhance_portrait`, `ps.gradient_fade`, `ps.sky_blend`, …)
- `PromptRegistry` integrated into `PhotoshopMCPServer`
- Intent taxonomy and degrade-path documentation for host LLMs

### New tools (78 total, up from ~62)
- **12 recipe tools** (`photoshop_recipe_*`): enhance portrait, remove background, prepare for web, export social variants, apply color grade, frequency separation, batch mockup replace, organize layers, gradient fade, sky blend, dodge & burn, remove distraction
- **4 new atomic tools**: mask tools, state tools, plus enhancements to adjustment/selection tools
- Structured **error envelopes**, version-aware **capabilities**, and improved ExtendScript error handling

### Testing & verification
- `npm run test:mcp-local` — local smoke test
- `npm run test:mcp-all` — full MCP tool coverage (78 tools)
- `npm run test:intent-expansion` — prompt-intent-expansion integration test
- `npm run verify:photoshop-prompts` — prompt ↔ recipe parity check

### Documentation
- README updated with AI/Prompt Layer section and v1.1+ feature overview
- New `docs/prompt-layer.md` reference
- `docs/plans/prompt-intent-expansion/` planning docs

**64 files changed** · +6,770 / −229 lines · **8 commits** since `master`

## Commits included

| Commit | Description |
|--------|-------------|
| `0414f29` | 1.1.2 version bump |
| `3e871ab` | Core prompt layer, initial recipes, PromptRegistry, docs |
| `56f303d` | Test scripts, ExtendScript reliability, recipe shared helpers |
| `1ec19f0` | README v1.1, intent taxonomy draft |
| `cc18f6c` | `.gitignore` local planning docs |
| `1ce32bb` | 4 new recipes + prompts (gradient fade, sky blend, dodge & burn, remove distraction), mask tools |
| `8fe5a68` | Intent expansion integration test |
| `6502d01` | Docs/tool count alignment (78 tools) |

## Test plan

- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] `npm run lint` — no new lint errors
- [ ] `npm run verify:photoshop-prompts` — prompt/recipe parity passes
- [ ] `npm run test:mcp-local` — local MCP smoke test passes (Photoshop running)
- [ ] `npm run test:mcp-all` — all 78 tools respond correctly (Photoshop running)
- [ ] `npm run test:intent-expansion` — intent expansion features covered
- [ ] Manual: connect via Cursor/Claude Desktop, call `prompts/list`, run one recipe (e.g. `ps.enhance_portrait`)
- [ ] Manual: standalone UI (`npx photoshop-mcp-ui`) still works with new tools