### PR TITLE
Fix #2: MCP stability, dialog suppression, font tooling, and UTF-8 encoding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ Run these before every PR.
 
 ```bash
 npm run test:mcp-local    # prompt-layer smoke tests
+npm run spike:issue-2     # issue #2 targeted regression
 npm run test:mcp-all      # full sequential tool sweep
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ requests into reliable Photoshop actions:
   background, enhance portrait, prepare for web, export social variants, color
   grade, frequency separation, batch mockup, organize layers, gradient fade,
   sky blend, dodge & burn, remove distraction). Each wraps steps in a single
-  Photoshop history state (one Undo reverts all). **78 tools total** (66 atomic
+  Photoshop history state (one Undo reverts all). **80 tools total** (68 atomic
   + 12 recipe).
 - **State & preview** — `photoshop_get_state` (cheap snapshot),
   `photoshop_get_preview` (base64 JPEG for vision verification),
@@ -104,12 +104,12 @@ Local MCP integration tests run against a live Photoshop instance over stdio
 
 | Suite | Command | Result |
 |-------|---------|--------|
-| Issue #2 regression | `npm run spike:issue-2` | 10 targeted checks (document metadata, layers, place, alert, CJK names) |
-| Full tool + recipe sweep | `npm run test:mcp-all` | **117 pass**, **0 fail**, **4 skip** (121 total) |
+| Issue #2 regression | `npm run spike:issue-2` | Targeted checks (metadata, layers, place, Smart Object transform, jsString escapes, fonts, alert, CJK names) |
+| Full tool + recipe sweep | `npm run test:mcp-all` | **119 pass**, **0 fail**, **4 skip** (123 total) |
 | Prompt-layer smoke | `npm run test:mcp-local` | 16 prompt templates + core recipes |
 | Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 12↔12 strict match + 4 guides |
 
-**Tool coverage:** 79 total tools (67 atomic `photoshop_*` + 12 recipe
+**Tool coverage:** 80 total tools (68 atomic `photoshop_*` + 12 recipe
 `photoshop_recipe_*`) — re-run `npm run test:mcp-all` for a fresh pass count.
 
 **Intentional skips** (environment-dependent, not regressions):
@@ -612,14 +612,16 @@ Create a text layer.
 - `x` (number, optional): X position in pixels (default: 100)
 - `y` (number, optional): Y position in pixels (default: 100)
 - `fontSize` (number, optional): Font size in points (default: 24)
+- `fontName` (string, optional): Font display or PostScript name (see `photoshop_list_fonts`)
 
 ```javascript
-// Example: Create a text layer
+// Example: Create a text layer with Arial
 photoshop_create_text_layer({
   text: "Hello World",
   x: 200,
   y: 150,
-  fontSize: 48
+  fontSize: 48,
+  fontName: "Arial"
 })
 ```
 
@@ -987,11 +989,27 @@ photoshop_invert()
 
 ### Text Formatting
 
-#### `photoshop_set_text_font`
-Set font family and size for active text layer.
+#### `photoshop_list_fonts`
+List installed fonts available to Photoshop. First call may be slow (`app.fonts` can exceed 1000 entries).
 
 **Parameters:**
-- `fontName` (string, required): Font family name
+- `query` (string, optional): Substring filter (matches name, postScriptName, or family)
+- `limit` (number, optional): Maximum fonts to return (default: 200)
+
+**Returns:** `{ fonts: [{ name, postScriptName, family, style }], total, truncated }`
+
+Use `postScriptName` when setting fonts manually via `execute_script`; `photoshop_set_text_font` and `photoshop_create_text_layer` resolve display names automatically.
+
+```javascript
+// Example: Find Arial variants
+photoshop_list_fonts({ query: "Arial", limit: 20 })
+```
+
+#### `photoshop_set_text_font`
+Set font family and size for active text layer. Accepts display name (e.g. `"Arial"`) or PostScript name (e.g. `"ArialMT"`).
+
+**Parameters:**
+- `fontName` (string, required): Font display or PostScript name (use `photoshop_list_fonts` to discover)
 - `fontSize` (number, optional): Font size in points
 
 ```javascript
@@ -1566,7 +1584,7 @@ photoshop-mcp/
 │   │   ├── photoshop-api.ts    # API factory
 │   │   ├── batch-play.ts       # UXP batchPlay helpers (legacy)
 │   │   └── extendscript.ts     # ExtendScript snippets library
-│   ├── tools/            # MCP tool implementations (78 tools: 66 atomic + 12 recipe)
+│   ├── tools/            # MCP tool implementations (80 tools: 68 atomic + 12 recipe)
 │   │   ├── document-tools.ts        # Document operations
 │   │   ├── layer-tools.ts           # Layer creation/deletion
 │   │   ├── layer-properties-tools.ts # Opacity, blend modes, etc.

--- a/README.md
+++ b/README.md
@@ -100,16 +100,16 @@ Local MCP integration tests run against a live Photoshop instance over stdio
 (same path as Cursor / Claude Desktop). Last verified on **Photoshop 26.5.0**
 (macOS).
 
-*Recorded on PS 26.5.0 before the intent-expansion tools landed; counts predate
-the 4 new atomics + 4 new recipes — re-run `npm run test:mcp-all` to refresh.*
+*Recorded on PS 26.5.0 (macOS) after issue #2 fixes and Phase 2 test harness — re-run `npm run test:mcp-all` to refresh.*
 
 | Suite | Command | Result |
 |-------|---------|--------|
-| Full tool + recipe sweep | `npm run test:mcp-all` | **94 pass**, **0 fail**, **3 skip** (97 total) |
+| Issue #2 regression | `npm run spike:issue-2` | 10 targeted checks (document metadata, layers, place, alert, CJK names) |
+| Full tool + recipe sweep | `npm run test:mcp-all` | **117 pass**, **0 fail**, **4 skip** (121 total) |
 | Prompt-layer smoke | `npm run test:mcp-local` | 16 prompt templates + core recipes |
 | Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 12↔12 strict match + 4 guides |
 
-**Tool coverage:** 78 total tools (66 atomic `photoshop_*` + 12 recipe
+**Tool coverage:** 79 total tools (67 atomic `photoshop_*` + 12 recipe
 `photoshop_recipe_*`) — re-run `npm run test:mcp-all` for a fresh pass count.
 
 **Intentional skips** (environment-dependent, not regressions):
@@ -117,6 +117,7 @@ the 4 new atomics + 4 new recipes — re-run `npm run test:mcp-all` to refresh.*
 | Tool | Reason |
 |------|--------|
 | `photoshop_play_action` | Requires a real Actions palette entry on the machine |
+| `photoshop_select_subject` | Requires a recognizable subject in the active layer |
 | `photoshop_recipe_remove_background` | Synthetic test canvas has no recognizable subject for Select Subject |
 | `photoshop_recipe_batch_mockup_replace` | Requires a Smart Object mockup PSD |
 
@@ -1516,6 +1517,7 @@ npm run format
 
 ```bash
 npm run build:server
+npm run spike:issue-2     # issue #2 targeted regression (10 checks)
 npm run test:mcp-local    # prompt-layer smoke
 npm run test:mcp-all      # full sequential tool sweep
 npm run verify:photoshop-prompts

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "spike:photoshop-actions": "tsx scripts/spike-photoshop-actions.ts",
+    "spike:issue-2": "tsx scripts/spike-issue-2.ts",
     "verify:photoshop-prompts": "tsx scripts/verify-photoshop-prompt-coverage.ts",
     "test:mcp-local": "tsx scripts/test-mcp-local.ts",
     "test:mcp-all": "tsx scripts/test-all-mcp-tools.ts",

--- a/scripts/spike-issue-2.ts
+++ b/scripts/spike-issue-2.ts
@@ -195,6 +195,51 @@ async function main(): Promise<void> {
     fail('photoshop_place_image (parse)', error instanceof Error ? error.message : String(error));
   }
 
+  // Step 6b: Smart Object transform after place (DialogModes.NO must not block)
+  console.log('\n--- Step 6b: Smart Object scale + move after place_image ---');
+  try {
+    const placePayload = parseJsonFromText(textFrom(place)) as { layerName?: string };
+    if (placePayload.layerName) {
+      const selectPlaced = await callTool(client, 'photoshop_select_layer_by_name', {
+        name: placePayload.layerName,
+      });
+      assert(!selectPlaced.isError, 'photoshop_select_layer_by_name (placed layer)');
+    }
+    const scale = await callTool(
+      client,
+      'photoshop_scale_layer',
+      { scalePercent: 95 },
+      ALERT_TIMEOUT_MS
+    );
+    assert(!scale.isError, 'photoshop_scale_layer on placed Smart Object');
+    const move = await callTool(
+      client,
+      'photoshop_move_layer',
+      { deltaX: 5, deltaY: 5 },
+      ALERT_TIMEOUT_MS
+    );
+    assert(!move.isError, 'photoshop_move_layer on placed Smart Object');
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    fail('Smart Object transform after place', msg.includes('Timed out') ? 'dialog blocked — timed out' : msg);
+  }
+
+  // Step 6c: jsString edge case (backslash, quote, newline in layer name)
+  console.log('\n--- Step 6c: jsString escape round-trip ---');
+  const ESCAPE_LAYER_NAME = 'MCP\\"Test\\nName';
+  const escapeCreate = await callTool(client, 'photoshop_create_layer', { name: ESCAPE_LAYER_NAME });
+  assert(!escapeCreate.isError, 'photoshop_create_layer (escaped name)');
+  const escapeSelect = await callTool(client, 'photoshop_select_layer_by_name', {
+    name: ESCAPE_LAYER_NAME,
+  });
+  assert(!escapeSelect.isError, 'photoshop_select_layer_by_name (escaped name)');
+  try {
+    const payload = parseJsonFromText(textFrom(escapeSelect)) as { layerName?: string };
+    assert(payload.layerName === ESCAPE_LAYER_NAME, 'escaped layer name round-trip', payload.layerName);
+  } catch (error) {
+    fail('jsString round-trip (parse)', error instanceof Error ? error.message : String(error));
+  }
+
   // Step 7
   console.log('\n--- Step 7: execute_script alert (dialog suppression) ---');
   try {
@@ -226,7 +271,37 @@ async function main(): Promise<void> {
   }
 
   // Step 9
-  console.log('\n--- Step 9: CJK layer name round-trip ---');
+  console.log('\n--- Step 9: font discovery + create_text_layer fontName ---');
+  const listFonts = await callTool(client, 'photoshop_list_fonts', { query: 'Arial', limit: 20 });
+  assert(!listFonts.isError, 'photoshop_list_fonts (query: Arial)');
+  try {
+    const fontPayload = parseJsonFromText(textFrom(listFonts)) as {
+      fonts?: Array<{ name?: string; postScriptName?: string }>;
+    };
+    assert((fontPayload.fonts?.length ?? 0) > 0, 'list_fonts returns Arial matches');
+  } catch (error) {
+    fail('photoshop_list_fonts (parse)', error instanceof Error ? error.message : String(error));
+  }
+  const fontText = await callTool(client, 'photoshop_create_text_layer', {
+    text: 'Font Test',
+    x: 200,
+    y: 200,
+    fontSize: 18,
+    fontName: 'Arial',
+  });
+  assert(!fontText.isError, 'photoshop_create_text_layer with fontName');
+  try {
+    const fontVerify = await callTool(client, 'photoshop_execute_script', {
+      code: `for (var i=0;i<app.activeDocument.artLayers.length;i++){var L=app.activeDocument.artLayers[i]; if(L.kind==LayerKind.TEXT&&L.textItem.contents=="Font Test"){return{font:L.textItem.font,contents:L.textItem.contents};}} throw new Error("text layer not found");`,
+    });
+    const verifyPayload = parseJsonFromText(textFrom(fontVerify)) as { font?: string };
+    assert(typeof verifyPayload.font === 'string' && verifyPayload.font.length > 0, 'font applied on text layer', verifyPayload.font);
+  } catch (error) {
+    fail('fontName verify (parse)', error instanceof Error ? error.message : String(error));
+  }
+
+  // Step 10
+  console.log('\n--- Step 10: CJK layer name round-trip ---');
   const cjkCreate = await callTool(client, 'photoshop_create_layer', { name: CJK_LAYER_NAME });
   assert(!cjkCreate.isError, 'photoshop_create_layer (CJK name)');
   const cjkSelect = await callTool(client, 'photoshop_select_layer_by_name', {
@@ -241,8 +316,8 @@ async function main(): Promise<void> {
     fail('CJK round-trip (parse)', error instanceof Error ? error.message : String(error));
   }
 
-  // Step 10
-  console.log('\n--- Step 10: select_layer_by_name missing ---');
+  // Step 11
+  console.log('\n--- Step 11: select_layer_by_name missing ---');
   const missing = await callTool(client, 'photoshop_select_layer_by_name', {
     name: '__MCP_MISSING_LAYER__',
   });

--- a/scripts/spike-issue-2.ts
+++ b/scripts/spike-issue-2.ts
@@ -1,0 +1,273 @@
+/**
+ * Targeted regression script for GitHub issue #2 fixes.
+ * Run: npm run spike:issue-2
+ *
+ * Requires a live Photoshop instance (macOS or Windows).
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TEST_CHAT_ID = 'local-mcp-spike-issue-2';
+const ALERT_TIMEOUT_MS = 10_000;
+const CJK_LAYER_NAME = '测试レイヤー';
+
+let failures = 0;
+
+function textFrom(result: {
+  content?: Array<{ type: string; text?: string }>;
+}): string {
+  return (result.content ?? [])
+    .filter((c) => c.type === 'text' && c.text)
+    .map((c) => c.text!)
+    .join('\n');
+}
+
+function parseJsonFromText(body: string): unknown {
+  const jsonStart = body.indexOf('{');
+  const jsonArrayStart = body.indexOf('[');
+  const start =
+    jsonStart >= 0 && (jsonArrayStart < 0 || jsonStart <= jsonArrayStart)
+      ? jsonStart
+      : jsonArrayStart;
+  if (start < 0) throw new Error('No JSON payload in tool response');
+  return JSON.parse(body.slice(start));
+}
+
+function pass(label: string, detail?: string): void {
+  console.log(`  PASS ${label}${detail ? ` — ${detail}` : ''}`);
+}
+
+function fail(label: string, detail?: string): void {
+  failures += 1;
+  console.log(`  FAIL ${label}${detail ? ` — ${detail}` : ''}`);
+}
+
+function assert(condition: boolean, label: string, detail?: string): void {
+  if (condition) pass(label, detail);
+  else fail(label, detail);
+}
+
+function writeTestPng(path: string): void {
+  execSync(
+    `python3 -c "import struct,zlib,binascii; w=h=64; rows=b''.join(b'\\x00'+b'\\xff\\x00\\x00'*w for _ in range(h)); comp=zlib.compress(rows,9); crc=lambda t,d: struct.pack('>I',binascii.crc32(t+d)&0xffffffff); ch=lambda t,d: struct.pack('>I',len(d))+t+d+crc(t,d); png=b'\\x89PNG\\r\\n\\x1a\\n'+ch(b'IHDR',struct.pack('>IIBBBBB',w,h,8,2,0,0,0))+ch(b'IDAT',comp)+ch(b'IEND',b''); open('${path}','wb').write(png)"`,
+    { stdio: 'ignore' }
+  );
+}
+
+async function callTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown> = {},
+  timeoutMs?: number
+): Promise<{ isError?: boolean; content?: Array<{ type: string; text?: string }> }> {
+  const call = client.callTool({ name, arguments: args });
+  if (timeoutMs === undefined) return call;
+  return Promise.race([
+    call,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs)
+    ),
+  ]);
+}
+
+async function main(): Promise<void> {
+  const testPng = join(tmpdir(), 'photoshop-mcp-spike-issue-2.png');
+  writeTestPng(testPng);
+
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['tsx', join(ROOT, 'src/index.ts')],
+    env: {
+      ...process.env,
+      LOG_LEVEL: '0',
+      PHOTOSHOP_EXPORT_CHAT_ID: TEST_CHAT_ID,
+    },
+    stderr: 'pipe',
+    cwd: ROOT,
+  });
+
+  const client = new Client({ name: 'spike-issue-2', version: '1.0.0' });
+
+  console.log('\n=== Issue #2 regression spike ===\n');
+
+  try {
+    await client.connect(transport);
+  } catch (error) {
+    console.error(
+      'Could not connect to MCP server. Is Node available and the project built?'
+    );
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  const ping = await callTool(client, 'photoshop_ping');
+  if (ping.isError) {
+    fail(
+      'photoshop_ping',
+      'Photoshop is not reachable — launch Photoshop and retry'
+    );
+    await transport.close();
+    process.exit(1);
+  }
+  pass('photoshop_ping');
+
+  await callTool(client, 'photoshop_execute_script', {
+    code: `while (app.documents.length > 0) { app.activeDocument.close(SaveOptions.DONOTSAVECHANGES); } return { documentsClosed: true };`,
+  });
+
+  // Step 1
+  console.log('\n--- Step 1: create document ---');
+  const createDoc = await callTool(client, 'photoshop_create_document', {
+    width: 800,
+    height: 600,
+  });
+  assert(!createDoc.isError, 'photoshop_create_document');
+
+  // Step 2
+  console.log('\n--- Step 2: get_document_info ---');
+  const docInfo = await callTool(client, 'photoshop_get_document_info');
+  assert(!docInfo.isError, 'photoshop_get_document_info (tool level)');
+  try {
+    const payload = parseJsonFromText(textFrom(docInfo)) as {
+      document?: { width?: number; height?: number; error?: string };
+    };
+    assert(payload.document?.width === 800, 'document.width === 800', String(payload.document?.width));
+    assert(payload.document?.height === 600, 'document.height === 600', String(payload.document?.height));
+    assert(!payload.document?.error, 'no document.error', payload.document?.error);
+  } catch (error) {
+    fail('photoshop_get_document_info (parse)', error instanceof Error ? error.message : String(error));
+  }
+
+  // Step 3
+  console.log('\n--- Step 3: get_state ---');
+  const state = await callTool(client, 'photoshop_get_state');
+  assert(!state.isError, 'photoshop_get_state (tool level)');
+  try {
+    const payload = parseJsonFromText(textFrom(state)) as {
+      document?: { width?: number; height?: number; error?: string };
+    };
+    assert(payload.document?.width === 800, 'context.document.width === 800', String(payload.document?.width));
+    assert(payload.document?.height === 600, 'context.document.height === 600', String(payload.document?.height));
+    assert(!payload.document?.error, 'no context.document.error', payload.document?.error);
+  } catch (error) {
+    fail('photoshop_get_state (parse)', error instanceof Error ? error.message : String(error));
+  }
+
+  // Step 4
+  console.log('\n--- Step 4: create layer + adjust curves ---');
+  const createLayer = await callTool(client, 'photoshop_create_layer', { name: 'MCP_Spike_Paint' });
+  assert(!createLayer.isError, 'photoshop_create_layer');
+  await callTool(client, 'photoshop_fill_layer', { red: 100, green: 150, blue: 200 });
+  const curves = await callTool(client, 'photoshop_adjust_curves', { preset: 'auto_tone' });
+  assert(!curves.isError, 'photoshop_adjust_curves');
+
+  // Step 5
+  console.log('\n--- Step 5: get_layers ---');
+  const layers = await callTool(client, 'photoshop_get_layers');
+  assert(!layers.isError, 'photoshop_get_layers (tool level)');
+  try {
+    const payload = parseJsonFromText(textFrom(layers)) as { layers?: unknown[] };
+    assert((payload.layers?.length ?? 0) >= 2, 'layers.length >= 2', String(payload.layers?.length));
+  } catch (error) {
+    fail('photoshop_get_layers (parse)', error instanceof Error ? error.message : String(error));
+  }
+
+  // Step 6
+  console.log('\n--- Step 6: place_image ---');
+  const place = await callTool(client, 'photoshop_place_image', {
+    filePath: testPng,
+    x: 100,
+    y: 100,
+  });
+  assert(!place.isError, 'photoshop_place_image (tool level)');
+  try {
+    const body = textFrom(place);
+    const payload = parseJsonFromText(body) as { placed?: boolean };
+    const placedFromResult = payload.placed === true;
+    const placedFromText = body.includes('"placed": true') || body.includes('"placed":true');
+    assert(placedFromResult || placedFromText, 'placed === true');
+  } catch (error) {
+    fail('photoshop_place_image (parse)', error instanceof Error ? error.message : String(error));
+  }
+
+  // Step 7
+  console.log('\n--- Step 7: execute_script alert (dialog suppression) ---');
+  try {
+    const alertResult = await callTool(
+      client,
+      'photoshop_execute_script',
+      { code: `alert('mcp'); return { alerted: true };` },
+      ALERT_TIMEOUT_MS
+    );
+    assert(!alertResult.isError, 'alert script (tool level)');
+    const payload = parseJsonFromText(textFrom(alertResult)) as { alerted?: boolean };
+    assert(payload.alerted === true, 'alerted === true');
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    fail('alert script', msg.includes('Timed out') ? 'dialog blocked — timed out' : msg);
+  }
+
+  // Step 8
+  console.log('\n--- Step 8: execute_script return value ---');
+  const docCount = await callTool(client, 'photoshop_execute_script', {
+    code: 'return { n: app.documents.length };',
+  });
+  assert(!docCount.isError, 'execute_script return (tool level)');
+  try {
+    const payload = parseJsonFromText(textFrom(docCount)) as { n?: unknown };
+    assert(typeof payload.n === 'number', 'parsed n is number', String(typeof payload.n));
+  } catch (error) {
+    fail('execute_script return (parse)', error instanceof Error ? error.message : String(error));
+  }
+
+  // Step 9
+  console.log('\n--- Step 9: CJK layer name round-trip ---');
+  const cjkCreate = await callTool(client, 'photoshop_create_layer', { name: CJK_LAYER_NAME });
+  assert(!cjkCreate.isError, 'photoshop_create_layer (CJK name)');
+  const cjkSelect = await callTool(client, 'photoshop_select_layer_by_name', {
+    name: CJK_LAYER_NAME,
+  });
+  assert(!cjkSelect.isError, 'photoshop_select_layer_by_name (CJK)');
+  try {
+    const payload = parseJsonFromText(textFrom(cjkSelect)) as { layerName?: string; selected?: boolean };
+    assert(payload.selected === true, 'CJK layer selected');
+    assert(payload.layerName === CJK_LAYER_NAME, 'CJK name round-trip', payload.layerName);
+  } catch (error) {
+    fail('CJK round-trip (parse)', error instanceof Error ? error.message : String(error));
+  }
+
+  // Step 10
+  console.log('\n--- Step 10: select_layer_by_name missing ---');
+  const missing = await callTool(client, 'photoshop_select_layer_by_name', {
+    name: '__MCP_MISSING_LAYER__',
+  });
+  assert(
+    missing.isError === true || textFrom(missing).toLowerCase().includes('error'),
+    'missing layer returns error',
+    missing.isError ? 'isError' : textFrom(missing).slice(0, 80)
+  );
+
+  await callTool(client, 'photoshop_close_document', { save: false });
+  await transport.close();
+
+  console.log('\n========================================');
+  if (failures === 0) {
+    console.log('SUMMARY: all checks PASS');
+    console.log('========================================\n');
+    process.exit(0);
+  }
+
+  console.log(`SUMMARY: ${failures} check(s) FAIL`);
+  console.log('========================================\n');
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/test-all-mcp-tools.ts
+++ b/scripts/test-all-mcp-tools.ts
@@ -307,10 +307,18 @@ async function main(): Promise<void> {
   await t.run('photoshop_apply_motion_blur', { angle: 0, radius: 5 });
 
   console.log('\n=== Phase 9: Text ===');
+  await t.run('photoshop_list_fonts', { query: 'Arial', limit: 50 });
   await t.run('photoshop_execute_script', {
     code: `for (var i = 0; i < app.activeDocument.artLayers.length; i++) { var L = app.activeDocument.artLayers[i]; if (L.kind == LayerKind.TEXT) { app.activeDocument.activeLayer = L; break; } } return { active: app.activeDocument.activeLayer.name };`,
   });
   await t.run('photoshop_set_text_font', { fontName: 'Arial', fontSize: 32 });
+  await t.run('photoshop_create_text_layer', {
+    text: 'MCP Arial',
+    x: 160,
+    y: 160,
+    fontSize: 20,
+    fontName: 'Arial',
+  });
   await t.run('photoshop_set_text_color', { red: 10, green: 10, blue: 200 });
   await t.run('photoshop_set_text_alignment', { alignment: 'CENTER' });
   await t.run('photoshop_update_text_content', { text: 'MCP Updated' });

--- a/scripts/test-all-mcp-tools.ts
+++ b/scripts/test-all-mcp-tools.ts
@@ -23,10 +23,12 @@ interface ToolRunResult {
   ms: number;
 }
 
-function textFrom(result: {
-  content?: Array<{ type: string; text?: string }>;
-}): string {
-  return (result.content ?? [])
+function textFrom(result: unknown): string {
+  const content = ((result as { content?: unknown }).content ?? []) as Array<{
+    type: string;
+    text?: string;
+  }>;
+  return content
     .filter((c) => c.type === 'text' && c.text)
     .map((c) => c.text!)
     .join('\n');
@@ -35,6 +37,17 @@ function textFrom(result: {
 function short(text: string, max = 140): string {
   const oneLine = text.replace(/\s+/g, ' ').trim();
   return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max)}…`;
+}
+
+function parseJsonFromToolText(body: string): unknown {
+  const jsonStart = body.indexOf('{');
+  const jsonArrayStart = body.indexOf('[');
+  const start =
+    jsonStart >= 0 && (jsonArrayStart < 0 || jsonStart <= jsonArrayStart)
+      ? jsonStart
+      : jsonArrayStart;
+  if (start < 0) throw new Error('No JSON payload in tool response');
+  return JSON.parse(body.slice(start));
 }
 
 class ToolTestRunner {
@@ -47,7 +60,7 @@ class ToolTestRunner {
   async run(
     name: string,
     args: Record<string, unknown> = {},
-    opts: { required?: boolean; skip?: string } = {}
+    opts: { required?: boolean; skip?: string; expectError?: boolean } = {}
   ): Promise<boolean> {
     if (opts.skip) {
       this.record(name, 'skip', opts.skip, 0);
@@ -60,6 +73,18 @@ class ToolTestRunner {
       const result = await this.client.callTool({ name, arguments: args });
       const ms = Date.now() - started;
       const body = textFrom(result);
+
+      if (opts.expectError) {
+        if (result.isError) {
+          this.record(name, 'pass', short(body), ms);
+          console.log(`  OK   ${name} (expected error, ${ms}ms) — ${short(body)}`);
+          return true;
+        }
+        this.record(name, 'fail', 'expected tool error', ms);
+        console.log(`  FAIL ${name} (${ms}ms) — expected error but tool succeeded`);
+        if (opts.required) throw new Error(`Expected error but tool succeeded: ${name}`);
+        return false;
+      }
 
       if (result.isError) {
         this.record(name, 'fail', short(body), ms);
@@ -161,7 +186,41 @@ async function main(): Promise<void> {
 
   console.log('\n=== Phase 1: Document ===');
   await t.run('photoshop_create_document', { width: 800, height: 600 }, { required: true });
-  await t.run('photoshop_get_document_info', {}, { required: true });
+
+  {
+    const docInfoResult = await client.callTool({ name: 'photoshop_get_document_info', arguments: {} });
+    const docInfoBody = textFrom(docInfoResult);
+    if (docInfoResult.isError) {
+      t.recordPrompt('assert:document_info_fields', 'fail', short(docInfoBody), 0);
+      console.log(`  FAIL assert:document_info_fields — ${short(docInfoBody)}`);
+    } else {
+      try {
+        const payload = parseJsonFromToolText(docInfoBody) as {
+          document?: { width?: number; height?: number; error?: string };
+        };
+        const ok =
+          payload.document?.width === 800 &&
+          payload.document?.height === 600 &&
+          !payload.document?.error;
+        t.recordPrompt(
+          'assert:document_info_fields',
+          ok ? 'pass' : 'fail',
+          ok
+            ? `width=${payload.document?.width}, height=${payload.document?.height}`
+            : JSON.stringify(payload.document),
+          0
+        );
+        console.log(
+          `  ${ok ? 'OK' : 'FAIL'}  assert:document_info_fields — ${ok ? 'width/height populated, no document.error' : short(JSON.stringify(payload.document))}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        t.recordPrompt('assert:document_info_fields', 'fail', msg, 0);
+        console.log(`  FAIL assert:document_info_fields — ${msg}`);
+      }
+    }
+  }
+
   await t.run('photoshop_get_state', {}, { required: true });
 
   console.log('\n=== Phase 2: Layers ===');
@@ -174,6 +233,8 @@ async function main(): Promise<void> {
     fontSize: 36,
   });
   await t.run('photoshop_get_layers', {}, { required: true });
+  await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint' }, { required: true });
+  await t.run('photoshop_select_layer_by_name', { name: '__MCP_MISSING_LAYER__' }, { expectError: true });
 
   console.log('\n=== Phase 3: Layer properties ===');
   await t.run('photoshop_execute_script', {
@@ -225,18 +286,21 @@ async function main(): Promise<void> {
   await t.run('photoshop_deselect');
 
   console.log('\n=== Phase 7: Adjustments ===');
+  await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint_Renamed copy' });
   await t.run('photoshop_execute_script', {
-    code: `var doc=app.activeDocument; var L=doc.artLayers.getByName("MCP_Paint_Renamed copy"); doc.activeLayer=L; L.blendMode=BlendMode.NORMAL; return { selected: L.name };`,
+    code: `var L=app.activeDocument.activeLayer; L.blendMode=BlendMode.NORMAL; return { selected: L.name, blendMode: String(L.blendMode) };`,
   });
   await t.run('photoshop_adjust_brightness_contrast', { brightness: 5, contrast: 5 });
   await t.run('photoshop_adjust_hue_saturation', { hue: 5, saturation: 5, lightness: 0 });
   await t.run('photoshop_auto_levels');
   await t.run('photoshop_auto_contrast');
   await t.run('photoshop_adjust_curves', { preset: 'auto_tone' });
+  await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint_Renamed copy' });
   await t.run('photoshop_desaturate');
   await t.run('photoshop_invert');
 
   console.log('\n=== Phase 8: Filters ===');
+  await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint_Renamed copy' });
   await t.run('photoshop_apply_gaussian_blur', { radius: 1.5 });
   await t.run('photoshop_apply_sharpen', { amount: 50, radius: 1, threshold: 0 });
   await t.run('photoshop_apply_noise', { amount: 2, distribution: 'UNIFORM', monochromatic: true });
@@ -299,8 +363,14 @@ async function main(): Promise<void> {
   });
   await t.run('photoshop_recipe_gradient_fade', { direction: 'bottom_to_top' });
   await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_execute_script', {
+    code: `var doc=app.activeDocument; var target=null; function findRaster(c){for(var i=0;i<c.layers.length;i++){var L=c.layers[i]; if(L.typename==='LayerSet'){var n=findRaster(L); if(n)return n;} else if(String(L.kind)==='LayerKind.NORMAL'&&!L.isBackgroundLayer){return L;}} return null;} target=findRaster(doc); if(!target) throw new Error('No raster layer'); doc.activeLayer=target; return {active:target.name,kind:String(target.kind)};`,
+  });
   await t.run('photoshop_recipe_dodge_burn', { blend_mode: 'overlay' });
   await t.run('photoshop_undo', { steps: 1 });
+  await t.run('photoshop_execute_script', {
+    code: `var doc=app.activeDocument; var target=null; function findRaster(c){for(var i=0;i<c.layers.length;i++){var L=c.layers[i]; if(L.typename==='LayerSet'){var n=findRaster(L); if(n)return n;} else if(String(L.kind)==='LayerKind.NORMAL'&&!L.isBackgroundLayer){return L;}} return null;} target=findRaster(doc); if(!target) throw new Error('No raster layer'); doc.activeLayer=target; return {active:target.name,kind:String(target.kind)};`,
+  });
   await t.run('photoshop_select_rectangle', { left: 80, top: 80, right: 200, bottom: 200 });
   await t.run('photoshop_recipe_remove_distraction', { feather_px: 1 });
   await t.run('photoshop_undo', { steps: 1 });
@@ -376,7 +446,7 @@ async function main(): Promise<void> {
   await transport.close();
 
   const failed = t.getResults().filter((r) => r.outcome === 'fail').length;
-  const requiredTools = 78;
+  const requiredTools = 79;
   const passedTools = t.getResults().filter((r) => r.outcome === 'pass' && r.name.startsWith('photoshop_')).length;
   console.log(`\nTool coverage: ${passedTools}/${requiredTools} atomic+recipe tools passed.`);
   process.exit(failed > 0 ? 1 : 0);

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -14,6 +14,25 @@ function sTID(s) { return app.stringIDToTypeID(s); }
 `;
 
 /**
+ * Resolve a display or PostScript font name to the PostScript name required by TextItem.font.
+ * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/TextItem/font.html
+ * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/TextFont.html
+ */
+const resolveFontPostScriptName = `
+function resolveFontPostScriptName(name) {
+  for (var i = 0; i < app.fonts.length; i++) {
+    var f = app.fonts[i];
+    try {
+      if (f.postScriptName === name || f.name === name) {
+        return f.postScriptName;
+      }
+    } catch (e) {}
+  }
+  return null;
+}
+`;
+
+/**
  * Helper function to get current context information
  */
 const getContextInfo = `
@@ -283,8 +302,9 @@ export const ExtendScriptSnippets = {
   /**
    * Create a text layer
    */
-  createTextLayer: (text: string, x = 100, y = 100, fontSize = 24) => `
+  createTextLayer: (text: string, x = 100, y = 100, fontSize = 24, fontName?: string) => `
     ${getContextInfo}
+    ${resolveFontPostScriptName}
     
     if (app.documents.length === 0) {
       throw new Error('No active document');
@@ -292,16 +312,24 @@ export const ExtendScriptSnippets = {
     var doc = app.activeDocument;
     var textLayer = doc.artLayers.add();
     textLayer.kind = LayerKind.TEXT;
-    textLayer.textItem.contents = "${text.replace(/"/g, '\\"')}";
+    textLayer.textItem.contents = "${jsString(text)}";
     textLayer.textItem.position = [${x}, ${y}];
     textLayer.textItem.size = ${fontSize};
+    ${fontName ? `
+    var __psFont = resolveFontPostScriptName("${jsString(fontName)}");
+    if (!__psFont) {
+      throw new Error('font_not_found: ${jsString(fontName)}');
+    }
+    textLayer.textItem.font = __psFont;
+    ` : ''}
     
     var result = {
       created: true,
       layerName: textLayer.name,
-      text: "${text.replace(/"/g, '\\"')}",
+      text: "${jsString(text)}",
       position: { x: ${x}, y: ${y} },
       fontSize: ${fontSize},
+      ${fontName ? `font: textLayer.textItem.font,` : ''}
       context: getContextInfo()
     };
     return result;
@@ -318,9 +346,9 @@ export const ExtendScriptSnippets = {
       throw new Error('No active document');
     }
     
-    var imageFile = new File("${filePath.replace(/\\/g, '\\\\')}");
+    var imageFile = new File("${jsString(filePath)}");
     if (!imageFile.exists) {
-      throw new Error('Image file not found: ${filePath}');
+      throw new Error('Image file not found: ${jsString(filePath)}');
     }
     
     // Place image using ActionDescriptor
@@ -337,7 +365,7 @@ export const ExtendScriptSnippets = {
     
     var result = {
       placed: true,
-      filePath: "${filePath}",
+      filePath: "${jsString(filePath)}",
       position: { x: ${x}, y: ${y} },
       context: getContextInfo()
     };
@@ -359,9 +387,9 @@ export const ExtendScriptSnippets = {
    * Open an image file as a new document
    */
   openImage: (filePath: string) => `
-    var imageFile = new File("${filePath.replace(/\\/g, '\\\\')}");
+    var imageFile = new File("${jsString(filePath)}");
     if (!imageFile.exists) {
-      throw new Error('Image file not found: ${filePath}');
+      throw new Error('Image file not found: ${jsString(filePath)}');
     }
     
     var doc = app.open(imageFile);
@@ -442,7 +470,7 @@ export const ExtendScriptSnippets = {
     }
     var doc = app.activeDocument;
     var layer = doc.artLayers.add();
-    ${name ? `layer.name = "${name.replace(/"/g, '\\"')}";` : ''}
+    ${name ? `layer.name = "${jsString(name)}";` : ''}
     
     var result = { 
       created: true,
@@ -853,7 +881,7 @@ export const ExtendScriptSnippets = {
     var layer = doc.activeLayer;
     
     var oldName = layer.name;
-    layer.name = "${newName.replace(/"/g, '\\"')}";
+    layer.name = "${jsString(newName)}";
     
     return { 
       oldName: oldName,
@@ -872,7 +900,7 @@ export const ExtendScriptSnippets = {
     var layer = doc.activeLayer;
     
     var duplicated = layer.duplicate();
-    ${newName ? `duplicated.name = "${newName.replace(/"/g, '\\"')}";` : ''}
+    ${newName ? `duplicated.name = "${jsString(newName)}";` : ''}
     
     return { 
       originalName: layer.name,
@@ -1275,6 +1303,7 @@ export const ExtendScriptSnippets = {
    * Set text layer font
    */
   setTextFont: (fontName: string, fontSize?: number) => `
+    ${resolveFontPostScriptName}
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
@@ -1284,12 +1313,58 @@ export const ExtendScriptSnippets = {
       throw new Error('Active layer is not a text layer');
     }
     
-    layer.textItem.font = "${fontName.replace(/"/g, '\\"')}";
+    var __psFont = resolveFontPostScriptName("${jsString(fontName)}");
+    if (!__psFont) {
+      throw new Error('font_not_found: ${jsString(fontName)}');
+    }
+    layer.textItem.font = __psFont;
     ${fontSize ? `layer.textItem.size = ${fontSize};` : ''}
     
     return { 
       font: layer.textItem.font,
       size: layer.textItem.size
+    };
+  `,
+
+  /**
+   * List installed fonts (PostScript names required for TextItem.font).
+   */
+  listFonts: (query?: string, limit = 200) => `
+    var query = ${query !== undefined ? `"${jsString(query)}"` : 'null'};
+    var limit = ${limit};
+    var fonts = [];
+    var total = app.fonts.length;
+    var truncated = false;
+    for (var i = 0; i < total; i++) {
+      var f = app.fonts[i];
+      try {
+        var entry = {
+          name: f.name,
+          postScriptName: f.postScriptName,
+          family: f.family,
+          style: f.style
+        };
+        if (query) {
+          var q = query.toLowerCase();
+          if (
+            entry.name.toLowerCase().indexOf(q) < 0 &&
+            entry.postScriptName.toLowerCase().indexOf(q) < 0 &&
+            entry.family.toLowerCase().indexOf(q) < 0
+          ) {
+            continue;
+          }
+        }
+        fonts.push(entry);
+        if (fonts.length >= limit) {
+          truncated = i < total - 1;
+          break;
+        }
+      } catch (e) {}
+    }
+    return {
+      fonts: fonts,
+      total: total,
+      truncated: truncated
     };
   `,
 
@@ -1350,7 +1425,7 @@ export const ExtendScriptSnippets = {
       throw new Error('Active layer is not a text layer');
     }
     
-    layer.textItem.contents = "${newText.replace(/"/g, '\\"')}";
+    layer.textItem.contents = "${jsString(newText)}";
     
     return { 
       text: layer.textItem.contents
@@ -1649,7 +1724,7 @@ export const ExtendScriptSnippets = {
    * Play an action from Actions palette
    */
   playAction: (actionName: string, actionSetName: string) => `
-    app.doAction("${actionName.replace(/"/g, '\\"')}", "${actionSetName.replace(/"/g, '\\"')}");
+    app.doAction("${jsString(actionName)}", "${jsString(actionSetName)}");
     
     return { 
       action: '${actionName}',
@@ -1851,7 +1926,7 @@ export const ExtendScriptSnippets = {
     // Find target layer
     var targetLayer = null;
     for (var i = 0; i < doc.layers.length; i++) {
-      if (doc.layers[i].name === "${targetLayerName.replace(/"/g, '\\"')}") {
+      if (doc.layers[i].name === "${jsString(targetLayerName)}") {
         targetLayer = doc.layers[i];
         break;
       }

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -3,6 +3,8 @@
  * ExtendScript is the legacy scripting API for Photoshop
  */
 
+import { jsString } from '../utils/js-string.js';
+
 /**
  * Helper functions for character/string ID conversion
  */
@@ -21,58 +23,59 @@ function getContextInfo() {
   };
   
   if (context.hasDocument) {
+    var doc = null;
     try {
-    var doc = app.activeDocument;
-    context.document = {
-      name: doc.name,
-      width: doc.width.as('px'),
-      height: doc.height.as('px'),
-      resolution: doc.resolution,
-      colorMode: String(doc.mode),
-      layerCount: doc.layers.length,
-      hasSelection: (function () {
-        try {
-          return !!(doc.selection && doc.selection.bounds);
-        } catch (e) {
-          // ExtendScript throws "No such element" when there is no active selection
-          return false;
-        }
-      })()
-    };
-    
-    try {
-      if (doc.activeLayer) {
-        var layer = doc.activeLayer;
-        context.activeLayer = {
-          name: layer.name,
-          kind: String(layer.kind),
-          opacity: layer.opacity,
-          blendMode: String(layer.blendMode),
-          visible: layer.visible,
-          locked: layer.allLocked
-        };
-        try {
-          context.activeLayer.isBackground = layer.isBackgroundLayer;
-        } catch (e) {
-          context.activeLayer.isBackground = false;
-        }
-        try {
-          var bounds = layer.bounds;
-          context.activeLayer.bounds = {
-            left: bounds[0].as('px'),
-            top: bounds[1].as('px'),
-            right: bounds[2].as('px'),
-            bottom: bounds[3].as('px')
-          };
-        } catch (e) {
-          // Bounds not available for some layer types
-        }
-      }
+      doc = app.activeDocument;
     } catch (e) {
-      context.activeLayer = null;
+      doc = null;
     }
-    } catch (e) {
-      context.document = { error: e.message || String(e) };
+
+    if (doc) {
+      context.document = {};
+      try { context.document.name = doc.name; } catch (e) {}
+      try { context.document.width = doc.width.as('px'); } catch (e) {}
+      try { context.document.height = doc.height.as('px'); } catch (e) {}
+      try { context.document.resolution = doc.resolution; } catch (e) {}
+      try { context.document.colorMode = String(doc.mode); } catch (e) {}
+      try { context.document.layerCount = doc.layers.length; } catch (e) {}
+      try {
+        context.document.hasSelection = !!(doc.selection && doc.selection.bounds);
+      } catch (e) {
+        // ExtendScript throws "No such element" when there is no active selection
+        context.document.hasSelection = false;
+      }
+
+      try {
+        if (doc.activeLayer) {
+          var layer = doc.activeLayer;
+          context.activeLayer = {
+            name: layer.name,
+            kind: String(layer.kind),
+            opacity: layer.opacity,
+            blendMode: String(layer.blendMode),
+            visible: layer.visible,
+            locked: layer.allLocked
+          };
+          try {
+            context.activeLayer.isBackground = layer.isBackgroundLayer;
+          } catch (e) {
+            context.activeLayer.isBackground = false;
+          }
+          try {
+            var bounds = layer.bounds;
+            context.activeLayer.bounds = {
+              left: bounds[0].as('px'),
+              top: bounds[1].as('px'),
+              right: bounds[2].as('px'),
+              bottom: bounds[3].as('px')
+            };
+          } catch (e) {
+            // Bounds not available for some layer types
+          }
+        }
+      } catch (e) {
+        context.activeLayer = null;
+      }
     }
   }
   
@@ -332,18 +335,23 @@ export const ExtendScriptSnippets = {
     
     executeAction(cTID('Plc '), desc, DialogModes.NO);
     
-    var layer = app.activeDocument.activeLayer;
-    var result = { 
+    var result = {
       placed: true,
-      layerName: layer.name,
       filePath: "${filePath}",
       position: { x: ${x}, y: ${y} },
-      layerBounds: {
-        width: layer.bounds[2].as('px') - layer.bounds[0].as('px'),
-        height: layer.bounds[3].as('px') - layer.bounds[1].as('px')
-      },
       context: getContextInfo()
     };
+    try {
+      var layer = app.activeDocument.activeLayer;
+      result.layerName = layer.name;
+      var bounds = layer.bounds;
+      result.layerBounds = {
+        width: bounds[2].as('px') - bounds[0].as('px'),
+        height: bounds[3].as('px') - bounds[1].as('px')
+      };
+    } catch (e) {
+      // Place succeeded; layer metadata is best-effort
+    }
     return result;
   `,
 
@@ -539,16 +547,28 @@ export const ExtendScriptSnippets = {
     }
     var doc = app.activeDocument;
     var layers = [];
-    for (var i = 0; i < doc.layers.length; i++) {
-      var layer = doc.layers[i];
-      layers.push({
-        name: layer.name,
-        kind: String(layer.kind),
-        visible: layer.visible,
-        opacity: layer.opacity,
-        blendMode: String(layer.blendMode)
-      });
+    function collectLayers(container) {
+      for (var i = 0; i < container.layers.length; i++) {
+        var layer = container.layers[i];
+        try {
+          layers.push({
+            name: layer.name,
+            kind: String(layer.kind),
+            visible: layer.visible,
+            opacity: layer.opacity,
+            blendMode: String(layer.blendMode)
+          });
+        } catch (e) {
+          var layerName = 'layer_' + layers.length;
+          try { layerName = layer.name; } catch (e2) {}
+          layers.push({ name: layerName, error: e.message || String(e) });
+        }
+        if (layer.typename === 'LayerSet') {
+          collectLayers(layer);
+        }
+      }
     }
+    collectLayers(doc);
     
     var result = {
       layerCount: layers.length,
@@ -559,20 +579,51 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
-   * Select layer by name
+   * Select layer by name (recursive search including layer groups)
    */
-  selectLayer: (name: string) => `
+  selectLayerByName: (name: string) => `
+    ${getContextInfo}
+    
     if (app.documents.length === 0) {
       throw new Error('No active document');
     }
     var doc = app.activeDocument;
-    for (var i = 0; i < doc.layers.length; i++) {
-      if (doc.layers[i].name === "${name.replace(/"/g, '\\"')}") {
-        doc.activeLayer = doc.layers[i];
-        return { selected: true, name: doc.layers[i].name };
+    var targetName = "${jsString(name)}";
+    var target = null;
+    function findLayer(container, name) {
+      for (var i = 0; i < container.layers.length; i++) {
+        var l = container.layers[i];
+        if (l.name === name) return l;
       }
+      for (var j = 0; j < container.layerSets.length; j++) {
+        var nested = findLayer(container.layerSets[j], name);
+        if (nested) return nested;
+      }
+      return null;
     }
-    throw new Error('Layer not found: ${name.replace(/"/g, '\\"')}');
+    target = findLayer(doc, targetName);
+    if (!target) {
+      throw new Error('Layer not found: ' + targetName);
+    }
+    doc.activeLayer = target;
+    var result = {
+      selected: true,
+      layerName: target.name,
+      kind: String(target.kind),
+      context: getContextInfo()
+    };
+    try {
+      var b = target.bounds;
+      result.bounds = {
+        left: b[0].as('px'),
+        top: b[1].as('px'),
+        right: b[2].as('px'),
+        bottom: b[3].as('px'),
+        width: b[2].as('px') - b[0].as('px'),
+        height: b[3].as('px') - b[1].as('px')
+      };
+    } catch (e) {}
+    return result;
   `,
 
   /**

--- a/src/api/photoshop-api.ts
+++ b/src/api/photoshop-api.ts
@@ -108,6 +108,8 @@ class ExtendScriptPhotoshopAPI implements PhotoshopAPI {
   var __originalTypeUnits = null;
   var __origDialogs = null;
   var __origAlert = null;
+  var __origConfirm = null;
+  var __origPrompt = null;
   try { __originalRulerUnits = app.preferences.rulerUnits; } catch (e) {}
   try { __originalTypeUnits = app.preferences.typeUnits; } catch (e) {}
   try { __origDialogs = app.displayDialogs; } catch (e) {}
@@ -115,6 +117,17 @@ class ExtendScriptPhotoshopAPI implements PhotoshopAPI {
   if (typeof alert !== 'undefined') {
     __origAlert = alert;
     alert = function(msg) { $.writeln('[MCP] ' + msg); };
+  }
+  if (typeof confirm !== 'undefined') {
+    __origConfirm = confirm;
+    confirm = function() { $.writeln('[MCP] confirm suppressed'); return true; };
+  }
+  if (typeof prompt !== 'undefined') {
+    __origPrompt = prompt;
+    prompt = function(msg, def) {
+      $.writeln('[MCP] prompt suppressed: ' + msg);
+      return def || '';
+    };
   }
 
   try {
@@ -135,6 +148,8 @@ class ExtendScriptPhotoshopAPI implements PhotoshopAPI {
     try { if (__originalTypeUnits !== null) app.preferences.typeUnits = __originalTypeUnits; } catch (e) {}
     try { if (__origDialogs !== null) app.displayDialogs = __origDialogs; } catch (e) {}
     if (__origAlert !== null) { alert = __origAlert; }
+    if (__origConfirm !== null) { confirm = __origConfirm; }
+    if (__origPrompt !== null) { prompt = __origPrompt; }
   }
 })();
     `.trim();

--- a/src/api/photoshop-api.ts
+++ b/src/api/photoshop-api.ts
@@ -106,8 +106,16 @@ class ExtendScriptPhotoshopAPI implements PhotoshopAPI {
 (function() {
   var __originalRulerUnits = null;
   var __originalTypeUnits = null;
+  var __origDialogs = null;
+  var __origAlert = null;
   try { __originalRulerUnits = app.preferences.rulerUnits; } catch (e) {}
   try { __originalTypeUnits = app.preferences.typeUnits; } catch (e) {}
+  try { __origDialogs = app.displayDialogs; } catch (e) {}
+  try { app.displayDialogs = DialogModes.NO; } catch (e) {}
+  if (typeof alert !== 'undefined') {
+    __origAlert = alert;
+    alert = function(msg) { $.writeln('[MCP] ' + msg); };
+  }
 
   try {
     try { app.preferences.rulerUnits = Units.PIXELS; } catch (e) {}
@@ -125,6 +133,8 @@ class ExtendScriptPhotoshopAPI implements PhotoshopAPI {
   } finally {
     try { if (__originalRulerUnits !== null) app.preferences.rulerUnits = __originalRulerUnits; } catch (e) {}
     try { if (__originalTypeUnits !== null) app.preferences.typeUnits = __originalTypeUnits; } catch (e) {}
+    try { if (__origDialogs !== null) app.displayDialogs = __origDialogs; } catch (e) {}
+    if (__origAlert !== null) { alert = __origAlert; }
   }
 })();
     `.trim();

--- a/src/errors/envelope.ts
+++ b/src/errors/envelope.ts
@@ -10,6 +10,7 @@ export type PhotoshopErrorCode =
   | 'generative_unavailable'
   | 'extendscript_runtime_error'
   | 'file_not_found'
+  | 'font_not_found'
   | 'unsupported_color_mode'
   | 'unknown';
 
@@ -33,6 +34,7 @@ const ERROR_PATTERNS: Array<{
   { pattern: /selection/i, code: 'selection_required', suggested_next_tool: 'photoshop_get_state' },
   { pattern: /version_unsupported|not supported.*version/i, code: 'version_unsupported', suggested_next_tool: 'photoshop_get_capabilities' },
   { pattern: /generative/i, code: 'generative_unavailable', suggested_next_tool: 'photoshop_get_capabilities' },
+  { pattern: /font_not_found/i, code: 'font_not_found', suggested_next_tool: 'photoshop_list_fonts' },
   { pattern: /file not found|does not exist/i, code: 'file_not_found' },
   { pattern: /color mode/i, code: 'unsupported_color_mode', suggested_next_tool: 'photoshop_get_document_info' },
 ];

--- a/src/platform/macos-executor.ts
+++ b/src/platform/macos-executor.ts
@@ -4,6 +4,7 @@ import { writeFile, unlink } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Logger } from '../utils/logger.js';
+import { prefixExtendScriptBom } from '../utils/extendscript-file.js';
 import { parseExtendScriptPayload } from '../utils/extendscript-result.js';
 import { ScriptExecutor } from './script-executor.js';
 
@@ -74,7 +75,7 @@ export class MacOSExecutor implements ScriptExecutor {
     const tempAppleScriptPath = join(tmpdir(), `photoshop-applescript-${Date.now()}.scpt`);
 
     try {
-      await writeFile(tempScriptPath, script, 'utf8');
+      await writeFile(tempScriptPath, prefixExtendScriptBom(script), 'utf8');
 
       // Create AppleScript that tells Photoshop to execute the JSX
       const appleScript = this.createAppleScriptWrapper(tempScriptPath);
@@ -166,7 +167,7 @@ end tell`;
     const tempAppleScriptPath = join(tmpdir(), `photoshop-applescript-alt-${Date.now()}.scpt`);
 
     try {
-      await writeFile(tempScriptPath, script, 'utf8');
+      await writeFile(tempScriptPath, prefixExtendScriptBom(script), 'utf8');
 
       const appleScript = `tell application "${this.appName}"
 \tdo shell script "cat '${tempScriptPath}'"

--- a/src/platform/windows-executor.ts
+++ b/src/platform/windows-executor.ts
@@ -3,6 +3,8 @@ import { promisify } from 'util';
 import { writeFile, unlink } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { prefixExtendScriptBom } from '../utils/extendscript-file.js';
+import { parseExtendScriptPayload } from '../utils/extendscript-result.js';
 import { Logger } from '../utils/logger.js';
 import { ScriptExecutor } from './script-executor.js';
 
@@ -67,7 +69,7 @@ export class WindowsExecutor implements ScriptExecutor {
     const tempScriptPath = join(tmpdir(), `photoshop-script-${Date.now()}.jsx`);
     
     try {
-      await writeFile(tempScriptPath, script, 'utf8');
+      await writeFile(tempScriptPath, prefixExtendScriptBom(script), 'utf8');
 
       // Use VBScript to execute the JSX script via COM
       const vbsScript = this.createVBSWrapper(tempScriptPath);
@@ -108,7 +110,7 @@ End If
 
 ' Execute the JSX script
 Dim result
-result = photoshopApp.DoJavaScript("$.evalFile('" & Replace("${jsxPath}", "\\", "\\\\") & "');")
+result = photoshopApp.DoJavaScript("return $.evalFile('" & Replace("${jsxPath}", "\\", "\\\\") & "');")
 
 If Err.Number <> 0 Then
     WScript.Echo "ERROR: " & Err.Description
@@ -127,13 +129,7 @@ End If
       throw new Error(trimmed.substring(6).trim());
     }
 
-    // Try to parse as JSON
-    try {
-      return JSON.parse(trimmed);
-    } catch {
-      // Return as string if not JSON
-      return trimmed;
-    }
+    return parseExtendScriptPayload(trimmed);
   }
 
   async isPhotoshopRunning(): Promise<boolean> {

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -34,6 +34,9 @@ export function createActionTools(connection: PhotoshopConnection): ToolDefiniti
           'Use when: no existing tool covers the operation and you can write safe JSX.\n' +
           'Do NOT use when: a recipe or atomic tool exists — prefer photoshop_recipe_* or photoshop_* tools.\n\n' +
           'Returns: script return value serialized as text/JSON.\n' +
+          'IMPORTANT: Your code runs inside a wrapping IIFE. Use an explicit `return` to pass data back — ' +
+          'a bare trailing expression returns undefined. Example: `return { ok: true };` ' +
+          'Objects are serialized with toSource() and parsed automatically on macOS and Windows.\n' +
           'Preconditions: valid ExtendScript; active document if script expects one. Side effects: depends on code.',
         inputSchema: {
           type: 'object',

--- a/src/tools/layer-tools.ts
+++ b/src/tools/layer-tools.ts
@@ -41,10 +41,11 @@ export function createLayerTools(connection: PhotoshopConnection): ToolDefinitio
       tool: {
         name: 'photoshop_create_text_layer',
         description:
-          'Create a text layer with content, position, and font size.\n\n' +
+          'Create a text layer with content, position, font size, and optional font.\n\n' +
           'Use when: adding labels, titles, or typography to the design.\n' +
           'Do NOT use when: editing existing text — use photoshop_update_text_content.\n\n' +
-          'Returns: layer name, text, position, fontSize, context.\n' +
+          'Returns: layer name, text, position, fontSize, font (when fontName set), context.\n' +
+          'Use photoshop_list_fonts to discover font names; photoshop_set_text_font to change font later.\n' +
           'Preconditions: active document. Side effects: adds text layer.',
         inputSchema: {
           type: 'object',
@@ -67,6 +68,11 @@ export function createLayerTools(connection: PhotoshopConnection): ToolDefinitio
               type: 'number',
               description: 'Font size in points (default: 24)',
               default: 24,
+            },
+            fontName: {
+              type: 'string',
+              description:
+                'Optional font display or PostScript name (resolved via app.fonts; see photoshop_list_fonts)',
             },
           },
           required: ['text'],
@@ -218,19 +224,20 @@ async function createTextLayer(
   const x = (args.x as number) || 100;
   const y = (args.y as number) || 100;
   const fontSize = (args.fontSize as number) || 24;
+  const fontName = args.fontName as string | undefined;
 
   try {
     const apiFactory = new PhotoshopAPIFactory(connection);
     const api = await apiFactory.createAPI();
 
-    const script = ExtendScriptSnippets.createTextLayer(text, x, y, fontSize);
+    const script = ExtendScriptSnippets.createTextLayer(text, x, y, fontSize, fontName);
     await api.executeScript(script);
 
     return {
       content: [
         {
           type: 'text' as const,
-          text: `Text layer created: "${text}" at (${x}, ${y})`,
+          text: `Text layer created: "${text}" at (${x}, ${y})${fontName ? ` with font ${fontName}` : ''}`,
         },
       ],
     };

--- a/src/tools/layer-tools.ts
+++ b/src/tools/layer-tools.ts
@@ -121,6 +121,29 @@ export function createLayerTools(connection: PhotoshopConnection): ToolDefinitio
       },
       handler: async () => getLayers(connection),
     },
+    {
+      tool: {
+        name: 'photoshop_select_layer_by_name',
+        description:
+          'Select the active layer by exact name, including layers inside groups.\n\n' +
+          'Use when: a transform or property tool must target a named layer (photoshop_scale_layer, etc.).\n' +
+          'Do NOT use when: the layer is already active — check photoshop_get_state first.\n\n' +
+          'Returns: selected, layerName, kind, bounds (best-effort), context.\n' +
+          'First depth-first name match wins when duplicate names exist in different groups.\n' +
+          'Preconditions: active document. Side effects: changes active layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Exact layer name (case-sensitive)',
+            },
+          },
+          required: ['name'],
+        },
+      },
+      handler: async (args) => selectLayerByName(connection, args),
+    },
   ];
 }
 
@@ -282,6 +305,40 @@ async function getLayers(connection: PhotoshopConnection): Promise<ToolResult> {
         {
           type: 'text' as const,
           text: `Error getting layers: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+async function selectLayerByName(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const name = args.name as string;
+
+  try {
+    const apiFactory = new PhotoshopAPIFactory(connection);
+    const api = await apiFactory.createAPI();
+
+    const script = ExtendScriptSnippets.selectLayerByName(name);
+    const result = await api.executeScript(script);
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Layer selected:\n${JSON.stringify(result, null, 2)}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Error selecting layer: ${error instanceof Error ? error.message : String(error)}`,
         },
       ],
       isError: true,

--- a/src/tools/recipes/_shared.ts
+++ b/src/tools/recipes/_shared.ts
@@ -283,13 +283,7 @@ export function clampInt(value: unknown, min: number, max: number, fallback: num
   return Math.max(min, Math.min(max, Math.round(value)));
 }
 
-export function jsString(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r');
-}
+export { jsString } from '../../utils/js-string.js';
 
 export function gradientMaskAxisPercents(
   direction: GradientMaskDirection,

--- a/src/tools/text-tools.ts
+++ b/src/tools/text-tools.ts
@@ -7,14 +7,45 @@ export function createTextTools(connection: PhotoshopConnection): ToolDefinition
   return [
     {
       tool: {
+        name: 'photoshop_list_fonts',
+        description:
+          'List installed fonts available to Photoshop.\n\n' +
+          'Use when: choosing a font for photoshop_create_text_layer or photoshop_set_text_font.\n' +
+          'TextItem.font requires the PostScript name — use postScriptName from results, or pass display name to set/create tools (they resolve automatically).\n\n' +
+          'Returns: fonts array ({ name, postScriptName, family, style }), total count, truncated flag.\n' +
+          'First call may be slow (app.fonts.length can exceed 1000). Side effects: none.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Optional substring filter (matches name, postScriptName, or family)',
+            },
+            limit: {
+              type: 'number',
+              description: 'Maximum fonts to return (default: 200)',
+              default: 200,
+              minimum: 1,
+              maximum: 1000,
+            },
+          },
+        },
+      },
+      handler: async (args) => listFonts(connection, args),
+    },
+    {
+      tool: {
         name: 'photoshop_set_text_font',
-        description: 'Set font family and size for active text layer',
+        description:
+          'Set font family and size for active text layer.\n\n' +
+          'Accepts display name (e.g. "Arial") or PostScript name (e.g. "ArialMT") — resolved via app.fonts.\n' +
+          'Use photoshop_list_fonts to discover available fonts.',
         inputSchema: {
           type: 'object',
           properties: {
             fontName: {
               type: 'string',
-              description: 'Font family name (e.g., "Arial", "Helvetica")',
+              description: 'Font display or PostScript name (see photoshop_list_fonts)',
             },
             fontSize: {
               type: 'number',
@@ -94,6 +125,41 @@ export function createTextTools(connection: PhotoshopConnection): ToolDefinition
       handler: async (args) => updateTextContent(connection, args),
     },
   ];
+}
+
+async function listFonts(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const query = args.query as string | undefined;
+  const limit = (args.limit as number | undefined) ?? 200;
+
+  try {
+    const apiFactory = new PhotoshopAPIFactory(connection);
+    const api = await apiFactory.createAPI();
+
+    const script = ExtendScriptSnippets.listFonts(query, limit);
+    const result = await api.executeScript(script);
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Fonts listed${query ? ` (query: "${query}")` : ''}\nResult: ${JSON.stringify(result)}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Error listing fonts: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
 }
 
 async function setTextFont(

--- a/src/utils/extendscript-file.ts
+++ b/src/utils/extendscript-file.ts
@@ -1,0 +1,6 @@
+export const EXTENDSCRIPT_UTF8_BOM = '\uFEFF';
+
+/** Prefix UTF-8 BOM once so ExtendScript $.evalFile detects UTF-8 (Adobe docs). */
+export function prefixExtendScriptBom(script: string): string {
+  return script.startsWith(EXTENDSCRIPT_UTF8_BOM) ? script : EXTENDSCRIPT_UTF8_BOM + script;
+}

--- a/src/utils/js-string.ts
+++ b/src/utils/js-string.ts
@@ -1,0 +1,7 @@
+export function jsString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+}


### PR DESCRIPTION
## Summary

Fixes [#2](https://github.com/alisaitteke/photoshop-mcp/issues/2) — reliability, automation, and typography gaps reported during real multi-layer PSD workflows.

**80 tools total** (68 atomic + 12 recipe) · **16 files changed** · +866 / −128 lines · **2 commits**

---

### ExtendScript API hardening (`src/api/extendscript.ts`, `src/api/photoshop-api.ts`)

- **`getContextInfo`** — per-property `try/catch` for document metadata; no whole-payload wipe on single property failure
- **`placeImage`** — returns `{ placed: true }` after successful `executeAction`; `layerName` / `layerBounds` are best-effort
- **`getLayerNames`** — per-layer error isolation + recursive `LayerSet` walk; failed entries become `{ name, error }`
- **`selectLayerByName`** — recursive group search (mirrors `batch-mockup-replace` `findLayer`)
- **`wrapInErrorHandling`** — global dialog suppression (`DialogModes.NO`); `alert`, `confirm`, and `prompt` redirected to `$.writeln` for all atomic snippets and `execute_script`
- **`jsString` migration** — all user-string interpolations in ExtendScript snippets use shared escaping (`\`, `"`, `\n`, `\r`)

> **Reported by [@pokipoi](https://github.com/pokipoi):** `photoshop_get_document_info` and `photoshop_get_layers` intermittently returned `No such element` even with a visible open document; `photoshop_place_image` returned false errors on success; `alert()` and native confirmation dialogs blocked unattended automation; Smart Object `scale`/`move` after place triggered "User cancelled" dialogs.
>
> Thank you for the detailed reproduction notes and the script-created-document edge case.

---

### Platform executors (`src/platform/`)

- UTF-8 BOM prefix on every temp `.jsx` write (macOS + Windows) via `prefixExtendScriptBom`
- Windows `parseExtendScriptPayload` parity for `execute_script` return capture
- Shared `jsString` utility (`src/utils/js-string.ts`) for consistent JSX string escaping

> **Reported by [@KunnyStark](https://github.com/KunnyStark):** Japanese and Chinese text garbled in layer names — traced to ExtendScript's `$.evalFile()` defaulting to Mac OS Roman without a UTF-8 BOM; proposed the BOM prepend fix. Also flagged unescaped backslashes and newlines in JSX string interpolation.
>
> Thank you for the root-cause analysis — the BOM fix and full `jsString` hardening are directly based on your issue thread contribution.

---

### New and updated MCP tools

- **`photoshop_select_layer_by_name`** — select a layer by name (including nested groups)
- **`photoshop_list_fonts`** — discover installed fonts with optional `query` filter and `limit` (default 200); returns `name`, `postScriptName`, `family`, `style`
- **`photoshop_create_text_layer`** — new optional `fontName` param (display or PostScript name, resolved via `app.fonts`)
- **`photoshop_set_text_font`** — now resolves font names via `resolveFontPostScriptName`; returns `font_not_found` error envelope with `suggested_next_tool: photoshop_list_fonts`
- **`photoshop_execute_script`** — description updated with explicit `return` requirement

> **Reported by [@a714443294-bit](https://github.com/a714443294-bit):** No direct controls for font types during graphic design workflows — hard to discover which tools handle typography.
>
> Thank you for the practitioner perspective — font discovery and creation-time font selection are now first-class MCP tools.

---

### Test harness and docs

- **`npm run spike:issue-2`** — 11-step targeted regression (metadata, layers, place, Smart Object transform, jsString escapes, fonts, alert, CJK round-trip, missing layer)
- **`npm run test:mcp-all`** — extended Phase 9 with `list_fonts` and `fontName` on create; Phase 7–8 raster re-select via `select_layer_by_name`
- README and CONTRIBUTING updated — 80 tools, spike command, font tool catalog entries

### Response contract changes

| Tool | Before | After |
|------|--------|-------|
| `photoshop_get_document_info` | Intermittent `document.error: "No such element"` | Real `name`, `width`, `height` when readable |
| `photoshop_place_image` | False tool-level error on success | `{ placed: true }` minimum; metadata best-effort |
| `photoshop_get_layers` | Crash or empty on mixed doc types | Partial list; per-layer `{ name, error }` on failure |
| `photoshop_execute_script` | `"undefined"` on Windows | Parsed return value when script uses explicit `return` |
| Non-ASCII layer names | Garbled output | UTF-8 BOM round-trip preserved |
| Layer/text names with `\`, `"`, newlines | Broken generated JSX | `jsString` full escape |
| Font at text creation | Not available | Optional `fontName` on `create_text_layer` |
| Font discovery | Not available | `photoshop_list_fonts` with query + limit |

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Checklist

- [x] PR title, description, and commit messages are in **English**
- [x] Code comments and user-facing strings are in **English**
- [ ] `npm run lint` passes — pre-existing baseline (84 errors repo-wide; none introduced in touched files)
- [x] `npm run build:server` passes
- [x] Tests run (check all that apply):
  - [x] `npm run verify:photoshop-prompts`
  - [x] `npm run test:mcp-local` (requires Photoshop)
  - [x] `npm run test:mcp-all` (requires Photoshop) — **119 pass, 0 fail, 4 skip** (123 total)
  - [x] `npm run spike:issue-2` — **all checks PASS** (11 steps)
- [x] UI change screenshots attached (if applicable) — N/A, no UI changes

## Related issues

Fixes #2

## Test plan

- [x] `npm run build:server`
- [x] `npm run verify:photoshop-prompts`
- [x] `npm run test:mcp-local`
- [x] `npm run spike:issue-2` — document metadata, Smart Object scale/move, jsString escapes, fonts, alert, CJK, missing layer
- [x] `npm run test:mcp-all` — full MCP tool sweep (123 steps)
- [ ] Manual smoke on Windows (BOM + `parseExtendScriptPayload` parity) — not run; macOS-only verification in this session