### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **Photoshop MCP server** (TypeScript, `@modelcontextprotocol/sdk`)
+plus a bundled **standalone web UI** (Vue 3 + Vite frontend, Hono backend, SQLite
+via `better-sqlite3`). See `README.md`, `docs/development.md`, and
+`docs/architecture.md` for the canonical docs.
+
+### Platform limitation (important)
+
+The MCP server controls Adobe Photoshop and **only supports macOS and Windows**.
+`PhotoshopConnection` (`src/platform/connection.ts`) throws
+`Unsupported platform: linux` on the Linux cloud VM. Consequences on this VM:
+
+- The MCP server itself (`npm start` / `dist/index.js`) cannot run.
+- Integration/verification scripts that construct a Photoshop `Session` cannot
+  run here: `verify:photoshop-prompts`, `test:mcp-local`, `test:mcp-all`,
+  `test:intent-expansion`, `spike:issue-2`, `spike:photoshop-actions`. These
+  require a live Photoshop on macOS/Windows (see `docs/development.md`).
+
+### What IS runnable on the cloud VM
+
+The **standalone web UI is platform-independent** and is the thing to develop/
+demo here.
+
+- Run both backend + frontend: `npm run dev:ui`
+  - Hono backend (hot reload via `tsx watch`) on `http://127.0.0.1:5174`
+  - Vite frontend on `http://localhost:5173` (proxies `/api` → 5174, rewriting
+    the `Origin` header so Hono's loopback-origin guard accepts it)
+- The backend enforces a loopback-origin guard on `/api/*`; browser requests
+  must come from `localhost`/`127.0.0.1`. Direct `curl` (no `Origin` header)
+  works for quick API checks (e.g. `GET /api/status`, `GET /api/providers`,
+  `POST /api/chats`).
+- UI config + chat history persist to SQLite at `~/.photoshop-mcp/data.db`.
+- Actually chatting (and driving Photoshop) needs a provider API key (or a
+  Claude Code / Gemini CLI account) **and** a running Photoshop — neither is
+  available on this VM. The onboarding, provider config, and chat CRUD work
+  without them.
+
+### Build / lint notes
+
+- `npm install` triggers the `prepare` hook → full `npm run build` (builds the
+  server with `tsc` **and** installs + builds `web/`). So a single root install
+  bootstraps everything; no separate `web/` install step is needed.
+- `npm run build:server` (tsc) works on Linux. `npm run build:web` works on Linux.
+- `npm run lint` currently fails (~105 `no-undef`/`no-unused-vars` errors): the
+  flat ESLint config (`eslint.config.js`) does not declare Node globals
+  (`process`, `crypto`, `URL`, `Response`, `AbortController`) for `src/**/*.ts`.
+  This is a pre-existing repo config issue, not an environment problem.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment and documents non-obvious caveats in a new `AGENTS.md`. No application/source code changed — only environment setup plus `AGENTS.md`.

Key learnings captured:
- The MCP server controls Adobe Photoshop and **only supports macOS/Windows**; `PhotoshopConnection` throws `Unsupported platform: linux`. So the MCP server and all Photoshop integration scripts can't run on the Linux cloud VM.
- The **standalone web UI** (`npm run dev:ui`: Hono backend on `127.0.0.1:5174` + Vite frontend on `localhost:5173`) is platform-independent and is the runnable/demoable app here.
- `npm install` triggers the `prepare` hook → full build (server + `web/` install + build), so a single root install bootstraps everything.
- `npm run lint` currently fails (~105 `no-undef` errors) because the flat ESLint config does not declare Node globals — a pre-existing repo config issue, not an environment problem.

## Type of change

- [x] Documentation

## Checklist

- [x] PR title, description, and commit messages are in **English**
- [x] Code comments and user-facing strings are in **English**
- [ ] `npm run lint` passes (pre-existing repo config failure — see AGENTS.md)
- [x] `npm run build:server` passes
- [ ] Tests run:
  - [ ] `npm run verify:photoshop-prompts` (requires Photoshop; throws on Linux)
  - [ ] `npm run test:mcp-local` (requires Photoshop)
  - [ ] `npm run test:mcp-all` (requires Photoshop)
- [x] UI change screenshots attached (web UI demo below)

## Demo

Standalone web UI onboarding running locally:

[photoshop_mcp_web_ui_onboarding.mp4](https://cursor.com/agents/bc-8b7c19c5-9fb5-40e9-9fbd-c1df88857606/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphotoshop_mcp_web_ui_onboarding.mp4)

[Onboarding screen](https://cursor.com/agents/bc-8b7c19c5-9fb5-40e9-9fbd-c1df88857606/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fui_onboarding.webp)
[Anthropic API key entry](https://cursor.com/agents/bc-8b7c19c5-9fb5-40e9-9fbd-c1df88857606/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fui_anthropic_apikey.webp)

## Related issues

Fixes #


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b7c19c5-9fb5-40e9-9fbd-c1df88857606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b7c19c5-9fb5-40e9-9fbd-c1df88857606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

