### PR TITLE
fix(windows): remove top-level return from DoJavaScript for PS 2026

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,7 @@ export default [
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
-          caughtErrors: 'none',
+          caughtErrorsIgnorePattern: '^_',
         },
       ],
       '@typescript-eslint/no-explicit-any': 'warn',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import eslint from '@eslint/js';
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
+import globals from 'globals';
 
 export default [
   eslint.configs.recommended,
@@ -13,12 +14,27 @@ export default [
         sourceType: 'module',
         project: './tsconfig.json',
       },
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
     },
     plugins: {
       '@typescript-eslint': tseslint,
     },
     rules: {
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      // TypeScript compiler checks undefined identifiers; base no-undef flags TS types (e.g. NodeJS).
+      'no-undef': 'off',
+      // Base rule does not understand TS interfaces/enums; use the TS variant only.
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrors: 'none',
+        },
+      ],
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/src/platform/macos-detector.ts
+++ b/src/platform/macos-detector.ts
@@ -109,7 +109,7 @@ export class MacOSDetector {
         isRunning: await this.checkIfRunning(cleanPath),
         appName,
       };
-    } catch (error) {
+    } catch {
       return null;
     }
   }
@@ -130,7 +130,7 @@ export class MacOSDetector {
         if (version.trim()) {
           return version.trim();
         }
-      } catch (error) {
+      } catch {
         // PlistBuddy failed, try parsing manually
         const content = await readFile(plistPath, 'utf8');
         const versionMatch = content.match(
@@ -162,7 +162,7 @@ export class MacOSDetector {
       // Use pgrep to check if process is running
       const { stdout } = await execAsync(`pgrep -f "${appName}"`);
       return stdout.trim().length > 0;
-    } catch (error) {
+    } catch {
       // pgrep returns non-zero exit code if no process found
       return false;
     }
@@ -175,7 +175,7 @@ export class MacOSDetector {
         `/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "${plistPath}"`
       );
       return stdout.trim();
-    } catch (error) {
+    } catch {
       return null;
     }
   }

--- a/src/platform/macos-executor.ts
+++ b/src/platform/macos-executor.ts
@@ -129,7 +129,7 @@ end tell`;
     try {
       const { stdout } = await execAsync('pgrep -f "Adobe Photoshop"');
       return stdout.trim().length > 0;
-    } catch (error) {
+    } catch {
       // pgrep returns non-zero exit code if no process found
       return false;
     }

--- a/src/platform/windows-detector.ts
+++ b/src/platform/windows-detector.ts
@@ -66,7 +66,7 @@ export class WindowsDetector {
             const info = await this.checkPath(latest.path);
             if (info) return info;
           }
-        } catch (error) {
+        } catch {
           // Continue to next registry path
           continue;
         }
@@ -86,7 +86,7 @@ export class WindowsDetector {
             const info = await this.checkPath(exePath);
             if (info) return info;
           }
-        } catch (error) {
+        } catch {
           continue;
         }
       }
@@ -177,7 +177,7 @@ export class WindowsDetector {
         path: cleanPath,
         isRunning: await this.checkIfRunning(),
       };
-    } catch (error) {
+    } catch {
       return null;
     }
   }
@@ -202,7 +202,7 @@ export class WindowsDetector {
     try {
       const { stdout } = await execAsync('tasklist /FI "IMAGENAME eq Photoshop.exe"');
       return stdout.toLowerCase().includes('photoshop.exe');
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/src/platform/windows-executor.ts
+++ b/src/platform/windows-executor.ts
@@ -110,7 +110,7 @@ End If
 
 ' Execute the JSX script
 Dim result
-result = photoshopApp.DoJavaScript("return $.evalFile('" & Replace("${jsxPath}", "\\", "\\\\") & "');")
+result = photoshopApp.DoJavaScript("$.evalFile('" & Replace("${jsxPath}", "\\", "\\\\") & "')")
 
 If Err.Number <> 0 Then
     WScript.Echo "ERROR: " & Err.Description

--- a/src/platform/windows-executor.ts
+++ b/src/platform/windows-executor.ts
@@ -136,7 +136,7 @@ End If
     try {
       const { stdout } = await execAsync('tasklist /FI "IMAGENAME eq Photoshop.exe"');
       return stdout.toLowerCase().includes('photoshop.exe');
-    } catch (error) {
+    } catch {
       return false;
     }
   }


### PR DESCRIPTION
Fixes #8

cc @Blues-star — thanks for the root-cause analysis and PowerShell verification.

## Summary
- Remove top-level `return` from Windows VBS `DoJavaScript("$.evalFile(...)")` call — PS 2026 rejects it via COM; matches macOS executor pattern
- ESLint: Node/ES2021 globals + TypeScript `no-unused-vars` setup
- Platform catch blocks: unused `error` → `catch {}`

## Test plan
- [x] `npm run build:server`
- [x] `npm run lint`
- [x] `npm run test:mcp-local` / `test:mcp-all` / `test:intent-expansion` (macOS, PS 26.5)
- [ ] Manual smoke on Windows + Photoshop 2026 (`get_state`, `execute_script`)