### PR TITLE
fix(layers): make duplicate_layer activate the duplicated layer

### DIFF
--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -890,7 +890,12 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
-   * Duplicate active layer
+   * Duplicate active layer.
+   *
+   * DOM layer.duplicate() does NOT activate the duplicate — the original
+   * layer stays active, so without the explicit activeLayer assignment any
+   * follow-up active-layer tool (masks, filters, transforms) would target
+   * the original instead of the copy.
    */
   duplicateLayer: (newName?: string) => `
     if (app.documents.length === 0) {
@@ -901,11 +906,15 @@ export const ExtendScriptSnippets = {
     
     var duplicated = layer.duplicate();
     ${newName ? `duplicated.name = "${jsString(newName)}";` : ''}
+    doc.activeLayer = duplicated;
     
-    return { 
+    var result = {
       originalName: layer.name,
-      newName: duplicated.name
+      newName: duplicated.name,
+      activated: true
     };
+    try { result.newLayerId = duplicated.id; } catch (e) {}
+    return result;
   `,
 
   /**

--- a/src/tools/layer-properties-tools.ts
+++ b/src/tools/layer-properties-tools.ts
@@ -135,7 +135,9 @@ export function createLayerPropertiesTools(connection: PhotoshopConnection): Too
     {
       tool: {
         name: 'photoshop_duplicate_layer',
-        description: 'Duplicate the active layer',
+        description:
+          'Duplicate the active layer. The duplicate becomes the active layer; ' +
+          'returns its name and, when available, its layer id.',
         inputSchema: {
           type: 'object',
           properties: {


### PR DESCRIPTION
## Problem

DOM `layer.duplicate()` leaves the *original* layer active. Any follow-up tool that operates on the active layer silently targets the original instead of the copy — e.g. the chain `photoshop_duplicate_layer` → `photoshop_select_subject` → `photoshop_create_layer_mask` masks the original, and the composite looks unchanged because the unmasked duplicate sits on top. Nothing errors, so it's easy to miss.

## Fix

- Set `doc.activeLayer = duplicated` immediately after duplication in the `duplicateLayer` ExtendScript snippet.
- The result now returns `newName`, `activated: true`, and best-effort `newLayerId`, so callers can bind to the layer they created rather than whatever happens to be active.
- Tool description updated to match.

## Verification

Live on Photoshop 27.8.0 (macOS, Apple Silicon): create doc → duplicate (named and unnamed) → `get_state` shows the duplicate active; the duplicate → select-subject → mask chain now masks the copy. 9/9 chain passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
