### PR TITLE
docs(i18n): add locale README translations (ES, ZH, DE, JA, TR)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,766 @@
+# Photoshop MCP Server
+
+<p align="center">
+  <a href="https://github.com/alisaitteke/photoshop-mcp">
+    <img src="./images/readme-hero.png" alt="Photoshop MCP — KI-gesteuerte Photoshop-Automatisierung" width="100%" />
+  </a>
+</p>
+
+**Sprachen:** [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · Deutsch · [日本語](README.ja.md) · [Türkçe](README.tr.md)
+
+*v1.1+ — Rezept-Workflows, weniger Round-Trips, flinkere Sitzungen. Die eigenständige UI liefert **Action Plan (Beta)** für Plan-dann-Ausführen-Abläufe.*
+
+> **Hinweis:** Dies ist ein inoffizielles, von der Community gepflegtes Projekt und steht in keiner Verbindung zu Adobe Inc. und wird von Adobe Inc. nicht unterstützt.
+
+[![npm-Version](https://img.shields.io/npm/v/@alisaitteke/photoshop-mcp.svg)](https://www.npmjs.com/package/@alisaitteke/photoshop-mcp)
+[![GitHub-Release](https://img.shields.io/github/v/release/alisaitteke/photoshop-mcp?include_prereleases)](https://github.com/alisaitteke/photoshop-mcp/releases)
+[![Action Plan](https://img.shields.io/badge/Action%20Plan-beta-amber.svg)](#action-plan-beta)
+[![Lizenz: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
+[![Plattform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS-lightgrey.svg)]()
+
+Ein Model Context Protocol (MCP)-Server, der KI-Assistenten wie Claude und Cursor ermöglicht, Adobe Photoshop programmatisch zu steuern. Damit lassen sich Designs erstellen, Bilder bearbeiten und Photoshop-Workflows mit natürlicher Sprache automatisieren – direkt aus der IDE heraus oder über die mitgelieferte **eigenständige Web-UI**, die sowohl API-Schlüssel als auch CLI-Abonnementkonten (Claude Code / Gemini CLI) unterstützt. Die UI bietet außerdem einen opt-in **Action Plan (Beta)**-Modus, der alle Photoshop-Schritte in einem einzigen LLM-Aufruf plant und dann in einem einzigen Durchgang ausführt.
+
+## Warum dieses Projekt existiert
+
+Designerinnen, Designer und Entwicklerinnen und Entwickler möchten Photoshop über KI-Assistenten steuern, aber rohe ExtendScript-Aufrufe sind fehleranfällig: Agenten verschwenden Token durch Trial-and-Error, Ebenentypen brechen Filter, und ein fehlgeschlagener Befehl hinterlässt das Dokument in einem unbekannten Zustand.
+
+Photoshop MCP ergänzt **State-Awareness** (`get_state`, `get_preview`, `get_capabilities`), **Rezept-Werkzeuge**, die mehrstufige Ergebnisse in einem einzigen Undo-Schritt kapseln, sowie **strukturierte Fehler-Envelopes**, sodass Agenten wissen, was als Nächstes zu versuchen ist. Die optionale eigenständige UI und der Action-Plan-Modus reduzieren Round-Trips bei längeren Workflows – sodass natürliche Sprache tatsächlich Pixel erzeugt, anstatt sie nur vorzuschlagen.
+
+Technische Vertiefung: [`docs/architecture.md`](docs/architecture.md).
+
+## 🖥️ Eigenständige UI (kein IDE erforderlich)
+
+Keine Lust, dies in Claude Desktop oder Cursor einzubinden? Dasselbe Paket enthält eine vollständig lokale Web-UI, mit der sich ein KI-Modell anschreiben und Photoshop über diesen MCP-Server steuern lässt. Verbindung per Anbieter-API-Schlüssel **oder**, für Anthropic und Google, Wiederverwendung der OAuth-Sitzung von **Claude Code** oder **Gemini
+CLI** – kein separater API-Schlüssel erforderlich.
+
+![Screenshot der eigenständigen UI](./images/frame_generic_light.png)
+
+```bash
+npx -p @alisaitteke/photoshop-mcp photoshop-mcp-ui
+```
+
+Das war's. Ein lokaler Server startet auf `127.0.0.1` (zufälliger freier Port) und der Standard-Browser öffnet die Chat-UI automatisch.
+
+### Unterstützte Anbieter
+
+Beim ersten Start einen der folgenden Anbieter auswählen – per API-Schlüssel **oder** bestehendem CLI-Abonnementkonto (Anthropic und Google):
+
+| Anbieter | Modelle | API-Schlüssel | CLI-Konto |
+|---|---|---|---|
+| **Anthropic** | Claude Sonnet / Opus / Haiku | [console.anthropic.com](https://console.anthropic.com/settings/keys) | `npm i -g @anthropic-ai/claude-code` → `claude auth login` |
+| **OpenAI** | GPT-5, GPT-4.1, o-series | [platform.openai.com](https://platform.openai.com/api-keys) | — |
+| **Google** | Gemini 2.5 Pro / Flash / Flash-Lite | [aistudio.google.com](https://aistudio.google.com/apikey) | `npm i -g @google/gemini-cli` → `gemini auth login` |
+| **OpenRouter** | 100+ Modelle von beliebigen Anbietern | [openrouter.ai](https://openrouter.ai/keys) | — |
+
+### Authentifizierungsmodi
+
+- **`api_key` (Standard)** — Vercel AI SDK + eigener Anbieter-API-Schlüssel. Die Nutzung wird pro Token zu API-Tarifen abgerechnet; die UI zeigt die geschätzten Kosten pro Chat.
+- **`cli_account`** — Verwendet die lokale OAuth-Sitzung von Claude Code oder Gemini CLI.
+  Es wird kein API-Schlüssel gespeichert; die UI prüft `claude auth status` / `gemini` headless,
+  um die Anmeldung zu verifizieren. Die Nutzung wird dem **Abonnementkontingent** angerechnet, nicht der API-Abrechnung — die Statusleiste zeigt "Included in subscription".
+
+Die Authentifizierungsmethode kann pro Anbieter in den Einstellungen gewechselt werden, ohne das andere Credential zu verlieren (z. B. API-Schlüssel behalten, während das CLI-Konto ausprobiert wird, und dann zurückwechseln).
+
+### Action Plan (Beta)
+
+Ein optionaler Ausführungsmodus in der eigenständigen Web-UI **nur für API-Schlüssel-Authentifizierung**
+(`cli_account` verwendet immer den Standard-Agenten-Fluss). Aktivieren über den
+**Action Plan**-Schalter neben der Modellauswahl im composer.
+
+Statt einer schrittweisen ReAct-Schleife (Modell → Werkzeug → Modell → Werkzeug …) führt Action Plan Folgendes durch:
+
+1. **Einen** Planungs-LLM-Aufruf, der eine geordnete Aufgabenliste mit
+   Photoshop-MCP-Tool-Aufrufen und Parametern ausgibt.
+2. Führt diese Werkzeuge **direkt** nacheinander aus – keine zusätzlichen Modell-Round-Trips
+   zwischen den Schritten.
+3. Bei einem fehlgeschlagenen Schritt oder einer ungelösten Abhängigkeit läuft eine begrenzte **Reparatur**-Schleife
+   (plant nur die verbleibenden Schritte neu, bis zu 3 Mal).
+
+Der Plan erscheint als Live-Aufgabenliste über den Tool-Aufruf-Karten mit schrittweisem
+Status (`pending` → `running` → `done` / `error`). Pläne werden im Chatverlauf gespeichert und überleben Seitenneuladungen. Der Schalter ist standardmäßig deaktiviert; der bestehende
+Agenten-Fluss bleibt unverändert, wenn Action Plan deaktiviert ist.
+
+Geeignet für mehrstufige Prompts wie *„Hintergrund entfernen und für Web exportieren"*,
+bei denen weniger Modellaufrufe und eine schnellere End-to-End-Ausführung erwünscht sind.
+
+### Was beim ersten Start passiert
+
+1. Anbieter wählen und **API key** oder **Uses your account** auswählen.
+2. Schlüssel validieren oder CLI-Verbindung prüfen. Die Konfiguration wird lokal unter
+   `~/.photoshop-mcp/data.db` gespeichert (SQLite, `chmod 600`). API-Schlüssel verlassen die eigene Maschine nie; der CLI-Modus erbt OAuth von `~/.claude/` oder `~/.gemini/`.
+3. Prompts in natürlicher Sprache eingeben. Die UI streamt die Modellantwort, führt
+   Photoshop-Tool-Aufrufe in Echtzeit aus und rendert jeden Tool-Aufruf als überprüfbare Karte (Eingabe + Ergebnis).
+4. Anbieter, Authentifizierungsmethode oder Modell jederzeit über Einstellungen / Modellauswahl wechseln
+   — Chats, Kosten und Werkzeugverlauf werden sitzungsübergreifend gespeichert.
+
+### Authentifizierungsmethode später wechseln
+
+**Einstellungen** jederzeit über die Seitenleiste öffnen:
+
+| Aktion | API-Schlüssel-Modus | CLI-Konto-Modus |
+|---|---|---|
+| Einrichten | Schlüssel einfügen → **Save** | CLI installieren → `auth login` → **Check connection** |
+| Wechseln | **API key** wählen — gespeicherter Schlüssel bleibt erhalten | **Uses your account** wählen — Schlüssel wird nicht gelöscht |
+| Benutzerdefinierter Pfad | — | Optionaler **CLI path**, falls `claude` / `gemini` nicht im `PATH` |
+| Kostenanzeige | Schätzung pro Token in der Statusleiste | **Included in subscription**-Badge |
+
+Die Authentifizierungsmethode wird pro Anbieter in `~/.photoshop-mcp/data.db` gespeichert (`authMethod`:
+`api_key` oder `cli_account`). Bestehende Konfigurationen ohne `authMethod` verwenden standardmäßig
+`api_key` und funktionieren unverändert weiter.
+
+### CLI-Optionen
+
+```
+photoshop-mcp-ui [--port 5174] [--host 127.0.0.1] [--no-open]
+```
+
+### Hinweise
+
+- Der Agent ist auf Photoshop-MCP-Werkzeuge beschränkt – integrierte Shell-, Datei-
+  und Web-Werkzeuge sind deaktiviert.
+- Tech-Stack: Vue 3 + Tailwind v4 + [shadcn-vue](https://www.shadcn-vue.com/)
+  im Frontend; [Hono](https://hono.dev/) im Backend. Der API-Schlüssel-Modus verwendet
+  das [Vercel AI SDK](https://sdk.vercel.ai/); der CLI-Konto-Modus verwendet das
+  [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/mcp) (Anthropic)
+  oder Gemini CLI headless `stream-json` (Google). Alle Pfade kommunizieren mit diesem
+  Photoshop-MCP-Server über STDIO.
+- **CLI-Konto-Einschränkungen:** Gemini headless öffnet möglicherweise bei jedem Schritt eine neue Sitzung
+  (der Verlauf wird dem Prompt vorangestellt). Das Anthropic-CLI-Konto verbraucht
+  Abonnementkontingent. OAuth-Login ist vorrangig für macOS (`claude auth login` /
+  `gemini auth login` im Terminal).
+
+---
+
+## KI/Prompt-Schicht für Photoshop
+
+Über die atomaren `photoshop_*`-Werkzeuge hinaus liefert der Server eine KI/Prompt-Schicht,
+die Host-LLMs (Cursor, Claude Desktop usw.) dabei unterstützt, vage Benutzeranfragen in
+zuverlässige Photoshop-Aktionen zu übersetzen:
+
+- **Server-`instructions`** — Workflow-Vertrag, der beim MCP-`initialize` bekannt gegeben wird
+  (einmalig pingen, Zustand vor Aktion, Rezepte bevorzugen, Fehlerbehandlung). Siehe
+  [`src/prompts/instructions.ts`](src/prompts/instructions.ts).
+- **MCP-`prompts`-Primitiv** — 19 vorgefertigte Templates (12 Rezept + 7 Leitfaden:
+  `ps.enhance_portrait`, `ps.remove_background`, `ps.generative_fill`, …)
+  über `prompts/list` und `prompts/get`.
+- **Rezept-Werkzeuge** — 12 ergebnisorientierte `photoshop_recipe_*`-Werkzeuge (Hintergrund entfernen,
+  Porträt aufwerten, für Web vorbereiten, Social-Varianten exportieren, Farbkorrektur,
+  Frequenztrennung, Batch-Mockup, Ebenen organisieren, Verlaufsüberblendung,
+  Himmelaustausch, Dodge & Burn, Störobjekt entfernen). Jedes fasst Schritte in einem einzigen
+  Photoshop-Verlaufsstatus zusammen (ein Rückgängig macht alles rückgängig). **86 Werkzeuge insgesamt** (74 atomar + 12 Rezept).
+- **Generative KI** — `photoshop_generative_fill`, `photoshop_generative_remove`,
+  `photoshop_generative_expand`, `photoshop_generative_upscale`, `photoshop_sky_replacement`,
+  `photoshop_generate_image` (Firefly über ExtendScript; Adobe-Konto + Credits erforderlich).
+- **Neuronale Filter** — `photoshop_neural_filter` über optionales UXP-Bridge-Plugin (`uxp-plugin/`).
+- **Status & Vorschau** — `photoshop_get_state` (günstige Momentaufnahme),
+  `photoshop_get_preview` (Base64-JPEG zur visuellen Überprüfung),
+  `photoshop_get_capabilities` (versionsabhängige Feature-Flags).
+- **Strukturierte Fehler** — Fehler geben JSON-Envelopes mit `code` und
+  `suggested_next_tool` zur Selbstkorrektur zurück.
+
+Vollständige Referenz: [`docs/prompt-layer.md`](docs/prompt-layer.md).
+
+Parität prüfen: `npm run verify:photoshop-prompts`. Aktuelle Ergebnisse:
+[`docs/development.md#integration-test-results`](docs/development.md#integration-test-results).
+
+## Beispiel-Prompts
+
+Nachfolgend finden sich Beispiel-Prompts zur Verwendung mit KI-Assistenten (Claude, Cursor usw.),
+wenn dieser MCP-Server konfiguriert ist. Für mehrstufige Ergebnisse **Rezept-Werkzeuge** (`photoshop_recipe_*`)
+bevorzugen — jedes Rezept ist ein einziger Undo-Schritt. Atomare `photoshop_*`-Werkzeuge
+nur für feinkörnige Bearbeitungen verwenden, die kein Rezept abdeckt.
+
+<details>
+<summary>🧠 Zustandsbewusstes Arbeiten (empfohlener erster Schritt)</summary>
+
+```
+Photoshop anpingen und die Fähigkeiten für die installierte Version auslesen.
+Den aktuellen Dokumentzustand abrufen, bevor Änderungen vorgenommen werden.
+portrait.jpg öffnen und eine verkleinerte Vorschau abrufen, um das Motiv zu prüfen.
+Nach jedem wichtigen Rezept eine weitere Vorschau abrufen, um das Ergebnis zu bestätigen.
+```
+
+</details>
+
+<details>
+<summary>👤 Porträt-Retusche (Rezept)</summary>
+
+```
+Das Porträt auf der aktiven Ebene mit mittlerer Intensität und Hautglättung aufwerten.
+Das enhance-portrait recipe verwenden — ich möchte Frequenztrennung + Auto-Tonwerte in einem einzigen rückgängig machbaren Schritt.
+Wenn die aktive Ebene Text oder ein Smart Object ist, zuerst rastern oder eine Rasterebene auswählen.
+Nach Abschluss eine Vorschau zeigen.
+```
+
+Entsprechendes MCP-Prompt-Template: `ps.enhance_portrait` mit `{ intensity: "medium", skin_smoothing: "true" }`.
+
+</details>
+
+<details>
+<summary>✂️ Hintergrundentfernung (Rezept)</summary>
+
+```
+Den Hintergrund von der aktiven Porträtebene entfernen.
+Select Subject + eine Ebenenmaske mit 2 Pixel Weichzeichnung verwenden. Die Originalpixel hinter der Maske beibehalten.
+Falls der Briefing reinweiß RGB(255,255,255) verlangt, Motiv zentrieren und mindestens 70 % der Bildfläche einnehmen lassen.
+Das Motiv muss auf der aktiven Ebene liegen — keine einfarbige Füllfläche.
+```
+
+Entsprechendes MCP-Prompt-Template: `ps.remove_background` mit `{ feather_px: "2", keep_shadow: "false" }`.
+
+</details>
+
+<details>
+<summary>🎨 Farbkorrektur (Rezept)</summary>
+
+```
+Eine warme Film-Farbkorrektur auf das geöffnete Dokument als nicht-destruktive Einstellungsebenen anwenden.
+Das apply-color-grade recipe mit dem Preset warm_film verwenden.
+Das Ergebnis nach Abschluss in der Vorschau anzeigen.
+```
+
+</details>
+
+<details>
+<summary>🔬 Frequenztrennung einrichten (Rezept)</summary>
+
+```
+Frequenztrennung auf der aktiven Rasterebene mit einem Weichzeichnungsradius von 6 Pixeln einrichten.
+Ich werde selbst auf den Low- und High-Ebenen malen — keine zusätzliche Glättung anwenden.
+Mir mitteilen, welche Ebenen bearbeitet werden sollen, wenn der Ebenen-Stack bereit ist.
+```
+
+Entsprechendes MCP-Prompt-Template: `ps.frequency_separation` mit `{ radius_px: "6" }`.
+
+</details>
+
+<details>
+<summary>🌐 Für Web vorbereiten + Social-Export (Rezepte)</summary>
+
+```
+Das aktive Dokument für das Web vorbereiten: sRGB, verkleinern, schärfen, ein optimiertes JPEG nach ~/.photoshop-mcp/exports exportieren.
+Dann Instagram-Feed (1080×1350), Story/Reels (1080×1920), LinkedIn (1200×628) und X-Post (1200×675) als separate JPEGs exportieren.
+Die Ausgabepfade in einer Tabelle auflisten.
+```
+
+Entsprechende Templates: `ps.prepare_for_web`, `ps.export_social_variants`.
+
+</details>
+
+<details>
+<summary>📦 Batch-Mockup-Ersetzung (Rezept)</summary>
+
+```
+Ich habe ein Mockup-PSD geöffnet mit einer Smart Object-Ebene namens „Screen".
+Jedes PNG/JPG aus ~/assets/mockups/ ersetzen und ein JPEG pro Asset exportieren.
+Keine flachen Ebenen platzieren — das Smart Object tauschen, damit die Perspektive erhalten bleibt.
+```
+
+Entsprechendes MCP-Prompt-Template: `ps.batch_mockup_replace`.
+
+</details>
+
+<details>
+<summary>🗂️ Ebenen organisieren (Rezept)</summary>
+
+```
+Den Ebenen-Stack organisieren: nach Typ umbenennen, verwandte Ebenen automatisch gruppieren, Originale beibehalten.
+Das organize-layers recipe ausführen, dann die Ebenen auflisten, damit ich die neue Struktur überprüfen kann.
+```
+
+</details>
+
+<details>
+<summary>🎨 Einfaches Design erstellen</summary>
+
+```
+Ein 1920×1080-Photoshop-Dokument im RGB-Farbmodus erstellen.
+Eine hellblaue Hintergrundebene hinzufügen und mit RGB(240, 248, 255) füllen.
+Zentrierten Text „Welcome" in 64pt Schriftgröße hinzufügen.
+Als welcome.psd auf dem Schreibtisch speichern.
+```
+
+</details>
+
+<details>
+<summary>🖼️ Stock-Bild-Design (mit Pexels MCP)</summary>
+
+```
+Bei Pexels nach „mountain sunset"-Bildern suchen.
+Ein 1920×1080-Photoshop-Dokument erstellen.
+Das heruntergeladene Bild platzieren und so anpassen, dass es die gesamte Leinwand ausfüllt.
+Einen subtilen Gaußschen Weichzeichner von 3 Pixeln anwenden.
+Helligkeit um 15 und Kontrast um 10 erhöhen.
+Weißen Text „Adventure Awaits" in 72pt oben mittig hinzufügen.
+Textdeckkraft auf 90 % und Mischmodus auf OVERLAY setzen.
+Als adventure.jpg mit Qualität 10 speichern.
+```
+
+</details>
+
+<details>
+<summary>✨ Fotobearbeitung</summary>
+
+```
+photo.jpg vom Schreibtisch in Photoshop öffnen.
+Zustand abrufen, dann das enhance-portrait recipe mit niedriger Intensität ausführen.
+Falls nur schnelle Tonwertkorrekturen benötigt werden, stattdessen Auto-Tonwerte, Auto-Kontrast und Unschärfemaske (120 %, 1,5, 0) auf die aktive Ebene anwenden.
+Farbton um +15 und Sättigung um +15 anpassen, oder prepare-for-web verwenden, wenn der Export bereit ist.
+Als enhanced-photo.jpg mit Qualität 12 speichern.
+```
+
+</details>
+
+<details>
+<summary>🎭 Ebeneneffekte & Blending</summary>
+
+```
+Ein 1200×800-Dokument erstellen.
+Eine neue Ebene namens „Background" hinzufügen und mit RGB(50, 50, 50) füllen.
+logo.png an Position (100, 100) platzieren.
+Die Logo-Ebene auf 50 % ihrer aktuellen Größe skalieren.
+Mischmodus auf SCREEN und Deckkraft auf 85 % setzen.
+Eine weitere Ebene hinzufügen und mit RGB(255, 100, 50) füllen.
+Den Mischmodus dieser Ebene auf MULTIPLY und die Deckkraft auf 60 % setzen.
+Alle sichtbaren Ebenen zusammenführen.
+Als composite.psd speichern.
+```
+
+</details>
+
+<details>
+<summary>📝 Textplakat-Design</summary>
+
+```
+Ein 1080×1350-Hochformatdokument erstellen (Instagram-Story-Größe).
+Eine Ebene hinzufügen und mit der verlaufsähnlichen Farbe RGB(120, 40, 200) füllen.
+Text „SUMMER" an Position (540, 300) in 96pt hinzufügen.
+Textfarbe auf Weiß RGB(255, 255, 255) ändern.
+Textausrichtung auf CENTER setzen.
+Einen weiteren Text „2026" an Position (540, 450) in 128pt, weiße Farbe, hinzufügen.
+Gaußschen Weichzeichner 2px auf die Hintergrundebene anwenden.
+Als summer-poster.png speichern.
+```
+
+</details>
+
+<details>
+<summary>🎬 Stapelverarbeitung</summary>
+
+```
+image1.jpg öffnen.
+Auf 1920×1080 skalieren.
+Auto-Kontrast anwenden.
+Subtiles Schärfen anwenden (Stärke 80 %, Radius 1,0).
+Als processed-1.jpg mit Qualität 10 speichern.
+Ohne das Original zu speichern schließen.
+
+Dasselbe für image2.jpg und image3.jpg wiederholen.
+```
+
+</details>
+
+<details>
+<summary>🖌️ Kreative Bildbearbeitung</summary>
+
+```
+Ein 2000×2000-Quadratdokument erstellen.
+abstract-pattern.jpg platzieren und an das Dokument anpassen.
+Die Ebene duplizieren.
+Auf der Duplikat-Ebene Bewegungsunschärfe bei 45 Grad, Radius 50 Pixel anwenden.
+Mischmodus auf OVERLAY und Deckkraft auf 70 % setzen.
+Zentrierten Text „MOTION" in 120pt Weiß hinzufügen.
+Eine rechteckige Auswahl von (200, 200) bis (1800, 1800) erstellen.
+Die Auswahl umkehren und löschen (um einen Rahmeneffekt zu erzeugen).
+Das Bild reduzieren.
+Als motion-art.jpg speichern.
+```
+
+</details>
+
+<details>
+<summary>🎯 Erweiterter Workflow</summary>
+
+```
+Ein 3000×2000-Dokument mit 300 DPI für den Druck erstellen.
+hero-image.jpg platzieren und an die Leinwand anpassen.
+Die Bildebene duplizieren.
+Die Duplikat-Ebene vollständig entsättigen.
+Mischmodus auf LUMINOSITY und Deckkraft auf 50 % setzen.
+Eine neue Ebene namens „Overlay" erstellen.
+Mit RGB(255, 150, 0) füllen und Mischmodus auf SOFTLIGHT bei 30 % Deckkraft setzen.
+Text „PORTFOLIO" oben mittig bei (1500, 200) in 96pt hinzufügen.
+Textfarbe auf Weiß setzen.
+Untertext „2026 Collection" bei (1500, 320) in 36pt hinzufügen.
+Eine rechteckige Auswahl um den Textbereich erstellen.
+Eine Ebenenmaske auf der Overlay-Ebene erstellen.
+Sichtbare Ebenen zusammenführen.
+Als portfolio-cover.psd speichern.
+Als portfolio-cover.jpg mit Qualität 12 exportieren.
+```
+
+</details>
+
+<details>
+<summary>🔄 Aktionen verwenden</summary>
+
+```
+my-photo.jpg öffnen.
+Die Aktion „Vintage Look" aus dem Set „My Actions" ausführen.
+Helligkeit um -10 anpassen, um leicht abzudunkeln.
+Als vintage-photo.jpg speichern.
+```
+
+</details>
+
+<details>
+<summary>⚡ Benutzerdefinierte Skript-Ausführung</summary>
+
+```
+Diesen benutzerdefinierten ExtendScript-Code ausführen:
+app.beep();
+alert('Processing started!');
+```
+
+</details>
+
+<details>
+<summary>⏮️ Rückgängig/Wiederholen-Operationen</summary>
+
+```
+Gaußschen Weichzeichner 15px auf die aktive Ebene anwenden.
+[Auf Ergebnis warten]
+Das ist eigentlich zu viel Weichzeichnung. Das rückgängig machen.
+Stattdessen Gaußschen Weichzeichner 5px anwenden.
+```
+
+Oder:
+
+```
+Die Verlaufszustände abrufen, um zu sehen, welche Operationen durchgeführt wurden.
+Die letzten 3 Operationen rückgängig machen.
+1 Schritt wiederholen, um eine Operation zurückzubringen.
+```
+
+</details>
+
+<details>
+<summary>🔁 Fehlerbehandlung (strukturierte Envelopes)</summary>
+
+```
+Falls ein Rezept version_unsupported oder generative_unavailable zurückgibt, get_capabilities aufrufen und mitteilen, welche Photoshop-Funktion fehlt.
+Falls ein Werkzeug mit suggested_next_tool fehlschlägt, diesen Hinweis befolgen (z. B. rasterize_layer vor einem nur für Rasterebenen geeigneten Rezept).
+Niemals raten — nach einem Fehler get_state auslesen und den nächsten einzelnen Schritt vorschlagen.
+```
+
+</details>
+
+<details>
+<summary>📱 Social-Media-Formatkit</summary>
+
+```
+Ich habe ein 1:1-Key-Visual-Master (2000×2000 px) geöffnet.
+Bereite das aktive Dokument mit dem prepare-for-web recipe für sRGB vor und exportiere optimierte JPEGs nach ~/.photoshop-mcp/exports.
+Exportiere zusätzlich Instagram-Feed (1080×1350), Story/Reels (1080×1920, obere und untere 250 px als sichere Zone freihalten), LinkedIn (1200×628) und horizontales Banner (1200×628).
+Nutze photoshop_generative_expand nur, wenn das Motiv im 9:16-Format sonst abgeschnitten würde.
+Das Motiv soll mindestens 60 % der Bildfläche einnehmen; Logo oben rechts mit 20 px Abstand.
+Gib alle Ausgabepfade in einer Tabelle aus.
+```
+
+Entsprechende Templates: `ps.prepare_for_web`, `ps.export_social_variants`.
+
+</details>
+
+<details>
+<summary>🖨️ Druckdatenaufbereitung (CMYK / Beschnitt)</summary>
+
+```
+Bereite das aktive Dokument für den Offsetdruck vor:
+RGB nach CMYK konvertieren mit Zielprofil ISO Coated v2, 3 mm Beschnitt an allen Seiten, Auflösung 300 dpi im Endformat prüfen.
+Softproof für das Druckprofil einrichten und auf Farbverschiebungen hinweisen.
+Tiefschwarze Flächen auf C50 M20 Y20 K100 setzen; schwarzen Text nur mit K100.
+Als PDF/X-4 mit eingebettetem Profil exportieren und eine Vorschau anzeigen.
+```
+
+</details>
+
+<details>
+<summary>🛍️ Produktszene mit Generativem Füllen</summary>
+
+```
+Ich habe ein Produkt als PNG mit entferntem Hintergrund auf der aktiven Ebene.
+Erstelle mit photoshop_generative_fill drei unterschiedliche Szenen: Innenraum mit warmem Licht, Außenbereich bei Sonnenuntergang und reflektierende Oberfläche mit Wassertropfen.
+Für jede Variante photoshop_generative_expand auf 1080×1350 (4:5) anwenden und das Produkt zentriert halten.
+Nach jeder Szene eine Vorschau abrufen, um Schatten und Perspektive zu prüfen.
+Bei generative_unavailable get_capabilities aufrufen und mitteilen, was fehlt.
+```
+
+</details>
+
+<details>
+<summary>🎨 Einheitliche Farbkorrektur</summary>
+
+```
+Ich habe 30 Fotos aus demselben Projekt mit unterschiedlichem Licht.
+Wende das apply-color-grade recipe mit dem Preset warm_film als nicht-destruktive Einstellungsebenen an.
+Falls nötig, Kurven und Farbton/Sättigung für einen warmen cineastischen Look anpassen: kühle Schatten, goldene Lichter.
+Bereite eine Aktion vor, die jedes Bild mit 1080 px Breite in sRGB, JPEG Qualität 85, nach ~/.photoshop-mcp/exports/grade/ exportiert.
+Zeige eine Vorher/Nachher-Vorschau an drei repräsentativen Bildern.
+```
+
+Entsprechendes MCP-Template: `ps.apply_color_grade` mit `{ preset: "warm_film" }`.
+
+</details>
+
+<details>
+<summary>🏢 Marken-Mockups im Batch</summary>
+
+```
+Ich habe ein Mockup-PSD mit Smart Objects für Karte, A4-Dokument, Verpackung und Social-Profil geöffnet.
+Ersetze jedes Smart Object mit Assets aus ~/assets/brand/ — Ebenen nicht abflachen, Perspektive und Schatten beibehalten.
+Führe das batch_mockup_replace recipe aus und exportiere ein JPEG pro Variante nach ~/.photoshop-mcp/exports/mockups/.
+Liste alle Ausgabepfade in einer Tabelle.
+```
+
+Entsprechendes Template: `ps.batch_mockup_replace`.
+
+</details>
+
+<details>
+<summary>🏷️ Multivarianten-Export aus einem Master</summary>
+
+```
+Ich habe ein 1:1-Master-Creative und mehrere Logos in ~/assets/logos/.
+Exportiere für jede Variante Story 9:16, Feed 4:5 und Banner 1200×628 aus derselben PSD — Smart Objects für Logo und Text verwenden.
+Benenne die Dateien Variante_Format.jpg und speichere alles in ~/.photoshop-mcp/exports/variants/.
+Bei einem Fehler get_state lesen und nur den nächsten Schritt vorschlagen.
+Am Ende alle Pfade in einer Tabelle auflisten.
+```
+
+</details>
+
+## Funktionen
+
+- **Eigenständige Web-UI** — lokale Chat-Oberfläche (`photoshop-mcp-ui`); API-Schlüssel oder CLI-Abonnement-Authentifizierung pro Anbieter (Anthropic, Google)
+- **Action Plan (Beta)** — opt-in Plan-dann-Ausführen-Modus in der Web-UI (nur API-Schlüssel): ein Planungsaufruf, direkte Werkzeugausführung, begrenzte Reparatur bei Fehler
+- **Funktioniert auf Windows und macOS**
+- **Unterstützt Photoshop 2012–2025+**
+- **ExtendScript-API**: Universelle Kompatibilität über AppleScript/COM-Automatisierung
+- **Automatische Erkennung**: Findet die Photoshop-Installation automatisch
+- **78 Werkzeuge**: 66 atomare `photoshop_*` + 12 Rezept `photoshop_recipe_*`
+- **KI/Prompt-Schicht**: 16 MCP-Prompt-Templates (12 Rezept + 4 Leitfaden), Server-Instructions, Zustand-/Vorschau-/Fähigkeits-Werkzeuge
+- **Dokumentenverwaltung**: Dokumente erstellen, öffnen, speichern, schließen, beschneiden
+- **Ebenenoperationen**: Ebenen erstellen, löschen, duplizieren, zusammenführen, transformieren
+- **Ebeneneigenschaften**: Deckkraft, Mischmodi, Sichtbarkeit, Sperren
+- **Textformatierung**: Schrift, Größe, Farbe, Ausrichtung
+- **Bildplatzierung**: Bilder platzieren, Dateien öffnen, an Dokument anpassen
+- **Filter**: Gaußsche Unschärfe, Schärfen, Rauschen, Bewegungsunschärfe
+- **Farbanpassungen**: Helligkeit/Kontrast, Farbton/Sättigung, Kurven, Automatische Tonwerte/Kontrast
+- **Auswahlen & Masken**: Rechteckige Auswahlen, Motiv auswählen, inhaltsbewusstes Füllen, Verlaufsmaske, Ebenenmasken
+- **Verlaufssteuerung**: Rückgängig/Wiederholen-Operationen, Verlaufszustände anzeigen
+- **Aktionen**: Aufgezeichnete Aktionen ausführen, benutzerdefinierte Skripte ausführen
+- **Automatisches Rastern**: Konvertiert Ebenen automatisch, wenn für Filter erforderlich
+- **Kontext-Tracking**: Gibt nach jeder Operation den Dokument-/Ebenenstatus zurück, damit KI-Assistenten den Überblick behalten
+
+## Installation
+
+### Mit NPX (Empfohlen)
+
+Keine Installation erforderlich! Einfach den MCP-Client konfigurieren:
+
+```bash
+npx @alisaitteke/photoshop-mcp
+```
+
+Für die lokale Entwicklung am Repository: [Aus dem Quellcode](docs/development.md#from-source) im Entwicklungshandbuch.
+
+## Konfiguration
+
+### Für Cursor
+
+Zu den Cursor-Einstellungen (`.cursor/config.json` oder Workspace-Einstellungen) hinzufügen:
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### Für Claude Desktop
+
+Zur Claude Desktop-Konfiguration hinzufügen (`~/Library/Application Support/Claude/claude_desktop_config.json` unter macOS oder `%APPDATA%\Claude\claude_desktop_config.json` unter Windows):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### Umgebungsvariablen
+
+- `PHOTOSHOP_PATH`: (Optional) Benutzerdefinierten Photoshop-Installationspfad angeben
+- `LOG_LEVEL`: Protokollierungsstufe (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR)
+- `ANALYTICS_DISABLED`: Auf `1` oder `true` setzen, um anonyme Nutzungsanalysen vollständig zu deaktivieren
+- `POSTHOG_DISABLED`: Veralteter Alias für `ANALYTICS_DISABLED`
+- `ANALYTICS_PROVIDER`: Analytics-Backend — `mixpanel` (Standard) oder `posthog` (rollback)
+- `MIXPANEL_TOKEN`: (Optional) Mixpanel-Projekt-Token überschreiben
+- `MIXPANEL_API_HOST`: (Optional) Mixpanel-Ingest-Host (Standard: `https://api-eu.mixpanel.com`)
+- `POSTHOG_KEY`: (Optional, veraltet) PostHog-Projekt-Schlüssel — nur verwendet, wenn `ANALYTICS_PROVIDER=posthog`
+- `POSTHOG_API_HOST`: (Optional, veraltet) PostHog-Ingest-Host (Standard: `https://a.alisait.com`)
+- `POSTHOG_UI_HOST`: (Optional, veraltet) PostHog-UI-Host (Standard: `https://eu.posthog.com`)
+
+## Verfügbare Werkzeuge
+
+Vollständige Referenz aller atomaren `photoshop_*`-Werkzeuge (Parameter, Beispiele und Verwendung):
+[`docs/available-tools.md`](docs/available-tools.md).
+
+
+## Kontext-Tracking
+
+Jedes Werkzeug gibt umfassende Kontextinformationen über den aktuellen Photoshop-Zustand zurück, darunter:
+
+- **Dokumentinfo**: Name, Abmessungen, Auflösung, Farbmodus, Ebenenanzahl
+- **Aktive Ebene**: Name, Typ, Deckkraft, Mischmodus, Sichtbarkeit, Sperrzustand
+- **Auswahlstatus**: Ob eine Auswahl aktiv ist
+- **Operationsergebnis**: Details zu den vorgenommenen Änderungen
+
+Dadurch können KI-Assistenten den Überblick behalten über:
+- Welches Dokument aktiv ist
+- An welcher Ebene gearbeitet wird
+- Aktuelle Ebeneneigenschaften (Deckkraft, Mischmodus usw.)
+- Dokumentabmessungen und -einstellungen
+
+**Beispielantwort:**
+```javascript
+{
+  "applied": true,
+  "filter": "Gaussian Blur",
+  "radius": 10,
+  "wasRasterized": true,
+  "context": {
+    "hasDocument": true,
+    "document": {
+      "name": "design.psd",
+      "width": 1920,
+      "height": 1080,
+      "resolution": 72,
+      "colorMode": "RGBColorMode",
+      "layerCount": 3,
+      "hasSelection": false
+    },
+    "activeLayer": {
+      "name": "Background",
+      "kind": "NORMAL",
+      "opacity": 100,
+      "blendMode": "NORMAL",
+      "visible": true,
+      "locked": false,
+      "isBackground": false
+    }
+  }
+}
+```
+
+Dieser Kontext hilft KI-Assistenten, sich über mehrere Befehle hinweg zu merken, mit welchem Dokument und welcher Ebene sie arbeiten.
+
+---
+
+## Plattformspezifische Hinweise
+
+### Windows
+
+- Verwendet COM-Automatisierung zur Kommunikation mit Photoshop
+- Registrierungsbasierte automatische Erkennung von Installationspfaden
+- Unterstützt sowohl 32-Bit- als auch 64-Bit-Versionen
+
+### macOS
+
+- Verwendet AppleScript/OSA für die Photoshop-Kommunikation
+- Spotlight-basierte automatische Erkennung
+- Unterstützt mehrere gleichzeitig installierte Photoshop-Versionen
+- **CLI-Konto-Authentifizierung** (eigenständige UI) ist vorrangig für macOS: `claude auth login` /
+  `gemini auth login` im Terminal ausführen; Zugangsdaten werden unter `~/.claude/` und
+  `~/.gemini/` gespeichert
+
+## Unterstützte Photoshop-Versionen
+
+- **Alle Photoshop-Versionen** (2012–2025+): Verwendet die ExtendScript-API über AppleScript (macOS) oder COM (Windows)
+
+**Wichtiger Hinweis**: Obwohl Photoshop 2022+ UXP für Plugins unterstützt, kann externe Automatisierung über AppleScript/COM nur ExtendScript verwenden. UXP ist für interne Plugins ausgelegt und kann nicht von externen Skripten aufgerufen werden. Daher verwendet dieser MCP-Server ExtendScript für maximale Kompatibilität mit allen Photoshop-Versionen.
+
+## Fehlerbehebung
+
+Häufige Verbindungs-, Skripting- und Protokollierungsprobleme:
+[`docs/troubleshooting.md`](docs/troubleshooting.md).
+
+### Eigenständige UI — CLI-Konto-Authentifizierung
+
+| Symptom | Wahrscheinliche Ursache | Lösung |
+|---|---|---|
+| `cli_not_found` | Claude Code / Gemini CLI nicht installiert | `npm i -g @anthropic-ai/claude-code` oder `npm i -g @google/gemini-cli` |
+| `not_authenticated` | Keine OAuth-Sitzung | `claude auth login` oder `gemini auth login` im Terminal ausführen |
+| `claude` / `gemini` nicht im `PATH` | Benutzerdefinierter Installationsort | Einstellungen → **CLI path** → **Check connection** |
+| Chat funktioniert in IDE, nicht aber in UI (CLI-Modus) | OAuth-Token sind CLI-exklusiv | **CLI-Konto** in der UI verwenden; API-Schlüssel und CLI-Sitzungen sind getrennt |
+| Gemini Multi-Turn wirkt vergesslich | Headless-CLI öffnet möglicherweise bei jedem Schritt eine neue Sitzung | Bekannte Einschränkung; Verlauf wird dem Prompt vorangestellt (MVP) |
+
+## Entwicklung
+
+Einrichtung aus dem Quellcode, Build, Lint, Integrationstests (mit aktuellen Ergebnissen) und Nutzungsbeispiele:
+[`docs/development.md`](docs/development.md).
+
+## Architektur
+
+Systemdesign, Datenfluss, Plattformabstraktion und UI-Agent-Modi:
+[`docs/architecture.md`](docs/architecture.md).
+
+Teilen auf LinkedIn oder in sozialen Medien? [`images/og-social.png`](images/og-social.png) und
+[`docs/social-preview.md`](docs/social-preview.md) für OG-Einrichtung und Post-Text verwenden.
+
+## Mitwirken
+
+Beiträge sind willkommen! Bitte [CONTRIBUTING.md](CONTRIBUTING.md) lesen, bevor eine PR geöffnet wird.
+
+## Über den Maintainer
+
+**[Ali Sait Teke](https://alisait.com)** — Full-Stack-Ingenieur & Softwarearchitekt des KI-Zeitalters
+(Python, Go, Node.js, React, Next.js, Vue).
+
+Dieses Projekt entstand aus einer praktischen Frage: *Wie lässt sich Photoshop zuverlässig durch LLMs steuern, ohne fragile Einzelskripte?* Es wuchs zu einem MCP-Server mit 80 Werkzeugen, einer Rezept-/Prompt-Schicht für zuverlässige Mehrschritt-Workflows und einer lokalen Web-UI heran, damit kreative Arbeit kein IDE erfordert.
+
+**Was dieser Quellcode demonstriert:** TypeScript-Systemdesign, MCP-Protokollintegration,
+plattformübergreifende Desktop-Automatisierung (macOS AppleScript / Windows COM),
+strukturierte Fehlerwiederherstellung für agentische Schleifen und eine produktionsorientierte local-first-UI
+(Vue 3 + Hono + SQLite).
+
+- [Portfolio](https://alisait.com) · [GitHub](https://github.com/alisaitteke) · [LinkedIn](https://www.linkedin.com/in/alisait/)
+
+## Lizenz
+
+MIT
+
+## Anonyme Nutzungsanalyse
+
+Standardmäßig werden anonymisierte, aggregierte Nutzungsereignisse erfasst, um das Produkt zu verbessern. Eine opt-out-Option steht jederzeit zur Verfügung. Vollständige Details:
+[`docs/anonymous-usage-analytics.md`](docs/anonymous-usage-analytics.md).
+
+## Danksagungen
+
+- Entwickelt mit dem [Model Context Protocol SDK](https://github.com/modelcontextprotocol/sdk)
+- Inspiriert von der Adobe-Photoshop-Scripting-Community

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,717 @@
+# Photoshop MCP Server
+
+<p align="center">
+  <a href="https://github.com/alisaitteke/photoshop-mcp">
+    <img src="./images/readme-hero.png" alt="Photoshop MCP — Automatización de Photoshop impulsada por IA" width="100%" />
+  </a>
+</p>
+
+**Idiomas:** [English](README.md) · [简体中文](README.zh-CN.md) · Español · [Deutsch](README.de.md) · [日本語](README.ja.md) · [Türkçe](README.tr.md)
+
+*v1.1+ — flujos de trabajo con recetas, menos intercambios, sesiones más ágiles. La UI independiente incluye **Action Plan (beta)** para ejecuciones de planificar-y-ejecutar.*
+
+> **Nota:** Este es un proyecto no oficial mantenido por la comunidad y no está afiliado ni respaldado por Adobe Inc.
+
+[![npm version](https://img.shields.io/npm/v/@alisaitteke/photoshop-mcp.svg)](https://www.npmjs.com/package/@alisaitteke/photoshop-mcp)
+[![GitHub release](https://img.shields.io/github/v/release/alisaitteke/photoshop-mcp?include_prereleases)](https://github.com/alisaitteke/photoshop-mcp/releases)
+[![Action Plan](https://img.shields.io/badge/Action%20Plan-beta-amber.svg)](#action-plan-beta)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS-lightgrey.svg)]()
+
+Un servidor Model Context Protocol (MCP) que permite a asistentes de IA como Claude y Cursor controlar Adobe Photoshop de forma programática. Esto permite crear diseños, manipular imágenes y automatizar flujos de trabajo de Photoshop mediante comandos en lenguaje natural mientras se trabaja en el IDE — o a través de la **interfaz web independiente** incluida, que admite tanto claves de API como cuentas de suscripción CLI (Claude Code / Gemini CLI). La UI también ofrece un modo **Action Plan (beta)** opt-in que planifica cada paso de Photoshop en una sola llamada al LLM y los ejecuta en un único paso.
+
+## Por qué existe esto
+
+Los diseñadores y desarrolladores quieren controlar Photoshop desde asistentes de IA, pero las llamadas a ExtendScript sin procesar son frágiles: los agentes desperdician tokens en prueba y error, los tipos de capa rompen los filtros y un comando fallido deja el documento en un estado desconocido.
+
+Photoshop MCP añade **conciencia del estado** (`get_state`, `get_preview`, `get_capabilities`), **herramientas de recetas** que encapsulan resultados de varios pasos en un único paso de deshacer, y **envelopes de errores estructurados** para que los agentes sepan qué probar a continuación. La UI independiente opcional y el modo Action Plan reducen los intercambios en flujos de trabajo más extensos — para que el lenguaje natural pueda realmente producir píxeles, no solo sugerirlos.
+
+Análisis técnico detallado: [`docs/architecture.md`](docs/architecture.md).
+
+## 🖥️ UI Independiente (sin IDE requerido)
+
+¿No desea integrarlo con Claude Desktop o Cursor? El mismo paquete incluye una UI web completamente local que permite chatear con un modelo de IA y controlar Photoshop a través de este servidor MCP. Conéctese con una clave de API del proveedor **o**, para Anthropic y Google, reutilice la sesión OAuth de **Claude Code** o **Gemini CLI** — no se requiere una clave de API separada.
+
+![Captura de pantalla de la UI independiente](./images/frame_generic_light.png)
+
+```bash
+npx -p @alisaitteke/photoshop-mcp photoshop-mcp-ui
+```
+
+Eso es todo. Se inicia un servidor local en `127.0.0.1` (puerto libre aleatorio) y el navegador predeterminado abre la UI de chat automáticamente.
+
+### Proveedores admitidos
+
+Elija cualquiera de los siguientes en el primer inicio — use una clave de API **o** su cuenta de suscripción CLI existente (Anthropic y Google):
+
+| Proveedor | Modelos | Clave de API | Cuenta CLI |
+|---|---|---|---|
+| **Anthropic** | Claude Sonnet / Opus / Haiku | [console.anthropic.com](https://console.anthropic.com/settings/keys) | `npm i -g @anthropic-ai/claude-code` → `claude auth login` |
+| **OpenAI** | GPT-5, GPT-4.1, o-series | [platform.openai.com](https://platform.openai.com/api-keys) | — |
+| **Google** | Gemini 2.5 Pro / Flash / Flash-Lite | [aistudio.google.com](https://aistudio.google.com/apikey) | `npm i -g @google/gemini-cli` → `gemini auth login` |
+| **OpenRouter** | 100+ modelos de cualquier proveedor | [openrouter.ai](https://openrouter.ai/keys) | — |
+
+### Modos de autenticación
+
+- **`api_key` (predeterminado)** — Vercel AI SDK + su clave de API del proveedor. El uso se factura por token a las tarifas de API; la UI muestra el costo estimado por chat.
+- **`cli_account`** — Usa su sesión OAuth local de Claude Code o Gemini CLI. No se almacena ninguna clave de API; la UI verifica `claude auth status` / `gemini` en modo headless para confirmar el inicio de sesión. El uso se descuenta de su **cuota de suscripción**, no de la facturación de API — la barra de estado muestra "Incluido en la suscripción".
+
+Es posible cambiar el método de autenticación por proveedor en Configuración sin perder las demás credenciales (por ejemplo, conservar una clave de API mientras se prueba la cuenta CLI y luego volver a cambiar).
+
+### Action Plan (beta)
+
+Un modo de ejecución opcional en la UI web independiente solo para **autenticación con clave de API** (`cli_account` siempre usa el flujo agéntico predeterminado). Actívelo con el interruptor **Action Plan** junto al selector de modelos en el composer.
+
+En lugar de un bucle ReAct por paso (modelo → herramienta → modelo → herramienta …), Action Plan:
+
+1. Realiza **una** llamada de planificación al LLM que genera una lista de tareas ordenada de llamadas a herramientas de Photoshop MCP con parámetros.
+2. Ejecuta esas herramientas **directamente** en secuencia — sin intercambios de modelos adicionales entre pasos.
+3. Si un paso falla o hay una dependencia no resuelta, ejecuta un bucle de **reparación** acotado (replanifica solo los pasos restantes, hasta 3 veces).
+
+El plan aparece como una lista de tareas en tiempo real sobre las tarjetas de llamadas a herramientas, con estado por paso (`pending` → `running` → `done` / `error`). Los planes se persisten en el historial de chat para que sobrevivan a la recarga. El interruptor está desactivado de forma predeterminada; el flujo agéntico existente no cambia cuando Action Plan está desactivado.
+
+Ideal para prompts de varios pasos como *"eliminar el fondo y exportar para web"*, donde se desean menos llamadas al modelo y una ejecución de principio a fin más rápida.
+
+### Qué sucede en el primer inicio
+
+1. Elija un proveedor y seleccione **Clave de API** o **Uses your account**.
+2. Valide la clave o verifique la conexión CLI. La configuración se almacena localmente en `~/.photoshop-mcp/data.db` (SQLite, `chmod 600`). Las claves de API nunca abandonan el equipo; el modo CLI hereda OAuth de `~/.claude/` o `~/.gemini/`.
+3. Escriba prompts en lenguaje natural. La UI transmite la respuesta del modelo, ejecuta llamadas a herramientas de Photoshop en tiempo real y muestra cada llamada a herramienta como una tarjeta inspeccionable (entrada + resultado).
+4. Cambie de proveedor, método de autenticación o modelo en cualquier momento desde Configuración / selector de modelos — los chats, costos e historial de herramientas se persisten entre sesiones.
+
+### Cambio del método de autenticación posteriormente
+
+Abra **Configuración** desde la barra lateral en cualquier momento:
+
+| Acción | Modo clave de API | Modo cuenta CLI |
+|---|---|---|
+| Configurar | Pegue la clave → **Guardar** | Instale CLI → `auth login` → **Verificar conexión** |
+| Cambiar de modo | Elija **Clave de API** — la clave almacenada se conserva | Elija **Uses your account** — la clave no se elimina |
+| Binario personalizado | — | **Ruta de CLI** opcional si `claude` / `gemini` no está en `PATH` |
+| Visualización de costos | Estimación por token en la barra de estado | Insignia **Incluido en la suscripción** |
+
+El método de autenticación se almacena por proveedor en `~/.photoshop-mcp/data.db` (`authMethod`: `api_key` o `cli_account`). Las configuraciones existentes sin `authMethod` toman `api_key` de forma predeterminada y siguen funcionando sin cambios.
+
+### Opciones de CLI
+
+```
+photoshop-mcp-ui [--port 5174] [--host 127.0.0.1] [--no-open]
+```
+
+### Notas
+
+- El agente está restringido únicamente a las herramientas de Photoshop MCP — las herramientas integradas de shell, archivos y web están deshabilitadas.
+- Stack tecnológico: Vue 3 + Tailwind v4 + [shadcn-vue](https://www.shadcn-vue.com/) en el frontend; [Hono](https://hono.dev/) en el backend. El modo con clave de API utiliza el [Vercel AI SDK](https://sdk.vercel.ai/); el modo de cuenta CLI usa el [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/mcp) (Anthropic) o Gemini CLI headless `stream-json` (Google). Todos los caminos se comunican con este mismo servidor Photoshop MCP a través de STDIO.
+- **Limitaciones de la cuenta CLI:** Gemini en modo headless puede abrir una nueva sesión en cada turno (el historial se antepone al prompt). La cuenta CLI de Anthropic consume cuota de suscripción. El inicio de sesión OAuth es prioritariamente para macOS (`claude auth login` / `gemini auth login` en Terminal).
+
+---
+
+## Capa de IA/Prompt para Photoshop
+
+Además de las herramientas atómicas `photoshop_*`, el servidor incluye una capa de IA/prompt con criterio propio que ayuda a los LLM anfitriones (Cursor, Claude Desktop, etc.) a traducir solicitudes vagas del usuario en acciones de Photoshop confiables:
+
+- **`instructions` del servidor** — contrato de flujo de trabajo anunciado en `initialize` de MCP (ping inicial, estado antes de la acción, preferir recetas, recuperación de errores). Ver [`src/prompts/instructions.ts`](src/prompts/instructions.ts).
+- **Primitiva `prompts` de MCP** — 19 plantillas prediseñadas (12 de recetas + 7 de guía: `ps.enhance_portrait`, `ps.remove_background`, `ps.generative_fill`, …) a través de `prompts/list` y `prompts/get`.
+- **Herramientas de recetas** — 12 herramientas `photoshop_recipe_*` orientadas a resultados (eliminar fondo, mejorar retrato, preparar para web, exportar variantes sociales, gradación de color, separación de frecuencias, mockup por lotes, organizar capas, desvanecimiento con degradado, mezcla de cielo, dodge y burn, eliminar distracción). Cada una encapsula los pasos en un único estado de historial de Photoshop (un Deshacer revierte todo). **86 herramientas en total** (74 atómicas + 12 de recetas).
+- **IA Generativa** — `photoshop_generative_fill`, `photoshop_generative_remove`, `photoshop_generative_expand`, `photoshop_generative_upscale`, `photoshop_sky_replacement`, `photoshop_generate_image` (Firefly mediante ExtendScript; se requiere cuenta de Adobe + créditos).
+- **Filtros neuronales** — `photoshop_neural_filter` mediante el complemento puente UXP opcional (`uxp-plugin/`).
+- **Estado y vista previa** — `photoshop_get_state` (instantánea ligera), `photoshop_get_preview` (JPEG en base64 para verificación visual), `photoshop_get_capabilities` (indicadores de funciones según versión).
+- **Errores estructurados** — los fallos devuelven envelopes JSON con `code` y `suggested_next_tool` para autocorrección.
+
+Referencia completa: [`docs/prompt-layer.md`](docs/prompt-layer.md).
+
+Verifique la paridad: `npm run verify:photoshop-prompts`. Resultados más recientes: [`docs/development.md#integration-test-results`](docs/development.md#integration-test-results).
+
+## Ejemplos de Prompts
+
+A continuación se muestran ejemplos de prompts que puede usar con asistentes de IA (Claude, Cursor, etc.) cuando este servidor MCP esté configurado. Prefiera las **herramientas de recetas** (`photoshop_recipe_*`) para resultados de varios pasos — cada receta es un único paso de deshacer. Use herramientas atómicas `photoshop_*` solo para ediciones precisas que ninguna receta cubra.
+
+<details>
+<summary>🧠 Sesión con conciencia del estado (primer paso recomendado)</summary>
+
+```
+Haz ping a Photoshop y lee las capacidades para mi versión instalada.
+Obtén el estado actual del documento antes de cambiar nada.
+Abre portrait.jpg y obtén una vista previa reducida para verificar el sujeto.
+Después de cada receta principal, obtén otra vista previa para confirmar el resultado.
+```
+
+</details>
+
+<details>
+<summary>👤 Retoque de retrato (receta)</summary>
+
+```
+Mejora el retrato en la capa activa con intensidad media y suavizado de piel.
+Usa la receta enhance-portrait — quiero separación de frecuencias + autotonos en un solo paso deshacer.
+Si la capa activa es de texto o un Objeto inteligente, rasteriza primero o elige una capa rasterizada.
+Muéstrame una vista previa al terminar.
+```
+
+Plantilla de prompt MCP equivalente: `ps.enhance_portrait` con `{ intensity: "medium", skin_smoothing: "true" }`.
+
+</details>
+
+<details>
+<summary>✂️ Eliminación de fondo (receta)</summary>
+
+```
+Elimina el fondo de la capa de retrato activa.
+Usa Seleccionar sujeto + una máscara de capa con difuminado de 2px. Mantén los píxeles originales detrás de la máscara.
+Si el brief pide fondo blanco puro, coloca RGB(255,255,255) y centra el sujeto al 70 % del encuadre.
+El sujeto debe estar en la capa activa — no en un relleno de color plano.
+```
+
+Plantilla de prompt MCP equivalente: `ps.remove_background` con `{ feather_px: "2", keep_shadow: "false" }`.
+
+</details>
+
+<details>
+<summary>🎨 Gradación de color (receta)</summary>
+
+```
+Aplica una gradación de color de película cálida al documento abierto como capas de ajuste no destructivas.
+Usa la receta apply-color-grade con el preset warm_film.
+Previsualiza el resultado al terminar.
+```
+
+</details>
+
+<details>
+<summary>🔬 Configuración de separación de frecuencias (receta)</summary>
+
+```
+Configura la separación de frecuencias en la capa rasterizada activa con un radio de desenfoque de 6px.
+Yo pintaré en las capas Low y High por mi cuenta — no apliques suavizado adicional.
+Dime qué capas editar cuando el stack esté listo.
+```
+
+Plantilla de prompt MCP equivalente: `ps.frequency_separation` con `{ radius_px: "6" }`.
+
+</details>
+
+<details>
+<summary>🌐 Preparar para web + exportación social (recetas)</summary>
+
+```
+Prepara el documento activo para web: sRGB, reducir tamaño, enfocar, exportar un JPEG optimizado a ~/.photoshop-mcp/exports.
+Luego exporta variantes para post de Instagram (1080×1080), Feed vertical (1080×1350), Stories/Reels (1080×1920) y post de X (1200×675) desde el mismo documento.
+Lista las rutas de salida en una tabla.
+```
+
+Plantillas equivalentes: `ps.prepare_for_web`, `ps.export_social_variants`.
+
+</details>
+
+<details>
+<summary>📦 Reemplazo de mockup por lotes (receta)</summary>
+
+```
+Tengo un PSD de mockup abierto con una capa de Objeto inteligente llamada "Screen".
+Reemplázala con cada PNG/JPG en ~/assets/mockups/ y exporta un JPEG por recurso.
+No coloques capas planas — intercambia el Objeto inteligente para preservar la perspectiva.
+```
+
+Plantilla de prompt MCP equivalente: `ps.batch_mockup_replace`.
+
+</details>
+
+<details>
+<summary>🗂️ Organizar capas (receta)</summary>
+
+```
+Organiza el stack de capas: renombra por tipo, agrupa automáticamente las capas relacionadas y conserva los originales.
+Ejecuta la receta organize-layers y luego lista las capas para que pueda revisar la nueva estructura.
+```
+
+</details>
+
+<details>
+<summary>🎨 Creación de diseño básico</summary>
+
+```
+Crea un documento de Photoshop de 1920x1080 en modo de color RGB.
+Añade una capa de fondo azul claro y rellénala con RGB(240, 248, 255).
+Añade texto centrado "Welcome" en fuente de 64pt.
+Guarda como welcome.psd en el Escritorio.
+```
+
+</details>
+
+<details>
+<summary>🖼️ Diseño con imagen de stock (con Pexels MCP)</summary>
+
+```
+Busca imágenes de "mountain sunset" en Pexels.
+Crea un documento de Photoshop de 1920x1080.
+Coloca la imagen descargada y ajústala para llenar todo el lienzo.
+Aplica un desenfoque gaussiano sutil de 3px.
+Aumenta el brillo en 15 y el contraste en 10.
+Añade texto blanco "Adventure Awaits" centrado en la parte superior en 72pt.
+Establece la opacidad del texto al 90% y el modo de fusión en OVERLAY.
+Guarda como adventure.jpg con calidad 10.
+```
+
+</details>
+
+<details>
+<summary>✨ Mejora de fotografías</summary>
+
+```
+Abre photo.jpg desde el Escritorio en Photoshop.
+Obtén el estado y luego ejecuta la receta enhance-portrait con intensidad baja.
+Si solo necesito ajustes de tono rápidos, aplica niveles automáticos, contraste automático y máscara de enfoque (120%, 1.5, 0) en la capa activa.
+Ajusta el tono +15 y la saturación +15, o usa prepare-for-web cuando esté listo para exportar.
+Guarda como enhanced-photo.jpg con calidad 12.
+```
+
+</details>
+
+<details>
+<summary>🎭 Efectos de capa y mezcla</summary>
+
+```
+Crea un documento de 1200x800.
+Añade una nueva capa llamada "Background" y rellena con RGB(50, 50, 50).
+Coloca logo.png en la posición (100, 100).
+Ajusta la capa del logo al 50% de su tamaño actual.
+Establece el modo de fusión en SCREEN y la opacidad al 85%.
+Añade otra capa y rellena con RGB(255, 100, 50).
+Establece el modo de fusión de esta capa en MULTIPLY y la opacidad al 60%.
+Combina todas las capas visibles.
+Guarda como composite.psd.
+```
+
+</details>
+
+<details>
+<summary>📝 Diseño de cartel de texto</summary>
+
+```
+Crea un documento vertical de 1080x1350 (tamaño de historia de Instagram).
+Añade una capa y rellena con el color RGB(120, 40, 200) similar a un degradado.
+Añade texto "SUMMER" en la posición (540, 300) en 96pt.
+Cambia el color del texto a blanco RGB(255, 255, 255).
+Establece la alineación del texto en CENTER.
+Añade otro texto "2026" en (540, 450) en 128pt, color blanco.
+Aplica desenfoque gaussiano de 2px a la capa de fondo.
+Guarda como summer-poster.png.
+```
+
+</details>
+
+<details>
+<summary>🎬 Procesamiento por lotes</summary>
+
+```
+Abre image1.jpg.
+Redimensiona a 1920x1080.
+Aplica contraste automático.
+Aplica enfoque sutil (cantidad 80%, radio 1.0).
+Guarda como processed-1.jpg con calidad 10.
+Cierra sin guardar cambios en el original.
+
+Repite para image2.jpg e image3.jpg.
+```
+
+</details>
+
+<details>
+<summary>🖌️ Manipulación creativa</summary>
+
+```
+Crea un documento cuadrado de 2000x2000.
+Coloca abstract-pattern.jpg y ajústalo para llenar el documento.
+Duplica la capa.
+En el duplicado, aplica desenfoque de movimiento a 45 grados, radio 50px.
+Establece el modo de fusión en OVERLAY y la opacidad al 70%.
+Añade texto centrado "MOTION" en blanco de 120pt.
+Aplica una selección rectangular de (200, 200) a (1800, 1800).
+Invierte la selección y elimínala (para crear un efecto de borde).
+Aplana la imagen.
+Guarda como motion-art.jpg.
+```
+
+</details>
+
+<details>
+<summary>🎯 Flujo de trabajo avanzado</summary>
+
+```
+Crea un documento de 3000x2000 a 300 DPI para impresión.
+Coloca hero-image.jpg y ajústalo para llenar el lienzo.
+Duplica la capa de imagen.
+En el duplicado, desatura completamente.
+Establece el modo de fusión en LUMINOSITY y la opacidad al 50%.
+Crea una nueva capa llamada "Overlay".
+Rellena con RGB(255, 150, 0) y establece el modo de fusión en SOFTLIGHT con opacidad al 30%.
+Añade texto "PORTFOLIO" en la parte superior centrado en (1500, 200) en 96pt.
+Establece el color del texto en blanco.
+Añade subtexto "2026 Collection" en (1500, 320) en 36pt.
+Crea una selección rectangular alrededor del área de texto.
+Crea una máscara de capa en la capa overlay.
+Combina las capas visibles.
+Guarda como portfolio-cover.psd.
+Exporta como portfolio-cover.jpg con calidad 12.
+```
+
+</details>
+
+<details>
+<summary>🔄 Uso de acciones</summary>
+
+```
+Abre my-photo.jpg.
+Ejecuta la acción "Vintage Look" del conjunto "My Actions".
+Ajusta el brillo en -10 para oscurecer ligeramente.
+Guarda como vintage-photo.jpg.
+```
+
+</details>
+
+<details>
+<summary>⚡ Ejecución de scripts personalizados</summary>
+
+```
+Ejecuta este código ExtendScript personalizado:
+app.beep();
+alert('Processing started!');
+```
+
+</details>
+
+<details>
+<summary>⏮️ Operaciones de deshacer/rehacer</summary>
+
+```
+Aplica desenfoque gaussiano de 15px a la capa activa.
+[Esperar resultado]
+En realidad, es demasiado desenfoque. Deshaz eso.
+Aplica desenfoque gaussiano de 5px en su lugar.
+```
+
+O bien:
+
+```
+Obtén los estados del historial para ver qué operaciones se realizaron.
+Deshaz las últimas 3 operaciones.
+Rehaz 1 paso para recuperar una operación.
+```
+
+</details>
+
+<details>
+<summary>🔁 Recuperación de errores (envelopes estructurados)</summary>
+
+```
+Si una receta devuelve version_unsupported o generative_unavailable, llama a get_capabilities y dime qué función de Photoshop falta.
+Si una herramienta falla con suggested_next_tool, sigue esa sugerencia (p. ej. rasterize_layer antes de una receta solo para capas rasterizadas).
+Nunca adivines — lee get_state después de un fallo y propón el siguiente paso único.
+```
+
+</details>
+
+<details>
+<summary>📱 Kit de formatos para redes sociales</summary>
+
+```
+Tengo un maestro visual 1:1 (2000×2000 px) abierto.
+Prepara el documento activo para web: sRGB, recortar y exportar variantes con el recipe prepare-for-web.
+Luego exporta variantes para Instagram Feed (1080×1350), Stories/Reels (1080×1920 con zona segura superior e inferior), LinkedIn (1200×628) y banner horizontal (1200×628).
+Usa Ampliación generativa solo si hace falta para 9:16 sin perder el sujeto en el encuadre.
+El sujeto debe ocupar al menos el 60 % del área visual; el logo en la esquina superior derecha con 20 px de margen.
+Lista las rutas de salida en una tabla.
+```
+
+Plantillas equivalentes: `ps.prepare_for_web`, `ps.export_social_variants`.
+
+</details>
+
+<details>
+<summary>🖨️ Arte final para impresión (CMYK / sangrado)</summary>
+
+```
+Prepara el documento activo para impresión offset:
+convierte a CMYK con perfil ISO Coated v2, añade 3 mm de sangrado, comprueba la resolución a 300 ppp en tamaño final.
+Configura prueba en pantalla para el perfil de impresión y avísame si hay colores fuera de gamut.
+Las áreas de negro profundo deben ir a C50 M20 Y20 K100; el texto negro solo en K100.
+Exporta un PDF/X-4 listo para imprenta y muéstrame una vista previa antes de cerrar.
+```
+
+</details>
+
+<details>
+<summary>🛍️ Escena de producto con Relleno Generativo</summary>
+
+```
+Tengo un producto en PNG con fondo eliminado sobre la capa activa.
+Con photoshop_generative_fill crea tres escenarios distintos: interior con luz cálida, exterior al atardecer y superficie reflectante con gotas de agua.
+Para cada variante usa photoshop_generative_expand hasta 1080×1350 (4:5) manteniendo el producto centrado.
+Después de cada escena, obtén una vista previa para comprobar sombras y perspectiva.
+Si generative_unavailable, llama a get_capabilities y dime qué falta.
+```
+
+</details>
+
+<details>
+<summary>🎨 Gradación de color unificada</summary>
+
+```
+Tengo 30 fotos del mismo proyecto con luces distintas.
+Aplica el recipe apply-color-grade con preset warm_film como capas de ajuste no destructivas.
+Si hace falta, ajusta Curvas y Tono/Saturación para un look cinematográfico cálido: sombras frías, altas luces doradas.
+Prepara una Acción que exporte cada imagen a 1080 px de ancho en sRGB, JPEG calidad 85, en ~/.photoshop-mcp/exports/grade/.
+Muéstrame una vista previa del antes/después en tres imágenes representativas.
+```
+
+Equivalente MCP: `ps.apply_color_grade` con `{ preset: "warm_film" }`.
+
+</details>
+
+<details>
+<summary>🏢 Mockups de marca por lotes</summary>
+
+```
+Tengo un mockup PSD abierto con Smart Objects para tarjeta, documento A4, packaging y perfil social.
+Sustituye cada Smart Object con los assets de ~/assets/brand/ sin aplanar capas — conserva perspectiva y sombras.
+Ejecuta el recipe batch_mockup_replace para exportar un JPEG por variante en ~/.photoshop-mcp/exports/mockups/.
+Lista las rutas finales en una tabla.
+```
+
+Plantilla equivalente: `ps.batch_mockup_replace`.
+
+</details>
+
+<details>
+<summary>🏷️ Exportación multivariante desde un maestro</summary>
+
+```
+Tengo un creativo maestro 1:1 y varios logos en ~/assets/logos/.
+Para cada variante exporta Story 9:16, Feed 4:5 y banner 1200×628 desde el mismo PSD usando Smart Objects para logo y texto.
+Nombra los archivos Variante_Formato.jpg y guarda todo en ~/.photoshop-mcp/exports/variants/.
+Si un paso falla, lee get_state y propón solo el siguiente paso.
+Al terminar, lista todas las rutas en una tabla.
+```
+
+</details>
+
+## Características
+
+- **UI web independiente** — interfaz de chat local (`photoshop-mcp-ui`); autenticación con clave de API o suscripción CLI por proveedor (Anthropic, Google)
+- **Action Plan (beta)** — modo opt-in de planificar-y-ejecutar en la UI web (solo clave de API): una llamada de planificación, ejecución directa de herramientas, reparación acotada en caso de fallo
+- **Compatible con Windows y macOS**
+- **Admite Photoshop 2012-2025+**
+- **API ExtendScript**: Compatibilidad universal mediante automatización AppleScript/COM
+- **Detección automática**: Detecta automáticamente la instalación de Photoshop en el sistema
+- **78 herramientas**: 66 atómicas `photoshop_*` + 12 de recetas `photoshop_recipe_*`
+- **Capa de IA/Prompt**: 16 plantillas de prompts MCP (12 de recetas + 4 de guía), instrucciones del servidor, herramientas de estado/vista previa/capacidades
+- **Gestión de documentos**: Crear, abrir, guardar, cerrar, recortar documentos
+- **Operaciones de capa**: Crear, eliminar, duplicar, combinar, transformar capas
+- **Propiedades de capa**: Opacidad, modos de mezcla, visibilidad, bloqueo
+- **Formato de texto**: Controles de fuente, tamaño, color y alineación
+- **Colocación de imágenes**: Colocar imágenes, abrir archivos, ajustar al documento
+- **Filtros**: Desenfoque gaussiano, Enfocar, Ruido, Desenfoque de movimiento
+- **Ajustes de color**: Brillo/Contraste, Tono/Saturación, Curvas, Niveles/Contraste automáticos
+- **Selecciones y máscaras**: Selecciones rectangulares, seleccionar sujeto, relleno con reconocimiento de contenido, máscara de degradado, máscaras de capa
+- **Control de historial**: Operaciones de deshacer/rehacer, ver estados del historial
+- **Acciones**: Reproducir acciones grabadas, ejecutar scripts personalizados
+- **Rasterización automática**: Convierte capas automáticamente cuando es necesario para los filtros
+- **Seguimiento de contexto**: Devuelve el estado del documento/capa después de cada operación para la conciencia contextual de la IA
+
+## Instalación
+
+### Uso de NPX (recomendado)
+
+¡No se requiere instalación! Solo configure su cliente MCP:
+
+```bash
+npx @alisaitteke/photoshop-mcp
+```
+
+Para trabajar en el repositorio localmente, consulte [From Source](docs/development.md#from-source) en la guía de desarrollo.
+
+## Configuración
+
+### Para Cursor
+
+Añada a su configuración de Cursor (`.cursor/config.json` o la configuración del espacio de trabajo):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### Para Claude Desktop
+
+Añada a su configuración de Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` en macOS o `%APPDATA%\Claude\claude_desktop_config.json` en Windows):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### Variables de entorno
+
+- `PHOTOSHOP_PATH`: (Opcional) Especifique una ruta de instalación de Photoshop personalizada
+- `LOG_LEVEL`: Nivel de registro (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR)
+- `ANALYTICS_DISABLED`: Establezca en `1` o `true` para deshabilitar completamente el análisis de uso anónimo
+- `POSTHOG_DISABLED`: Alias heredado de `ANALYTICS_DISABLED`
+- `ANALYTICS_PROVIDER`: Backend de análisis — `mixpanel` (predeterminado) o `posthog` (rollback)
+- `MIXPANEL_TOKEN`: (Opcional) Anule el token del proyecto Mixpanel
+- `MIXPANEL_API_HOST`: (Opcional) Host de ingesta de Mixpanel (predeterminado: `https://api-eu.mixpanel.com`)
+- `POSTHOG_KEY`: (Opcional, heredado) Clave del proyecto PostHog — se usa solo cuando `ANALYTICS_PROVIDER=posthog`
+- `POSTHOG_API_HOST`: (Opcional, heredado) Host de ingesta de PostHog (predeterminado: `https://a.alisait.com`)
+- `POSTHOG_UI_HOST`: (Opcional, heredado) Host de UI de PostHog (predeterminado: `https://eu.posthog.com`)
+
+## Herramientas disponibles
+
+Referencia completa de todas las herramientas atómicas `photoshop_*` (parámetros, ejemplos y uso):
+[`docs/available-tools.md`](docs/available-tools.md).
+
+
+## Seguimiento de contexto
+
+Cada herramienta devuelve información de contexto exhaustiva sobre el estado actual de Photoshop, que incluye:
+
+- **Información del documento**: Nombre, dimensiones, resolución, modo de color, recuento de capas
+- **Información de la capa activa**: Nombre, tipo, opacidad, modo de mezcla, visibilidad, estado de bloqueo
+- **Estado de selección**: Si hay una selección activa
+- **Resultado de la operación**: Detalles específicos sobre lo que se modificó
+
+Esto permite a los asistentes de IA mantener conciencia de:
+- Qué documento está activo
+- En qué capa se está trabajando
+- Propiedades actuales de la capa (opacidad, modo de mezcla, etc.)
+- Dimensiones y configuración del documento
+
+**Respuesta de ejemplo:**
+```javascript
+{
+  "applied": true,
+  "filter": "Gaussian Blur",
+  "radius": 10,
+  "wasRasterized": true,
+  "context": {
+    "hasDocument": true,
+    "document": {
+      "name": "design.psd",
+      "width": 1920,
+      "height": 1080,
+      "resolution": 72,
+      "colorMode": "RGBColorMode",
+      "layerCount": 3,
+      "hasSelection": false
+    },
+    "activeLayer": {
+      "name": "Background",
+      "kind": "NORMAL",
+      "opacity": 100,
+      "blendMode": "NORMAL",
+      "visible": true,
+      "locked": false,
+      "isBackground": false
+    }
+  }
+}
+```
+
+Este contexto ayuda a los asistentes de IA a recordar en qué documento y capa están trabajando a lo largo de múltiples comandos.
+
+---
+
+## Notas específicas de la plataforma
+
+### Windows
+
+- Utiliza automatización COM para comunicarse con Photoshop
+- Detección automática basada en el registro para las rutas de instalación
+- Admite versiones de 32 y 64 bits
+
+### macOS
+
+- Utiliza AppleScript/OSA para la comunicación con Photoshop
+- Detección automática basada en Spotlight
+- Admite múltiples versiones de Photoshop instaladas simultáneamente
+- **La autenticación de cuenta CLI** (UI independiente) es prioritariamente para macOS: ejecute `claude auth login` / `gemini auth login` en Terminal; las credenciales se almacenan en `~/.claude/` y `~/.gemini/`
+
+## Versiones de Photoshop admitidas
+
+- **Todas las versiones de Photoshop** (2012-2025+): Utiliza la API ExtendScript mediante AppleScript (macOS) o COM (Windows)
+
+**Nota importante**: Aunque Photoshop 2022+ admite UXP para complementos, la automatización externa mediante AppleScript/COM solo puede usar ExtendScript. UXP está diseñado para complementos internos y no se puede invocar desde scripts externos. Por lo tanto, este servidor MCP utiliza ExtendScript para la máxima compatibilidad con todas las versiones de Photoshop.
+
+## Solución de problemas
+
+Problemas comunes de conexión, scripts y registro:
+[`docs/troubleshooting.md`](docs/troubleshooting.md).
+
+### UI independiente — Autenticación de cuenta CLI
+
+| Síntoma | Causa probable | Solución |
+|---|---|---|
+| `cli_not_found` | Claude Code / Gemini CLI no está instalado | `npm i -g @anthropic-ai/claude-code` o `npm i -g @google/gemini-cli` |
+| `not_authenticated` | Sin sesión OAuth | Ejecute `claude auth login` o `gemini auth login` en Terminal |
+| `claude` / `gemini` no está en `PATH` | Ubicación de instalación personalizada | Configuración → **Ruta de CLI** → **Verificar conexión** |
+| El chat funciona en el IDE pero no en la UI (modo CLI) | Los tokens OAuth son solo para CLI | Use **Cuenta CLI** en la UI; las claves de API y las sesiones CLI son independientes |
+| Gemini en conversaciones de varios turnos parece olvidadizo | El CLI headless puede iniciar una nueva sesión en cada turno | Limitación conocida; el historial se antepone al prompt (MVP) |
+
+## Desarrollo
+
+Configuración desde el código fuente, compilación, linting, pruebas de integración (con los resultados más recientes) y ejemplos de uso:
+[`docs/development.md`](docs/development.md).
+
+## Arquitectura
+
+Diseño del sistema, flujo de datos, abstracción de plataforma y modos de agente de UI:
+[`docs/architecture.md`](docs/architecture.md).
+
+¿Compartir en LinkedIn o redes sociales? Use [`images/og-social.png`](images/og-social.png) y
+[`docs/social-preview.md`](docs/social-preview.md) para la configuración OG y el texto de publicación.
+
+## Contribución
+
+¡Las contribuciones son bienvenidas! Lea [CONTRIBUTING.md](CONTRIBUTING.md) antes de abrir un PR.
+
+## Acerca del mantenedor
+
+**[Ali Sait Teke](https://alisait.com)** — Ingeniero Full-Stack y arquitecto de software para la era de la IA
+(Python, Go, Node.js, React, Next.js, Vue).
+
+Este proyecto surgió de una pregunta práctica: *¿cómo se hace que Photoshop sea controlable de forma confiable por LLMs sin scripts individuales frágiles?* Se convirtió en un servidor MCP con 80 herramientas, una capa de recetas/prompts para flujos de trabajo de varios pasos confiables y una UI web local para que el trabajo creativo no requiera un IDE.
+
+**Lo que demuestra este código fuente:** Diseño de sistemas en TypeScript, integración del protocolo MCP, automatización de escritorio multiplataforma (AppleScript de macOS / COM de Windows), recuperación estructurada de errores para bucles agénticos y una UI local orientada a producción (Vue 3 + Hono + SQLite).
+
+- [Portfolio](https://alisait.com) · [GitHub](https://github.com/alisaitteke) · [LinkedIn](https://www.linkedin.com/in/alisait/)
+
+## Licencia
+
+MIT
+
+## Análisis de uso anónimo
+
+De forma predeterminada se recopilan eventos de uso anónimos y agregados para mejorar el producto. Puede optar por no participar en cualquier momento. Detalles completos:
+[`docs/anonymous-usage-analytics.md`](docs/anonymous-usage-analytics.md).
+
+## Agradecimientos
+
+- Desarrollado con el [Model Context Protocol SDK](https://github.com/modelcontextprotocol/sdk)
+- Inspirado por la comunidad de scripting de Adobe Photoshop

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,712 @@
+# Photoshop MCP Server
+
+<p align="center">
+  <a href="https://github.com/alisaitteke/photoshop-mcp">
+    <img src="./images/readme-hero.png" alt="Photoshop MCP — AIによるPhotoshop自動化" width="100%" />
+  </a>
+</p>
+
+**言語：** [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Deutsch](README.de.md) · [日本語](README.ja.md) · [Türkçe](README.tr.md)
+
+*v1.1+ — レシピワークフロー、ラウンドトリップ削減、軽快なセッション。スタンドアロンUIには計画→実行を担う **Action Plan（ベータ）** が付属しています。*
+
+> **注意：** これは非公式のコミュニティ管理プロジェクトであり、Adobe Inc.との提携・承認関係はありません。
+
+[![npm version](https://img.shields.io/npm/v/@alisaitteke/photoshop-mcp.svg)](https://www.npmjs.com/package/@alisaitteke/photoshop-mcp)
+[![GitHub release](https://img.shields.io/github/v/release/alisaitteke/photoshop-mcp?include_prereleases)](https://github.com/alisaitteke/photoshop-mcp/releases)
+[![Action Plan](https://img.shields.io/badge/Action%20Plan-beta-amber.svg)](#action-plan-beta)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS-lightgrey.svg)]()
+
+モデルコンテキストプロトコル（MCP）サーバーで、ClaudeやCursorなどのAIアシスタントがAdobe Photoshopをプログラム的に操作できます。IDEから自然言語でデザイン作成・画像編集・ワークフロー自動化が可能です。同梱の**スタンドアロンWebUI**ではAPIキーとCLIサブスクリプションアカウント（Claude Code / Gemini CLI）の両方に対応しています。UIにはオプトインの**Action Plan（ベータ）**モードもあり、すべてのPhotoshopステップを1回のLLM呼び出しで計画し、一括実行できます。
+
+## このプロジェクトが存在する理由
+
+デザイナーや開発者はAIアシスタントからPhotoshopを操作したいと考えています。しかし生のExtendScript呼び出しは脆弱で、エージェントが試行錯誤でトークンを浪費し、レイヤータイプがフィルターを壊し、コマンドが1つ失敗するとドキュメントが不明な状態になります。
+
+Photoshop MCPは**状態認識**（`get_state`・`get_preview`・`get_capabilities`）、**レシピツール**（複数ステップの結果を1つのUndo単位にまとめる）、そして**構造化エラーエンベロープ**（エージェントが次の手順を把握できる）を追加します。オプションのスタンドアロンUIとAction Planモードにより、長いワークフローでのラウンドトリップを削減し、自然言語で実際にピクセルを生み出せます。
+
+技術的詳細：[`docs/architecture.md`](docs/architecture.md)
+
+## 🖥️ スタンドアロンUI（IDEは不要）
+
+Claude DesktopやCursorに組み込みたくない場合でも大丈夫です。同じパッケージにフルローカルのWebUIが同梱されており、AIモデルとチャットしてこのMCPサーバー経由でPhotoshopを操作できます。プロバイダーのAPIキーで接続するか、AnthropicとGoogleの場合は**Claude Code**または**Gemini CLI**のOAuthセッションを再利用できます（別途APIキー不要）。
+
+![スタンドアロンUIスクリーンショット](./images/frame_generic_light.png)
+
+```bash
+npx -p @alisaitteke/photoshop-mcp photoshop-mcp-ui
+```
+
+これだけです。`127.0.0.1`（ランダムな空きポート）でローカルサーバーが起動し、デフォルトブラウザにチャットUIが自動で開きます。
+
+### 対応プロバイダー
+
+初回起動時に以下のいずれかを選択します。APIキーまたは既存のCLIサブスクリプションアカウント（AnthropicとGoogle）を使用できます：
+
+| プロバイダー | モデル | APIキー | CLIアカウント |
+|---|---|---|---|
+| **Anthropic** | Claude Sonnet / Opus / Haiku | [console.anthropic.com](https://console.anthropic.com/settings/keys) | `npm i -g @anthropic-ai/claude-code` → `claude auth login` |
+| **OpenAI** | GPT-5, GPT-4.1, o-series | [platform.openai.com](https://platform.openai.com/api-keys) | — |
+| **Google** | Gemini 2.5 Pro / Flash / Flash-Lite | [aistudio.google.com](https://aistudio.google.com/apikey) | `npm i -g @google/gemini-cli` → `gemini auth login` |
+| **OpenRouter** | 100以上のモデル（各プロバイダー） | [openrouter.ai](https://openrouter.ai/keys) | — |
+
+### 認証モード
+
+- **`api_key`（デフォルト）** — Vercel AI SDK＋プロバイダーAPIキー。使用量はAPIレートでトークン単位で請求され、UIにはチャットごとの推定コストが表示されます。
+- **`cli_account`** — Claude CodeまたはGemini CLIのローカルOAuthセッションを使用します。APIキーは保存されず、UIが`claude auth status` / `gemini`をヘッドレスで確認してログインを検証します。使用量はAPI課金ではなく**サブスクリプション枠**に計上されます。ステータスバーには「Included in subscription」と表示されます。
+
+設定でプロバイダーごとに認証方法を切り替えても、もう一方のクレデンシャルは失われません（例：CLIアカウントを試しながらAPIキーを保持し、後で切り替えるなど）。
+
+### Action Plan (beta)
+
+スタンドアロンWebUIのオプション実行モードで、**APIキー認証専用**です（`cli_account`は常にデフォルトのエージェントフローを使用します）。composerのモデルセレクター横にある**Action Plan**トグルで有効にします。
+
+ステップごとのReActループ（モデル → ツール → モデル → ツール …）の代わりに、Action Planは以下を行います：
+
+1. **1回**の計画LLM呼び出しで、Photoshop MCPツール呼び出しとパラメーターの順序付きToDoリストを出力します。
+2. それらのツールを**直接**順番に実行します（ステップ間の追加モデルラウンドトリップなし）。
+3. ステップが失敗した場合や依存関係が未解決の場合、限定的な**修復**ループを実行します（残りのステップを最大3回再計画）。
+
+計画はツール呼び出しカードの上にライブToDoリストとして表示され、ステップごとのステータス（`pending` → `running` → `done` / `error`）が確認できます。計画はチャット履歴に保存され、リロードしても残ります。トグルはデフォルトで無効で、Action Planを無効にしている間は既存のエージェントフローに影響しません。
+
+*「背景を削除してWeb用にエクスポートして」*のようなモデル呼び出しを減らしてエンドツーエンドの実行を高速化したいマルチステッププロンプトに最適です。
+
+### 初回起動時の動作
+
+1. プロバイダーを選択し、**API key**または**Uses your account**を選択します。
+2. キーを検証するかCLI接続を確認します。設定は`~/.photoshop-mcp/data.db`（SQLite、`chmod 600`）にローカル保存されます。APIキーは端末外に出ません。CLIモードはOAuthを`~/.claude/`または`~/.gemini/`から継承します。
+3. 自然言語でプロンプトを入力します。UIはモデルの返答をストリーミングし、Photoshopツール呼び出しをリアルタイムで実行し、各ツール呼び出しを確認可能なカード（入力＋結果）としてレンダリングします。
+4. プロバイダー、認証方法、モデルはいつでも設定／モデルセレクターから変更できます。チャット、コスト、ツール履歴はセッションをまたいで保持されます。
+
+### 認証方法の後からの変更
+
+サイドバーからいつでも**設定**を開いてください：
+
+| 操作 | APIキーモード | CLIアカウントモード |
+|---|---|---|
+| 設定 | キーを貼り付け → **Save** | CLIをインストール → `auth login` → **Check connection** |
+| 切り替え | **API key**を選択（保存済みキーは保持） | **Uses your account**を選択（キーは削除されない） |
+| カスタムバイナリ | — | `claude` / `gemini`が`PATH`にない場合はオプションの**CLI path** |
+| コスト表示 | ステータスバーにトークン単位の見積もり | **Included in subscription**バッジ |
+
+認証方法は`~/.photoshop-mcp/data.db`にプロバイダーごとに保存されます（`authMethod`：`api_key`または`cli_account`）。`authMethod`のない既存の設定は`api_key`がデフォルトとなり、変更なく動作し続けます。
+
+### CLIオプション
+
+```
+photoshop-mcp-ui [--port 5174] [--host 127.0.0.1] [--no-open]
+```
+
+### 注意事項
+
+- エージェントはPhotoshop MCPツールのみに制限されています。組み込みのシェル・ファイル・Webツールは無効化されています。
+- 技術スタック：フロントエンドはVue 3 + Tailwind v4 + [shadcn-vue](https://www.shadcn-vue.com/)、バックエンドは[Hono](https://hono.dev/)。APIキーモードは[Vercel AI SDK](https://sdk.vercel.ai/)を、CLIアカウントモードは[Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/mcp)（Anthropic）またはGemini CLIヘッドレスの`stream-json`（Google）を使用します。すべてのパスはSTDIO経由でこのPhotoshop MCPサーバーと通信します。
+- **CLIアカウントの制限：** Geminiヘッドレスはターンごとに新しいセッションを開始する場合があります（履歴はプロンプトに追記されます）。AnthropicのCLIアカウントはサブスクリプション枠を消費します。OAuthログインはmacOS優先です（ターミナルで`claude auth login` / `gemini auth login`）。
+
+---
+
+## Photoshop向けAI/プロンプトレイヤー
+
+アトミックな`photoshop_*`ツールに加え、サーバーにはホストLLM（Cursor、Claude Desktopなど）があいまいなユーザーリクエストを確実なPhotoshopアクションに変換するためのAI/プロンプトレイヤーが付属しています：
+
+- **サーバー`instructions`** — MCPの`initialize`時にアドバタイズされるワークフロー規約（1回ping、アクション前に状態確認、レシピを優先、エラー回復）。[`src/prompts/instructions.ts`](src/prompts/instructions.ts)を参照。
+- **MCPの`prompts`プリミティブ** — 19個の事前設計済みテンプレート（12レシピ＋7ガイド：`ps.enhance_portrait`・`ps.remove_background`・`ps.generative_fill`など）を`prompts/list`と`prompts/get`で利用可能。
+- **レシピツール** — 12個の成果指向`photoshop_recipe_*`ツール（背景削除、ポートレート強調、Web向け準備、ソーシャル用バリアントエクスポート、カラーグレーディング、周波数分離、バッチモックアップ、レイヤー整理、グラデーションフェード、空の合成、ドッジ＆バーン、邪魔なもの削除）。各ステップは1つのPhotoshop履歴状態にまとめられます（Undoで全ステップを一括取り消し）。**合計86ツール**（アトミック74＋レシピ12）。
+- **生成AI** — `photoshop_generative_fill`・`photoshop_generative_remove`・`photoshop_generative_expand`・`photoshop_generative_upscale`・`photoshop_sky_replacement`・`photoshop_generate_image`（ExtendScript経由のFirefly；Adobeアカウント＋クレジットが必要）。
+- **ニューラルフィルター** — オプションのUXPブリッジプラグイン（`uxp-plugin/`）経由の`photoshop_neural_filter`。
+- **状態とプレビュー** — `photoshop_get_state`（軽量スナップショット）・`photoshop_get_preview`（ビジョン確認用のBase64 JPEG）・`photoshop_get_capabilities`（バージョン対応の機能フラグ）。
+- **構造化エラー** — 失敗時に`code`と`suggested_next_tool`を含むJSONエンベロープを返し、自己修正を支援します。
+
+完全なリファレンス：[`docs/prompt-layer.md`](docs/prompt-layer.md)
+
+パリティ確認：`npm run verify:photoshop-prompts`。最新の結果：[`docs/development.md#integration-test-results`](docs/development.md#integration-test-results)
+
+## プロンプト例
+
+以下はこのMCPサーバーを設定したAIアシスタント（Claude、Cursorなど）で使用できるプロンプト例です。複数ステップの作業には**レシピツール**（`photoshop_recipe_*`）を優先してください。各レシピは1つのUndoステップです。レシピでカバーできない細かい編集にのみアトミックな`photoshop_*`ツールを使用してください。
+
+<details>
+<summary>🧠 状態認識セッション（最初の推奨ステップ）</summary>
+
+```
+Photoshopにpingして、インストール済みバージョンの機能を読み取ってください。
+変更を加える前に現在のドキュメント状態を取得してください。
+portrait.jpgを開き、縮小プレビューを取得して被写体を確認してください。
+主要なレシピを実行するたびに、結果確認のためプレビューをもう一度取得してください。
+```
+
+</details>
+
+<details>
+<summary>👤 ポートレートリタッチ（レシピ）</summary>
+
+```
+アクティブなレイヤーのポートレートを中程度の強度と肌のスムージングで強調してください。
+enhance-portrait recipeを使用してください — 周波数分離＋自動トーンを1つのUndoステップにまとめてください。
+アクティブなレイヤーがテキストまたはSmart Objectの場合は、先にラスタライズするかラスターレイヤーを選んでください。
+完了したらプレビューを表示してください。
+```
+
+対応するMCPプロンプトテンプレート：`ps.enhance_portrait`（`{ intensity: "medium", skin_smoothing: "true" }`）
+
+</details>
+
+<details>
+<summary>✂️ 背景削除（レシピ）</summary>
+
+```
+アクティブなポートレートレイヤーから背景を削除してください。
+Select Subjectとフェザー2pxのレイヤーマスクを使用してください。マスクの後ろにオリジナルのピクセルを保持してください。
+briefでRGB(255,255,255)の白背景が必要な場合は、被写体をセンタリングして画像面積の70%以上を占めるようにしてください。
+被写体はアクティブなレイヤーにある必要があります — べた塗りフィルレイヤーは不可です。
+```
+
+対応するMCPプロンプトテンプレート：`ps.remove_background`（`{ feather_px: "2", keep_shadow: "false" }`）
+
+</details>
+
+<details>
+<summary>🎨 カラーグレーディング（レシピ）</summary>
+
+```
+開いているドキュメントにウォームフィルムのカラーグレードを非破壊調整レイヤーとして適用してください。
+apply-color-grade recipeをプリセットwarm_filmで使用してください。
+完了したら結果をプレビューしてください。
+```
+
+</details>
+
+<details>
+<summary>🔬 周波数分離のセットアップ（レシピ）</summary>
+
+```
+アクティブなラスターレイヤーにブラー半径6pxで周波数分離をセットアップしてください。
+LowレイヤーとHighレイヤーへの描き込みは自分で行います — 追加のスムージングは適用しないでください。
+レイヤースタックの準備ができたら、どのレイヤーを編集すべきか教えてください。
+```
+
+対応するMCPプロンプトテンプレート：`ps.frequency_separation`（`{ radius_px: "6" }`）
+
+</details>
+
+<details>
+<summary>🌐 Web向け準備＋ソーシャルエクスポート（レシピ）</summary>
+
+```
+アクティブなドキュメントをWeb向けに準備してください：sRGB変換、縮小、シャープネス処理を行い、最適化したJPEGを~/.photoshop-mcp/exportsにエクスポートしてください。
+続いて以下の形式で別々のJPEGをエクスポートしてください：
+Instagramフィード（1080×1350）、Stories/Reels（1080×1920）、LinkedIn（1200×628）、X投稿（1200×675）。
+出力パスを表にして一覧表示してください。
+```
+
+対応するテンプレート：`ps.prepare_for_web`・`ps.export_social_variants`
+
+</details>
+
+<details>
+<summary>📦 バッチモックアップ置換（レシピ）</summary>
+
+```
+「Screen」という名前のSmart ObjectレイヤーがあるモックアップPSDを開いています。
+~/assets/mockups/内のすべてのPNG/JPGで置換し、アセットごとに1枚JPEGをエクスポートしてください。
+フラットなレイヤーは配置せず、パースを維持するためにSmart Objectを差し替えてください。
+```
+
+対応するMCPプロンプトテンプレート：`ps.batch_mockup_replace`
+
+</details>
+
+<details>
+<summary>🗂️ レイヤーの整理（レシピ）</summary>
+
+```
+レイヤースタックを整理してください：種類ごとにリネームし、関連するレイヤーを自動グループ化し、オリジナルを保持してください。
+organize-layers recipeを実行して、新しい構造を確認できるようにレイヤーをリストアップしてください。
+```
+
+</details>
+
+<details>
+<summary>🎨 基本的なデザイン作成</summary>
+
+```
+RGBカラーモードで1920×1080のPhotoshopドキュメントを作成してください。
+薄い青の背景レイヤーを追加し、RGB(240, 248, 255)で塗りつぶしてください。
+中央に「Welcome」という64ptフォントのテキストを追加してください。
+デスクトップにwelcome.psdとして保存してください。
+```
+
+</details>
+
+<details>
+<summary>🖼️ ストック画像デザイン（Pexels MCPと連携）</summary>
+
+```
+Pexelsで「mountain sunset」の画像を検索してください。
+1920×1080のPhotoshopドキュメントを作成してください。
+ダウンロードした画像を配置し、キャンバス全体に収まるようにフィットさせてください。
+3pxのガウスぼかしを適用してください。
+明るさを15、コントラストを10上げてください。
+72ptの白いテキスト「Adventure Awaits」を上部中央に追加してください。
+テキストの不透明度を90%、ブレンドモードをOVERLAYに設定してください。
+品質10でadventure.jpgとして保存してください。
+```
+
+</details>
+
+<details>
+<summary>✨ 写真補正</summary>
+
+```
+デスクトップからphoto.jpgをPhotoshopで開いてください。
+状態を取得してから、enhance-portrait recipeを低い強度で実行してください。
+簡単なトーン調整だけが必要な場合は、代わりにアクティブなレイヤーにオートレベル、オートコントラスト、アンシャープマスク（120%、1.5、0）を適用してください。
+色相を+15、彩度を+15調整するか、エクスポートの準備ができたらprepare-for-webを使用してください。
+品質12でenhanced-photo.jpgとして保存してください。
+```
+
+</details>
+
+<details>
+<summary>🎭 レイヤーエフェクト＆ブレンディング</summary>
+
+```
+1200×800のドキュメントを作成してください。
+「Background」という名前の新しいレイヤーを追加し、RGB(50, 50, 50)で塗りつぶしてください。
+logo.pngを位置(100, 100)に配置してください。
+ロゴレイヤーを現在のサイズの50%にスケールしてください。
+ブレンドモードをSCREEN、不透明度を85%に設定してください。
+別のレイヤーを追加してRGB(255, 100, 50)で塗りつぶしてください。
+このレイヤーのブレンドモードをMULTIPLY、不透明度を60%に設定してください。
+表示中のレイヤーをすべて結合してください。
+composite.psdとして保存してください。
+```
+
+</details>
+
+<details>
+<summary>📝 テキストポスターデザイン</summary>
+
+```
+1080×1350の縦長ドキュメントを作成してください（Instagramストーリーサイズ）。
+レイヤーを追加してグラデーション風の色RGB(120, 40, 200)で塗りつぶしてください。
+位置(540, 300)に96ptで「SUMMER」テキストを追加してください。
+テキストカラーをホワイトRGB(255, 255, 255)に変更してください。
+テキストの配置をCENTERに設定してください。
+位置(540, 450)に128pt、ホワイトで「2026」テキストをもう一つ追加してください。
+背景レイヤーに2pxのガウスぼかしを適用してください。
+summer-poster.pngとして保存してください。
+```
+
+</details>
+
+<details>
+<summary>🎬 バッチ処理</summary>
+
+```
+image1.jpgを開いてください。
+1920×1080にリサイズしてください。
+オートコントラストを適用してください。
+控えめなシャープネスを適用してください（量80%、半径1.0）。
+品質10でprocessed-1.jpgとして保存してください。
+オリジナルへの変更を保存せずに閉じてください。
+
+image2.jpgとimage3.jpgでも同じ手順を繰り返してください。
+```
+
+</details>
+
+<details>
+<summary>🖌️ クリエイティブ加工</summary>
+
+```
+2000×2000の正方形ドキュメントを作成してください。
+abstract-pattern.jpgを配置してドキュメント全体に収まるようにフィットさせてください。
+レイヤーを複製してください。
+複製レイヤーに45度、半径50pxのモーションブラーを適用してください。
+ブレンドモードをOVERLAY、不透明度を70%に設定してください。
+120ptの白で「MOTION」テキストを中央に追加してください。
+(200, 200)から(1800, 1800)への矩形選択を作成してください。
+選択範囲を反転して削除してください（ボーダーエフェクト作成）。
+画像をフラット化してください。
+motion-art.jpgとして保存してください。
+```
+
+</details>
+
+<details>
+<summary>🎯 高度なワークフロー</summary>
+
+```
+印刷用に300DPIで3000×2000のドキュメントを作成してください。
+hero-image.jpgを配置してキャンバスに合わせてフィットさせてください。
+画像レイヤーを複製してください。
+複製レイヤーを完全にグレースケール化してください。
+ブレンドモードをLUMINOSITY、不透明度を50%に設定してください。
+「Overlay」という名前の新しいレイヤーを作成してください。
+RGB(255, 150, 0)で塗りつぶし、ブレンドモードをSOFTLIGHT、不透明度30%に設定してください。
+上部中央(1500, 200)に96ptで「PORTFOLIO」テキストを追加してください。
+テキストカラーをホワイトに設定してください。
+(1500, 320)に36ptで「2026 Collection」サブテキストを追加してください。
+テキストエリアを囲む矩形選択を作成してください。
+オーバーレイレイヤーにレイヤーマスクを作成してください。
+表示中のレイヤーを結合してください。
+portfolio-cover.psdとして保存してください。
+品質12でportfolio-cover.jpgとしてエクスポートしてください。
+```
+
+</details>
+
+<details>
+<summary>🔄 アクションの使用</summary>
+
+```
+my-photo.jpgを開いてください。
+「My Actions」セットから「Vintage Look」アクションを再生してください。
+明るさを-10に調整して少し暗くしてください。
+vintage-photo.jpgとして保存してください。
+```
+
+</details>
+
+<details>
+<summary>⚡ カスタムスクリプトの実行</summary>
+
+```
+以下のカスタムExtendScriptコードを実行してください：
+app.beep();
+alert('Processing started!');
+```
+
+</details>
+
+<details>
+<summary>⏮️ 元に戻す／やり直し操作</summary>
+
+```
+アクティブなレイヤーに15pxのガウスぼかしを適用してください。
+[結果を待つ]
+やはりぼかしが強すぎます。元に戻してください。
+代わりに5pxのガウスぼかしを適用してください。
+```
+
+または：
+
+```
+どの操作が実行されたかを確認するために履歴状態を取得してください。
+最後の3つの操作を元に戻してください。
+1ステップやり直して1つの操作を戻してください。
+```
+
+</details>
+
+<details>
+<summary>🔁 エラー回復（構造化エンベロープ）</summary>
+
+```
+レシピがversion_unsupportedまたはgenerative_unavailableを返した場合は、get_capabilitiesを呼び出してどのPhotoshop機能が不足しているか教えてください。
+ツールがsuggested_next_toolで失敗した場合は、そのヒントに従ってください（例：ラスターのみのレシピの前にrasterize_layerを実行するなど）。
+推測は禁止です — 失敗後にget_stateを読み取り、次の単一ステップを提案してください。
+```
+
+</details>
+
+<details>
+<summary>📱 ソーシャルメディア用フォーマットキット</summary>
+
+```
+1:1のキービジュアルマスター（2000×2000 px）が開いています。
+prepare-for-web recipeでアクティブなドキュメントをsRGBに変換し、最適化したJPEGを~/.photoshop-mcp/exportsにエクスポートしてください。
+さらにInstagramフィード（1080×1350）、Stories/Reels（1080×1920、上下のセーフゾーン）、LinkedIn（1200×628）、横長バナー（1200×628）のバリアントをエクスポートしてください。
+9:16フォーマットで被写体が切れる場合のみphotoshop_generative_expandを使用してください。
+被写体は画像面積の最低60%、ロゴは右上に20pxのマージンを設けてください。
+すべての出力パスを表にして一覧表示してください。
+```
+
+対応するテンプレート：`ps.prepare_for_web`・`ps.export_social_variants`
+
+</details>
+
+<details>
+<summary>🖨️ 印刷入稿データ（CMYK / 塗り足し）</summary>
+
+```
+アクティブなドキュメントをオフセット印刷向けに準備してください：
+RGBをCMYKに変換し、プロファイルはISO Coated v2を使用してください。
+全辺に3mmの塗り足しを設定し、最終サイズでの解像度が300dpi以上であることを確認してください。
+印刷プロファイルでソフトプルーフを設定して色ずれの可能性を指摘してください。
+ベタ黒の大きな面積はC50 M20 Y20 K100のリッチブラックに、テキストはK100のみにしてください。
+埋め込みプロファイル付きのPDF/X-4としてエクスポートし、プレビューを表示してください。
+```
+
+</details>
+
+<details>
+<summary>🛍️ 生成塗りつぶしによる商品シーン</summary>
+
+```
+背景除去済みの商品PNGがアクティブなレイヤーにあります。
+photoshop_generative_fillで3つの異なるシーンを作成してください：暖かい光の室内、夕暮れの屋外、水滴のある反射面。
+各バリアントはphotoshop_generative_expandで1080×1350（4:5）に拡張し、商品を中央に保ってください。
+各シーンの後にプレビューを取得し、影とパースを確認してください。
+generative_unavailableの場合はget_capabilitiesを呼び出し、不足している機能を教えてください。
+```
+
+</details>
+
+<details>
+<summary>🎨 統一カラーグレーディング</summary>
+
+```
+同じプロジェクトの30枚の写真があり、照明がそれぞれ異なります。
+apply-color-grade recipeとwarm_filmプリセットを、非破壊的な調整レイヤーとして適用してください。
+必要に応じてカーブと色相・彩度を調整し、温かみのあるシネマティックなルックにしてください：冷たい影、金色のハイライト。
+各画像を幅1080px、sRGB、JPEG品質85で~/.photoshop-mcp/exports/grade/にエクスポートするアクションを準備してください。
+代表的な3枚でビフォー・アフターのプレビューを表示してください。
+```
+
+対応するMCPテンプレート：`ps.apply_color_grade`（`{ preset: "warm_film" }`）
+
+</details>
+
+<details>
+<summary>🏢 ブランドモックアップ一括</summary>
+
+```
+名刺、A4文書、パッケージ、ソーシャルプロフィール用のSmart ObjectがあるモックアップPSDを開いています。
+~/assets/brand/のアセットで各Smart Objectを置換してください — レイヤーを統合せず、パースと影を保持してください。
+batch_mockup_replace recipeを実行し、バリアントごとに1枚JPEGを~/.photoshop-mcp/exports/mockups/にエクスポートしてください。
+すべての出力パスを表にして一覧表示してください。
+```
+
+対応するテンプレート：`ps.batch_mockup_replace`
+
+</details>
+
+<details>
+<summary>🏷️ マスターからのマルチバリアント書き出し</summary>
+
+```
+1:1のマスタークリエイティブと~/assets/logos/内の複数のロゴがあります。
+各バリアントについて、同一PSDからStory 9:16、Feed 4:5、バナー1200×628をエクスポートしてください — ロゴとテキストにはSmart Objectを使用してください。
+ファイル名はバリアント_フォーマット.jpgとし、すべて~/.photoshop-mcp/exports/variants/に保存してください。
+ステップが失敗した場合はget_stateを読み取り、次の単一ステップのみを提案してください。
+完了後、すべてのパスを表にして一覧表示してください。
+```
+
+</details>
+
+## 機能
+
+- **スタンドアロンWebUI** — ローカルチャットインターフェイス（`photoshop-mcp-ui`）；プロバイダーごとにAPIキーまたはCLIサブスクリプション認証（Anthropic、Google）
+- **Action Plan（ベータ）** — WebUIのオプトイン計画→実行モード（APIキーのみ）：1回の計画呼び出し、直接ツール実行、失敗時の限定的修復
+- **WindowsとmacOSの両方で動作**
+- **Photoshop 2012〜2025+をサポート**
+- **ExtendScript API**：AppleScript/COM自動化による汎用互換性
+- **自動検出**：システム上のPhotoshopインストールを自動で検出
+- **86ツール**：アトミック`photoshop_*` 74個＋レシピ`photoshop_recipe_*` 12個
+- **AI/プロンプトレイヤー**：MCPプロンプトテンプレート19個（レシピ12＋ガイド7）、サーバーInstructions、状態・プレビュー・機能ツール
+- **ドキュメント管理**：作成、開く、保存、閉じる、トリミング
+- **レイヤー操作**：作成、削除、複製、結合、変形
+- **レイヤープロパティ**：不透明度、ブレンドモード、表示/非表示、ロック
+- **テキスト書式設定**：フォント、サイズ、カラー、配置
+- **画像配置**：画像の配置、ファイルを開く、ドキュメントに合わせる
+- **フィルター**：ガウスぼかし、シャープネス、ノイズ、モーションブラー
+- **カラー調整**：明るさ/コントラスト、色相/彩度、曲線、オートレベル/コントラスト
+- **選択範囲とマスク**：矩形選択、被写体を選択、コンテンツに応じた塗りつぶし、グラデーションマスク、レイヤーマスク
+- **履歴管理**：元に戻す/やり直し操作、履歴状態の表示
+- **アクション**：記録済みアクションの再生、カスタムスクリプトの実行
+- **自動ラスタライズ**：フィルター適用時に必要に応じてレイヤーを自動変換
+- **コンテキストトラッキング**：各操作後にドキュメント/レイヤー状態を返し、AIアシスタントのコンテキスト認識を支援
+
+## インストール
+
+### NPXを使用（推奨）
+
+インストールは不要です！MCPクライアントを設定するだけです：
+
+```bash
+npx @alisaitteke/photoshop-mcp
+```
+
+ローカルでリポジトリを開発する場合は、開発ガイドの[ソースから](docs/development.md#from-source)を参照してください。
+
+## 設定
+
+### Cursor向け
+
+Cursorの設定に追加してください（`.cursor/config.json`またはワークスペース設定）：
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop向け
+
+Claude Desktopの設定に追加してください（macOSは`~/Library/Application Support/Claude/claude_desktop_config.json`、Windowsは`%APPDATA%\Claude\claude_desktop_config.json`）：
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### 環境変数
+
+- `PHOTOSHOP_PATH`：（オプション）Photoshopのカスタムインストールパスを指定
+- `LOG_LEVEL`：ログレベル（0=DEBUG、1=INFO、2=WARN、3=ERROR）
+- `ANALYTICS_DISABLED`：`1`または`true`に設定して匿名使用状況の解析を完全に無効化
+- `POSTHOG_DISABLED`：`ANALYTICS_DISABLED`の旧エイリアス
+- `ANALYTICS_PROVIDER`：解析バックエンド — `mixpanel`（デフォルト）または`posthog`（ロールバック）
+- `MIXPANEL_TOKEN`：（オプション）Mixpanelプロジェクトトークンを上書き
+- `MIXPANEL_API_HOST`：（オプション）Mixpanelインジェストホスト（デフォルト：`https://api-eu.mixpanel.com`）
+- `POSTHOG_KEY`：（オプション、旧仕様）PostHogプロジェクトキー — `ANALYTICS_PROVIDER=posthog`の場合のみ使用
+- `POSTHOG_API_HOST`：（オプション、旧仕様）PostHogインジェストホスト（デフォルト：`https://a.alisait.com`）
+- `POSTHOG_UI_HOST`：（オプション、旧仕様）PostHog UIホスト（デフォルト：`https://eu.posthog.com`）
+
+## 利用可能なツール
+
+すべてのアトミック`photoshop_*`ツールの完全なリファレンス（パラメーター、例、使用方法）：[`docs/available-tools.md`](docs/available-tools.md)
+
+## コンテキストトラッキング
+
+各ツールはPhotoshopの現在の状態に関する包括的なコンテキスト情報を返します：
+
+- **ドキュメント情報**：名前、サイズ、解像度、カラーモード、レイヤー数
+- **アクティブレイヤー情報**：名前、タイプ、不透明度、ブレンドモード、表示状態、ロック状態
+- **選択範囲の状態**：選択範囲がアクティブかどうか
+- **操作結果**：変更内容の詳細
+
+これにより、AIアシスタントは以下を把握し続けられます：
+- どのドキュメントがアクティブか
+- どのレイヤーで作業しているか
+- 現在のレイヤープロパティ（不透明度、ブレンドモードなど）
+- ドキュメントのサイズと設定
+
+**レスポンス例：**
+```javascript
+{
+  "applied": true,
+  "filter": "Gaussian Blur",
+  "radius": 10,
+  "wasRasterized": true,
+  "context": {
+    "hasDocument": true,
+    "document": {
+      "name": "design.psd",
+      "width": 1920,
+      "height": 1080,
+      "resolution": 72,
+      "colorMode": "RGBColorMode",
+      "layerCount": 3,
+      "hasSelection": false
+    },
+    "activeLayer": {
+      "name": "Background",
+      "kind": "NORMAL",
+      "opacity": 100,
+      "blendMode": "NORMAL",
+      "visible": true,
+      "locked": false,
+      "isBackground": false
+    }
+  }
+}
+```
+
+このコンテキストにより、AIアシスタントは複数のコマンドにわたって作業中のドキュメントとレイヤーを記憶します。
+
+---
+
+## プラットフォーム固有の注意事項
+
+### Windows
+
+- COM自動化を使用してPhotoshopと通信します
+- レジストリベースのインストールパス自動検出
+- 32ビットと64ビットの両バージョンをサポート
+
+### macOS
+
+- Photoshopの通信にAppleScript/OSAを使用します
+- Spotlightベースの自動検出
+- 複数のPhotoshopバージョンの同時インストールをサポート
+- **CLIアカウント認証**（スタンドアロンUI）はmacOS優先：ターミナルで`claude auth login` / `gemini auth login`を実行し、クレデンシャルは`~/.claude/`と`~/.gemini/`に保存されます
+
+## サポートされているPhotoshopバージョン
+
+- **すべてのPhotoshopバージョン**（2012〜2025+）：macOSはAppleScript、WindowsはCOM経由のExtendScript APIを使用
+
+**重要：** Photoshop 2022以降はプラグイン向けにUXPをサポートしていますが、AppleScript/COM経由の外部自動化ではExtendScriptのみ使用できます。UXPは内部プラグイン向けに設計されており、外部スクリプトから呼び出すことはできません。そのため、このMCPサーバーはすべてのPhotoshopバージョンとの最大互換性のためにExtendScriptを使用しています。
+
+## トラブルシューティング
+
+接続、スクリプト、ログに関するよくある問題：[`docs/troubleshooting.md`](docs/troubleshooting.md)
+
+### スタンドアロンUI — CLIアカウント認証
+
+| 症状 | 原因 | 対処法 |
+|---|---|---|
+| `cli_not_found` | Claude Code / Gemini CLIがインストールされていない | `npm i -g @anthropic-ai/claude-code`または`npm i -g @google/gemini-cli` |
+| `not_authenticated` | OAuthセッションがない | ターミナルで`claude auth login`または`gemini auth login`を実行 |
+| `claude` / `gemini`が`PATH`にない | カスタムインストール場所 | 設定 → **CLI path** → **Check connection** |
+| IDEではチャットできるがUIでできない（CLIモード） | OAuthトークンはCLI専用 | UIで**CLIアカウント**を使用；APIキーとCLIセッションは別々 |
+| Geminiのマルチターンが忘れっぽい | ヘッドレスCLIがターンごとに新しいセッションを開始する場合がある | 既知の制限；履歴はプロンプトに追記（MVP） |
+
+## 開発
+
+ソースからのセットアップ、ビルド、リント、統合テスト（最新結果付き）、使用例：[`docs/development.md`](docs/development.md)
+
+## アーキテクチャ
+
+システム設計、データフロー、プラットフォーム抽象化、UIエージェントモード：[`docs/architecture.md`](docs/architecture.md)
+
+LinkedInやソーシャルメディアでシェアする際は、[`images/og-social.png`](images/og-social.png)と[`docs/social-preview.md`](docs/social-preview.md)をOGセットアップとポスト用テキストとしてご活用ください。
+
+## コントリビューション
+
+コントリビューションを歓迎します！PRを開く前に[CONTRIBUTING.md](CONTRIBUTING.md)をお読みください。
+
+## メンテナーについて
+
+**[Ali Sait Teke](https://alisait.com)** — フルスタックエンジニア＆AI時代のソフトウェアアーキテクト
+（Python、Go、Node.js、React、Next.js、Vue）
+
+このプロジェクトは実践的な問いから始まりました：*脆弱な一発スクリプトなしに、LLMがPhotoshopを確実に操作できるようにするにはどうすればいいか？* それは80のツール、信頼性の高いマルチステップワークフロー向けのレシピ/プロンプトレイヤー、そしてクリエイティブな作業にIDEが不要なローカルWebUIを備えたMCPサーバーへと成長しました。
+
+**このコードベースが示すもの：** TypeScriptシステム設計、MCPプロトコル統合、クロスプラットフォームデスクトップ自動化（macOS AppleScript / Windows COM）、エージェントループのための構造化エラー回復、プロダクション品質のlocal-first UI（Vue 3 + Hono + SQLite）。
+
+- [Portfolio](https://alisait.com) · [GitHub](https://github.com/alisaitteke) · [LinkedIn](https://www.linkedin.com/in/alisait/)
+
+## ライセンス
+
+MIT
+
+## 匿名使用状況の解析
+
+製品改善のために、デフォルトで匿名の集計使用イベントが収集されます。いつでもオプトアウトできます。詳細：[`docs/anonymous-usage-analytics.md`](docs/anonymous-usage-analytics.md)
+
+## 謝辞
+
+- [Model Context Protocol SDK](https://github.com/modelcontextprotocol/sdk)を使用して構築
+- Adobe Photoshopスクリプティングコミュニティに触発されて制作

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   </a>
 </p>
 
+**Languages:** English · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Deutsch](README.de.md) · [日本語](README.ja.md) · [Türkçe](README.tr.md)
+
 *v1.1+ — recipe workflows, fewer round-trips, snappier sessions. Standalone UI ships **Action Plan (beta)** for plan-then-execute runs.*
 
 > **Note:** This is an unofficial, community-maintained project and is not affiliated with or endorsed by Adobe Inc.

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,0 +1,773 @@
+# Photoshop MCP Server
+
+<p align="center">
+  <a href="https://github.com/alisaitteke/photoshop-mcp">
+    <img src="./images/readme-hero.png" alt="Photoshop MCP — Yapay zeka destekli Photoshop otomasyonu" width="100%" />
+  </a>
+</p>
+
+**Diller:** [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Deutsch](README.de.md) · [日本語](README.ja.md) · Türkçe
+
+*v1.1+ — tarif iş akışları, daha az gidiş-dönüş, daha hızlı oturumlar. Bağımsız UI, plan-sonra-uygula çalıştırmaları için **Action Plan (beta)** sunar.*
+
+> **Not:** Bu, resmi olmayan, topluluk tarafından sürdürülen bir projedir; Adobe Inc. ile bağlantılı değildir ve Adobe Inc. tarafından desteklenmemektedir.
+
+[![npm version](https://img.shields.io/npm/v/@alisaitteke/photoshop-mcp.svg)](https://www.npmjs.com/package/@alisaitteke/photoshop-mcp)
+[![GitHub release](https://img.shields.io/github/v/release/alisaitteke/photoshop-mcp?include_prereleases)](https://github.com/alisaitteke/photoshop-mcp/releases)
+[![Action Plan](https://img.shields.io/badge/Action%20Plan-beta-amber.svg)](#action-plan-beta)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS-lightgrey.svg)]()
+
+Model Context Protocol (MCP) sunucusu; Claude ve Cursor gibi yapay zeka asistanlarının Adobe Photoshop'u programatik olarak kontrol etmesini sağlar. Bu sayede IDE'nizden doğal dil komutlarıyla tasarım oluşturabilir, görselleri düzenleyebilir ve Photoshop iş akışlarını otomatikleştirebilirsiniz. Ayrıca hem API anahtarlarını hem de CLI abonelik hesaplarını (Claude Code / Gemini CLI) destekleyen dahili **bağımsız web UI** üzerinden de çalışabilirsiniz. UI, isteğe bağlı **Action Plan (beta)** modunu da sunar: tüm Photoshop adımları tek bir LLM çağrısında planlanır, ardından tek seferde yürütülür.
+
+## Neden bu proje var
+
+Tasarımcılar ve geliştiriciler Photoshop'u yapay zeka asistanlarıyla yönetmek istiyor; ancak ham ExtendScript çağrıları kırılgandır: ajanlar deneme-yanılmayla token harcar, katman türleri filtreleri bozar ve başarısız bir komut belgeyi bilinmeyen bir durumda bırakır.
+
+Photoshop MCP; **durum farkındalığı** (`get_state`, `get_preview`, `get_capabilities`), çok adımlı sonuçları tek bir geri alma adımında kapsayan **tarif araçları** ve ajanların sıradaki adımı bilmesini sağlayan **yapılandırılmış hata zarfları** ekler. İsteğe bağlı bağımsız UI ve Action Plan modu, uzun iş akışlarındaki gidiş-dönüşleri azaltır — böylece doğal dil gerçekten piksel üretir, yalnızca önermekle kalmaz.
+
+Teknik derinleme: [`docs/architecture.md`](docs/architecture.md).
+
+## 🖥️ Bağımsız UI (IDE gerekmez)
+
+Bunu Claude Desktop veya Cursor'a bağlamak istemiyorsanız? Aynı paket, bir yapay zeka modeliyle sohbet etmenizi ve bu MCP sunucusu aracılığıyla Photoshop'u yönetmenizi sağlayan tam yerel bir web UI içerir. Sağlayıcı API anahtarıyla **ya da** Anthropic ve Google için **Claude Code** veya **Gemini CLI**'dan OAuth oturumunu yeniden kullanarak bağlanın — ayrı API anahtarı gerekmez.
+
+![Bağımsız UI Ekran Görüntüsü](./images/frame_generic_light.png)
+
+```bash
+npx -p @alisaitteke/photoshop-mcp photoshop-mcp-ui
+```
+
+Hepsi bu. `127.0.0.1` üzerinde yerel bir sunucu başlar (rastgele boş port) ve varsayılan tarayıcınız sohbet UI'ını otomatik olarak açar.
+
+### Desteklenen sağlayıcılar
+
+İlk başlatmada aşağıdakilerden birini seçin — API anahtarıyla **ya da** mevcut CLI abonelik hesabınızla (Anthropic ve Google):
+
+| Sağlayıcı | Modeller | API anahtarı | CLI hesabı |
+|---|---|---|---|
+| **Anthropic** | Claude Sonnet / Opus / Haiku | [console.anthropic.com](https://console.anthropic.com/settings/keys) | `npm i -g @anthropic-ai/claude-code` → `claude auth login` |
+| **OpenAI** | GPT-5, GPT-4.1, o-series | [platform.openai.com](https://platform.openai.com/api-keys) | — |
+| **Google** | Gemini 2.5 Pro / Flash / Flash-Lite | [aistudio.google.com](https://aistudio.google.com/apikey) | `npm i -g @google/gemini-cli` → `gemini auth login` |
+| **OpenRouter** | 100'den fazla sağlayıcı modeli | [openrouter.ai](https://openrouter.ai/keys) | — |
+
+### Kimlik doğrulama modları
+
+- **`api_key` (varsayılan)** — Vercel AI SDK + kendi sağlayıcı API anahtarınız. Kullanım token başına API ücretleriyle faturalandırılır; UI her sohbet için tahmini maliyeti gösterir.
+- **`cli_account`** — Yerel Claude Code veya Gemini CLI OAuth oturumunu kullanır.
+  API anahtarı saklanmaz; UI girişi doğrulamak için `claude auth status` / `gemini` başsız modunu yoklar. Kullanım **abonelik kotasına** sayılır, API faturalandırmasına değil — durum çubuğu "Included in subscription" gösterir.
+
+Diğer kimlik bilgisini kaybetmeden sağlayıcı başına Ayarlar'dan kimlik doğrulama yöntemini değiştirebilirsiniz (örn. CLI hesabı denerken API anahtarını saklayın, sonra geri geçin).
+
+### Action Plan (beta)
+
+Bağımsız web UI'da **yalnızca API anahtarı kimlik doğrulaması** için isteğe bağlı bir yürütme modu
+(`cli_account` her zaman varsayılan ajantik akışı kullanır). **composer**'daki model seçicinin yanındaki
+**Action Plan** düğmesiyle etkinleştirin.
+
+Adım başına ReAct döngüsü (model → araç → model → araç …) yerine Action Plan:
+
+1. Photoshop MCP araç çağrılarını ve parametrelerini içeren sıralı bir yapılacaklar listesi çıkaran **tek** bir planlama LLM çağrısı yapar.
+2. Bu araçları **doğrudan** sırayla çalıştırır — adımlar arasında ekstra model gidiş-dönüşü olmadan.
+3. Başarısız bir adımda veya çözümlenmemiş bağımlılıkta, sınırlı bir **onarım** döngüsü çalışır (yalnızca kalan adımları yeniden planlar, en fazla 3 kez).
+
+Plan, araç çağrı kartlarının üzerinde adım başına durum gösteren canlı bir yapılacaklar listesi olarak görünür (`pending` → `running` → `done` / `error`). Planlar sohbet geçmişinde kalıcı olarak saklanır ve yeniden yüklemeyi atlatır. Düğme varsayılan olarak kapalıdır; Action Plan devre dışıyken mevcut ajantik akış değişmeden kalır.
+
+*"arka planı kaldır ve web için dışa aktar"* gibi daha az model çağrısı ve daha hızlı uçtan uca yürütme istediğiniz çok adımlı istemler için idealdir.
+
+### İlk başlatmada neler olur
+
+1. Bir sağlayıcı seçin ve **API key** veya **Uses your account** seçeneğini belirleyin.
+2. Anahtarı doğrulayın veya CLI bağlantısını kontrol edin. Yapılandırma `~/.photoshop-mcp/data.db` konumunda yerel olarak saklanır (SQLite, `chmod 600`). API anahtarları makinenizi asla terk etmez; CLI modu OAuth'u `~/.claude/` veya `~/.gemini/`'den devralır.
+3. Doğal dil istemleri yazın. UI modelin yanıtını akışla iletir, Photoshop araç çağrılarını gerçek zamanlı çalıştırır ve her araç çağrısını incelenebilir bir kart olarak (girdi + sonuç) gösterir.
+4. Sağlayıcıyı, kimlik doğrulama yöntemini veya modeli istediğiniz zaman Ayarlar / model seçiciden değiştirin — sohbetler, maliyetler ve araç geçmişi oturumlar arasında kalıcı olarak saklanır.
+
+### Kimlik doğrulama yöntemini daha sonra değiştirme
+
+Kenar çubuğundan istediğiniz zaman **Ayarlar**'ı açın:
+
+| İşlem | API anahtarı modu | CLI hesabı modu |
+|---|---|---|
+| Kurulum | Anahtarı yapıştır → **Save** | CLI yükle → `auth login` → **Check connection** |
+| Geçiş | **API key** seç — saklanan anahtar korunur | **Uses your account** seç — anahtar silinmez |
+| Özel ikili | — | `claude` / `gemini` `PATH`'de değilse isteğe bağlı **CLI path** |
+| Maliyet göstergesi | Durum çubuğunda token başına tahmin | **Included in subscription** rozeti |
+
+Kimlik doğrulama yöntemi, `~/.photoshop-mcp/data.db` içinde sağlayıcı başına saklanır (`authMethod`:
+`api_key` veya `cli_account`). `authMethod` içermeyen mevcut yapılandırmalar varsayılan olarak `api_key`
+kullanır ve değişmeden çalışmaya devam eder.
+
+### CLI bayrakları
+
+```
+photoshop-mcp-ui [--port 5174] [--host 127.0.0.1] [--no-open]
+```
+
+### Notlar
+
+- Ajan yalnızca Photoshop MCP araçlarıyla sınırlıdır — dahili kabuk, dosya
+  ve web araçları devre dışıdır.
+- Teknoloji yığını: Frontend'de Vue 3 + Tailwind v4 + [shadcn-vue](https://www.shadcn-vue.com/);
+  backend'de [Hono](https://hono.dev/). API anahtarı modu [Vercel AI SDK](https://sdk.vercel.ai/)
+  kullanır; CLI hesabı modu [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/mcp)
+  (Anthropic) veya Gemini CLI başsız `stream-json` (Google) kullanır. Tüm yollar bu Photoshop
+  MCP sunucusuyla STDIO üzerinden iletişim kurar.
+- **CLI hesabı kısıtlamaları:** Gemini başsız modu her turda yeni bir oturum açabilir
+  (geçmiş, isteme eklenir). Anthropic CLI hesabı abonelik kotası tüketir. OAuth girişi
+  macOS önceliklidir (`claude auth login` / `gemini auth login` Terminal'de).
+
+---
+
+## Photoshop için Yapay Zeka/İstem Katmanı
+
+Atomik `photoshop_*` araçlarının üzerinde, sunucu; ana LLM'lerin (Cursor, Claude Desktop vb.)
+belirsiz kullanıcı isteklerini güvenilir Photoshop eylemlerine dönüştürmesine yardımcı olan görüşlü
+bir yapay zeka/istem katmanı sunar:
+
+- **Sunucu `instructions`'ları** — MCP `initialize`'da tanıtılan iş akışı sözleşmesi
+  (bir kez ping at, eylemden önce durum al, tarifleri tercih et, hata kurtarma). Bkz.
+  [`src/prompts/instructions.ts`](src/prompts/instructions.ts).
+- **MCP `prompts` primitifi** — 19 önceden hazırlanmış şablon (12 tarif + 7 kılavuz:
+  `ps.enhance_portrait`, `ps.remove_background`, `ps.generative_fill`, …)
+  `prompts/list` ve `prompts/get` üzerinden.
+- **Tarif araçları** — 12 sonuç odaklı `photoshop_recipe_*` aracı (arka plan kaldırma,
+  portre geliştirme, web için hazırlama, sosyal medya varyantları dışa aktarma, renk düzenlemesi,
+  frequency separation, toplu mockup, katmanları düzenleme, degrade solması,
+  gökyüzü karıştırma, dodge & burn, dikkat dağıtıcıyı kaldırma). Her biri adımları tek bir
+  Photoshop geçmiş durumuna sarar (tek bir Geri Al hepsini geri alır). **Toplamda 86 araç**
+  (74 atomik + 12 tarif).
+- **Üretken Yapay Zeka** — `photoshop_generative_fill`, `photoshop_generative_remove`,
+  `photoshop_generative_expand`, `photoshop_generative_upscale`, `photoshop_sky_replacement`,
+  `photoshop_generate_image` (ExtendScript aracılığıyla Firefly; Adobe hesabı + kredi gereklidir).
+- **Sinir Filtreleri** — isteğe bağlı UXP köprü eklentisi (`uxp-plugin/`) aracılığıyla
+  `photoshop_neural_filter`.
+- **Durum & Önizleme** — `photoshop_get_state` (ucuz anlık görüntü),
+  `photoshop_get_preview` (görsel doğrulama için base64 JPEG),
+  `photoshop_get_capabilities` (sürüme duyarlı özellik bayrakları).
+- **Yapılandırılmış hatalar** — başarısızlıklar otomatik düzeltme için `code` ve
+  `suggested_next_tool` içeren JSON zarfları döndürür.
+
+Tam başvuru: [`docs/prompt-layer.md`](docs/prompt-layer.md).
+
+Pariteyi doğrulayın: `npm run verify:photoshop-prompts`. Son sonuçlar:
+[`docs/development.md#integration-test-results`](docs/development.md#integration-test-results).
+
+## Örnek İstemler
+
+Aşağıda bu MCP sunucusu yapılandırıldığında yapay zeka asistanlarıyla (Claude, Cursor vb.)
+kullanabileceğiniz örnek istemler yer almaktadır. Çok adımlı sonuçlar için **tarif araçlarını**
+(`photoshop_recipe_*`) tercih edin — her tarif tek bir geri alma adımıdır. Atomik `photoshop_*`
+araçlarını yalnızca hiçbir tarifin karşılamadığı ince düzenlemeler için kullanın.
+
+<details>
+<summary>🧠 Durum farkındalıklı oturum (önerilen ilk adım)</summary>
+
+```
+Photoshop'u ping'le ve yüklü sürüm için yetenekleri oku.
+Herhangi bir değişiklik yapmadan önce mevcut belge durumunu al.
+portrait.jpg'yi aç, konuyu doğrulayabilmek için küçültülmüş bir önizleme al.
+Her önemli tariften sonra sonucu onaylamak için başka bir önizleme al.
+```
+
+</details>
+
+<details>
+<summary>👤 Portre rötuşu (tarif)</summary>
+
+```
+Aktif katmandaki portreyi orta yoğunlukta ve cilt düzleştirmeyle geliştir.
+enhance-portrait recipe kullan — tek bir geri alınabilir adımda frequency separation + auto-tone istiyorum.
+Aktif katman metin veya Smart Object ise önce rasterleştir ya da raster katman seç.
+Bitince bir önizleme göster.
+```
+
+Eşdeğer MCP istem şablonu: `ps.enhance_portrait` ile `{ intensity: "medium", skin_smoothing: "true" }`.
+
+</details>
+
+<details>
+<summary>✂️ Arka plan kaldırma (tarif)</summary>
+
+```
+Aktif portre katmanından arka planı kaldır.
+Select Subject + 2 piksel tüylendirmeli katman maskesi kullan. Orijinal pikselleri maskenin arkasında koru.
+Brifing saf beyaz RGB(255,255,255) arka plan gerektiriyorsa konuyu ortala ve çerçeve alanının en az %70'ini kapsamasını sağla.
+Konu aktif katmanda olmalı — düz bir renk dolgusu değil.
+```
+
+Eşdeğer MCP istem şablonu: `ps.remove_background` ile `{ feather_px: "2", keep_shadow: "false" }`.
+
+</details>
+
+<details>
+<summary>🎨 Renk düzenlemesi (tarif)</summary>
+
+```
+Açık belgeye yıkıcı olmayan ayarlama katmanları olarak sıcak bir film renk düzenlemesi uygula.
+apply-color-grade recipe'yi warm_film ön ayarıyla kullan.
+Bitince sonucu önizle.
+```
+
+</details>
+
+<details>
+<summary>🔬 Frekans ayrıştırma kurulumu (tarif)</summary>
+
+```
+Aktif raster katmanda 6 piksel bulanıklık yarıçapıyla frequency separation kur.
+Low ve High katmanlarına kendim boyayacağım — ek düzleştirme uygulama.
+Katman yığını hazır olduğunda hangi katmanların düzenleneceğini söyle.
+```
+
+Eşdeğer MCP istem şablonu: `ps.frequency_separation` ile `{ radius_px: "6" }`.
+
+</details>
+
+<details>
+<summary>🌐 Web için hazırla + sosyal medya dışa aktarımı (tarifler)</summary>
+
+```
+Aktif belgeyi web için hazırla: sRGB, küçült, keskinleştir, ~/.photoshop-mcp/exports'a optimize edilmiş bir JPEG dışa aktar.
+Ardından aynı belgeden Instagram gönderisi ve X gönderisi varyantlarını ayrı JPEG'ler olarak dışa aktar.
+Çıktı yollarını bir tabloda listele.
+```
+
+Eşdeğer şablonlar: `ps.prepare_for_web`, `ps.export_social_variants`.
+
+</details>
+
+<details>
+<summary>📦 Toplu mockup değiştirme (tarif)</summary>
+
+```
+"Screen" adında bir Smart Object katmanıyla açık bir mockup PSD'im var.
+~/assets/mockups/'taki her PNG/JPG ile değiştir ve her varlık için bir JPEG dışa aktar.
+Düz katmanlar yerleştirme — perspektif korunacak şekilde Smart Object'i takas et.
+```
+
+Eşdeğer MCP istem şablonu: `ps.batch_mockup_replace`.
+
+</details>
+
+<details>
+<summary>🗂️ Katmanları düzenleme (tarif)</summary>
+
+```
+Katman yığınını düzenle: türe göre yeniden adlandır, ilgili katmanları otomatik grupla, orijinalleri koru.
+organize-layers recipe'yi çalıştır, ardından yeni yapıyı gözden geçirebilmem için katmanları listele.
+```
+
+</details>
+
+<details>
+<summary>🎨 Temel Tasarım Oluşturma</summary>
+
+```
+RGB renk modunda 1920x1080 boyutunda bir Photoshop belgesi oluştur.
+Açık mavi bir arka plan katmanı ekle ve RGB(240, 248, 255) ile doldur.
+64 pt yazı tipinde ortalanmış "Welcome" metni ekle.
+Masaüstüme welcome.psd olarak kaydet.
+```
+
+</details>
+
+<details>
+<summary>🖼️ Stok Görsel Tasarımı (Pexels MCP ile)</summary>
+
+```
+Pexels'ta "mountain sunset" görselleri ara.
+1920x1080 boyutunda bir Photoshop belgesi oluştur.
+İndirilen görseli yerleştir ve tüm tuvali dolduracak şekilde ayarla.
+3 piksel ince Gaussian Blur uygula.
+Parlaklığı 15 ve kontrastı 10 artır.
+Üst kısımda 72 pt'ta ortalanmış beyaz "Adventure Awaits" metni ekle.
+Metin opaklığını %90 ve karışım modunu OVERLAY olarak ayarla.
+Kalite 10 ile adventure.jpg olarak kaydet.
+```
+
+</details>
+
+<details>
+<summary>✨ Fotoğraf Geliştirme</summary>
+
+```
+Masaüstümden photo.jpg'yi Photoshop'ta aç.
+Durumu al, ardından enhance-portrait recipe'yi düşük yoğunlukta çalıştır.
+Yalnızca hızlı ton düzeltmelerine ihtiyaç duyarsam, aktif katmanda otomatik düzeyler, otomatik kontrast ve keskinleştirme maskesi (120%, 1.5, 0) uygula.
+Tonu +15 ve doygunluğu +15 ayarla; dışa aktarmaya hazır olduğumda prepare-for-web kullan.
+Kalite 12 ile enhanced-photo.jpg olarak kaydet.
+```
+
+</details>
+
+<details>
+<summary>🎭 Katman Efektleri ve Karıştırma</summary>
+
+```
+1200x800 boyutunda bir belge oluştur.
+"Background" adında yeni bir katman ekle ve RGB(50, 50, 50) ile doldur.
+logo.png'yi (100, 100) konumuna yerleştir.
+Logo katmanını mevcut boyutunun %50'sine küçült.
+Karışım modunu SCREEN ve opaklığı %85 olarak ayarla.
+Başka bir katman ekle ve RGB(255, 100, 50) ile doldur.
+Bu katmanın karışım modunu MULTIPLY ve opaklığını %60 olarak ayarla.
+Tüm görünür katmanları birleştir.
+composite.psd olarak kaydet.
+```
+
+</details>
+
+<details>
+<summary>📝 Metin Posteri Tasarımı</summary>
+
+```
+1080x1350 dikey belge oluştur (Instagram story boyutu).
+Bir katman ekle ve degrade benzeri renk RGB(120, 40, 200) ile doldur.
+(540, 300) konumuna 96 pt'ta "SUMMER" metni ekle.
+Metin rengini beyaz RGB(255, 255, 255) olarak değiştir.
+Metin hizalamasını CENTER olarak ayarla.
+(540, 450) konumuna 128 pt'ta beyaz renkte "2026" metni ekle.
+Arka plan katmanına 2px Gaussian Blur uygula.
+summer-poster.png olarak kaydet.
+```
+
+</details>
+
+<details>
+<summary>🎬 Toplu İşleme</summary>
+
+```
+image1.jpg'yi aç.
+1920x1080'e yeniden boyutlandır.
+Otomatik kontrast uygula.
+İnce keskinleştirme uygula (miktar %80, yarıçap 1.0).
+Kalite 10 ile processed-1.jpg olarak kaydet.
+Orijinaldeki değişiklikleri kaydetmeden kapat.
+
+image2.jpg ve image3.jpg için de aynı işlemi tekrarla.
+```
+
+</details>
+
+<details>
+<summary>🖌️ Yaratıcı Manipülasyon</summary>
+
+```
+2000x2000 kare belge oluştur.
+abstract-pattern.jpg'yi yerleştir ve belgeyi dolduracak şekilde ayarla.
+Katmanı çoğalt.
+Kopyalanan katmanda 45 derece, 50px yarıçapta motion blur uygula.
+Karışım modunu OVERLAY ve opaklığı %70 olarak ayarla.
+Ortaya 120 pt beyaz "MOTION" metni ekle.
+(200, 200)'den (1800, 1800)'e dikdörtgen seçim oluştur.
+Seçimi tersine çevir ve sil (çerçeve efekti oluşturmak için).
+Görseli düzleştir.
+motion-art.jpg olarak kaydet.
+```
+
+</details>
+
+<details>
+<summary>🎯 Gelişmiş İş Akışı</summary>
+
+```
+Baskı için 300 DPI'da 3000x2000 belge oluştur.
+hero-image.jpg'yi yerleştir ve tuvali dolduracak şekilde ayarla.
+Görsel katmanını çoğalt.
+Kopyalanan katmanı tamamen doygunluğunu kaldır.
+Karışım modunu LUMINOSITY ve opaklığı %50 olarak ayarla.
+"Overlay" adında yeni bir katman oluştur.
+RGB(255, 150, 0) ile doldur ve karışım modunu %30 opaklıkla SOFTLIGHT olarak ayarla.
+Üst ortaya (1500, 200) konumuna 96 pt'ta "PORTFOLIO" metni ekle.
+Metin rengini beyaz olarak ayarla.
+(1500, 320) konumuna 36 pt'ta "2026 Collection" alt metni ekle.
+Metin alanının etrafında dikdörtgen seçim oluştur.
+Overlay katmanında katman maskesi oluştur.
+Görünür katmanları birleştir.
+portfolio-cover.psd olarak kaydet.
+Kalite 12 ile portfolio-cover.jpg olarak dışa aktar.
+```
+
+</details>
+
+<details>
+<summary>🔄 Eylem Kullanımı</summary>
+
+```
+my-photo.jpg'yi aç.
+"My Actions" setinden "Vintage Look" eylemini çalıştır.
+Hafifçe kararatmak için parlaklığı -10 olarak ayarla.
+vintage-photo.jpg olarak kaydet.
+```
+
+</details>
+
+<details>
+<summary>⚡ Özel Betik Çalıştırma</summary>
+
+```
+Bu özel ExtendScript kodunu çalıştır:
+app.beep();
+alert('Processing started!');
+```
+
+</details>
+
+<details>
+<summary>⏮️ Geri Al / Yeniden Yap İşlemleri</summary>
+
+```
+Aktif katmana 15px Gaussian Blur uygula.
+[Sonucu bekle]
+Aslında bu çok fazla bulanıklık. Geri al.
+Bunun yerine 5px Gaussian Blur uygula.
+```
+
+Ya da:
+
+```
+Hangi işlemlerin gerçekleştirildiğini görmek için geçmiş durumlarını al.
+Son 3 işlemi geri al.
+Bir işlemi geri getirmek için 1 adım yeniden uygula.
+```
+
+</details>
+
+<details>
+<summary>🔁 Hata kurtarma (yapılandırılmış zarflar)</summary>
+
+```
+Bir tarif version_unsupported veya generative_unavailable döndürürse, get_capabilities çağır ve hangi Photoshop özelliğinin eksik olduğunu söyle.
+Bir araç suggested_next_tool ile başarısız olursa o ipucunu takip et (ör. yalnızca raster içeren bir tariften önce rasterize_layer).
+Asla tahmin etme — başarısızlıktan sonra get_state oku ve bir sonraki tek adımı öner.
+```
+
+</details>
+
+<details>
+<summary>📱 Sosyal medya format kiti</summary>
+
+```
+Açık bir 1:1 key visual master'ım var (2000×2000 px).
+Aktif belgeyi prepare-for-web recipe ile sRGB'ye hazırla ve optimize edilmiş JPEG'leri ~/.photoshop-mcp/exports'a aktar.
+Ardından Instagram Feed (1080×1350), Stories/Reels (1080×1920, üst ve alt güvenli zon), LinkedIn (1200×628) ve yatay banner (1200×628) varyantlarını dışa aktar.
+9:16 formatta konu kesilecekse photoshop_generative_expand kullan.
+Konu, çerçeve alanının en az %60'ını kapsamalı; logo sağ üstte 20 piksel boşlukla.
+Tüm çıktı yollarını bir tabloda listele.
+```
+
+Eşdeğer şablonlar: `ps.prepare_for_web`, `ps.export_social_variants`.
+
+</details>
+
+<details>
+<summary>🖨️ Baskı teslim dosyası (CMYK / taşma payı)</summary>
+
+```
+Aktif belgeyi ofset baskı için hazırla:
+RGB'den CMYK'ya dönüştür; hedef profil ISO Coated v2.
+Her kenarda 3 mm taşma payı ekle, son formatta 300 dpi çözünürlüğü doğrula.
+Baskı profili için soft proof kur ve renk kaymalarını belirt.
+Zengin siyah alanları C50 M20 Y20 K100 olarak ayarla; siyah metin yalnızca K100.
+Gömülü profille PDF/X-4 olarak dışa aktar ve önizleme göster.
+```
+
+</details>
+
+<details>
+<summary>🛍️ Üretken dolgu ile ürün sahnesi</summary>
+
+```
+Aktif katmanda arka planı kaldırılmış bir ürün PNG'si var.
+photoshop_generative_fill ile üç farklı sahne oluştur: sıcak ışıklı iç mekan, gün batımı dış mekan ve su damlalı yansıtıcı yüzey.
+Her varyant için photoshop_generative_expand ile 1080×1350 (4:5) boyutuna genişlet; ürünü ortada tut.
+Her sahneden sonra gölgeleri ve perspektifi kontrol etmek için önizleme al.
+generative_unavailable ise get_capabilities çağır ve eksik olanı belirt.
+```
+
+</details>
+
+<details>
+<summary>🎨 Birleşik renk düzenlemesi</summary>
+
+```
+Aynı projeden farklı ışık koşullarında 30 fotoğrafım var.
+apply-color-grade recipe'yi warm_film ön ayarıyla yıkıcı olmayan ayar katmanları olarak uygula.
+Gerekirse eğriler ve ton/doygunluk ile sıcak sinematik bir görünüm ayarla: soğuk gölgeler, altın vurgular.
+Her görseli 1080 px genişlikte, sRGB, JPEG kalite 85 ile ~/.photoshop-mcp/exports/grade/'e aktaran bir eylem hazırla.
+Üç temsili görselde önce/sonra önizlemesi göster.
+```
+
+Eşdeğer MCP istem şablonu: `ps.apply_color_grade` ile `{ preset: "warm_film" }`.
+
+</details>
+
+<details>
+<summary>🏢 Toplu marka mockup'ları</summary>
+
+```
+Kartvizit, A4 belge, ambalaj ve sosyal profil için Smart Object'leri olan bir mockup PSD açık.
+~/assets/brand/ içindeki varlıklarla her Smart Object'i değiştir — katmanları düzleştirme, perspektif ve gölgeleri koru.
+batch_mockup_replace recipe'yi çalıştır ve varyant başına bir JPEG'i ~/.photoshop-mcp/exports/mockups/'a dışa aktar.
+Tüm çıktı yollarını bir tabloda listele.
+```
+
+Eşdeğer şablon: `ps.batch_mockup_replace`.
+
+</details>
+
+<details>
+<summary>🏷️ Ana dosyadan çoklu varyant dışa aktarımı</summary>
+
+```
+1:1 bir ana kreatif ve ~/assets/logos/ içinde birden fazla logo var.
+Her varyant için aynı PSD'den Story 9:16, Feed 4:5 ve banner 1200×628 dışa aktar — logo ve metin için Smart Object kullan.
+Dosyaları Varyant_Format.jpg olarak adlandır ve hepsini ~/.photoshop-mcp/exports/variants/'a kaydet.
+Bir adım başarısız olursa get_state oku ve yalnızca bir sonraki adımı öner.
+Bitince tüm yolları bir tabloda listele.
+```
+
+</details>
+
+## Özellikler
+
+- **Bağımsız web UI** — yerel sohbet arayüzü (`photoshop-mcp-ui`); sağlayıcı başına API anahtarı
+  veya CLI abonelik kimlik doğrulaması (Anthropic, Google)
+- **Action Plan (beta)** — web UI'da isteğe bağlı plan-sonra-uygula modu (yalnızca API anahtarı):
+  tek bir planlama çağrısı, doğrudan araç yürütme, başarısızlıkta sınırlı onarım
+- **Hem Windows hem macOS'ta çalışır**
+- **Photoshop 2012–2025+ destekler**
+- **ExtendScript API**: AppleScript/COM otomasyonu aracılığıyla evrensel uyumluluk
+- **Otomatik Algılama**: Sisteminizdeki Photoshop kurulumunu otomatik bulur
+- **86 Araç**: 74 atomik `photoshop_*` + 12 tarif `photoshop_recipe_*`
+- **Yapay Zeka/İstem Katmanı**: 19 MCP istem şablonu (12 tarif + 7 kılavuz), sunucu talimatları,
+  durum/önizleme/yetenek araçları
+- **Belge Yönetimi**: Belge oluşturma, açma, kaydetme, kapatma, kırpma
+- **Katman İşlemleri**: Katman oluşturma, silme, çoğaltma, birleştirme, dönüştürme
+- **Katman Özellikleri**: Opaklık, karışım modları, görünürlük, kilitleme
+- **Metin Biçimlendirme**: Yazı tipi, boyut, renk, hizalama kontrolleri
+- **Görsel Yerleştirme**: Görsel yerleştirme, dosya açma, belgeye sığdırma
+- **Filtreler**: Gaussian Blur, Keskinleştirme, Gürültü, Motion Blur
+- **Renk Ayarlamaları**: Parlaklık/Kontrast, Ton/Doygunluk, Eğriler, Otomatik Düzeyler/Kontrast
+- **Seçimler ve Maskeler**: Dikdörtgen seçimler, konu seçme, içerik duyarlı doldurma,
+  degrade maske, katman maskeleri
+- **Geçmiş Kontrolü**: Geri Al/Yeniden Yap işlemleri, geçmiş durumlarını görüntüleme
+- **Eylemler**: Kayıtlı eylemleri çalıştırma, özel betikler çalıştırma
+- **Otomatik Rasterleştirme**: Filtreler için gerektiğinde katmanları otomatik dönüştürür
+- **Bağlam Takibi**: Yapay zeka bağlam farkındalığı için her işlemden sonra belge/katman
+  durumunu döndürür
+
+## Kurulum
+
+### NPX Kullanımı (Önerilen)
+
+Kurulum gerekmez! Sadece MCP istemcinizi yapılandırın:
+
+```bash
+npx @alisaitteke/photoshop-mcp
+```
+
+Depoyu yerel olarak geliştirmek için geliştirme kılavuzundaki [Kaynaktan](docs/development.md#from-source) bölümüne bakın.
+
+## Yapılandırma
+
+### Cursor için
+
+Cursor ayarlarınıza ekleyin (`.cursor/config.json` veya workspace ayarları):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop için
+
+Claude Desktop yapılandırmanıza ekleyin (macOS'ta `~/Library/Application Support/Claude/claude_desktop_config.json` veya Windows'ta `%APPDATA%\Claude\claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### Ortam Değişkenleri
+
+- `PHOTOSHOP_PATH`: (İsteğe bağlı) Özel Photoshop kurulum yolunu belirtin
+- `LOG_LEVEL`: Günlük kaydı düzeyi (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR)
+- `ANALYTICS_DISABLED`: Anonim kullanım analizlerini tamamen devre dışı bırakmak için `1` veya `true`
+  olarak ayarlayın
+- `POSTHOG_DISABLED`: `ANALYTICS_DISABLED` için eski takma ad
+- `ANALYTICS_PROVIDER`: Analiz arka ucu — `mixpanel` (varsayılan) veya `posthog` (geri alma)
+- `MIXPANEL_TOKEN`: (İsteğe bağlı) Mixpanel proje tokenını geçersiz kılın
+- `MIXPANEL_API_HOST`: (İsteğe bağlı) Mixpanel ingest host'u (varsayılan: `https://api-eu.mixpanel.com`)
+- `POSTHOG_KEY`: (İsteğe bağlı, eski) PostHog proje anahtarı — yalnızca `ANALYTICS_PROVIDER=posthog`
+  olduğunda kullanılır
+- `POSTHOG_API_HOST`: (İsteğe bağlı, eski) PostHog ingest host'u (varsayılan: `https://a.alisait.com`)
+- `POSTHOG_UI_HOST`: (İsteğe bağlı, eski) PostHog UI host'u (varsayılan: `https://eu.posthog.com`)
+
+## Mevcut Araçlar
+
+Tüm atomik `photoshop_*` araçları için tam başvuru (parametreler, örnekler ve kullanım):
+[`docs/available-tools.md`](docs/available-tools.md).
+
+
+## Bağlam Takibi
+
+Her araç, Photoshop'un mevcut durumu hakkında aşağıdakiler dahil kapsamlı bağlam bilgisi döndürür:
+
+- **Belge Bilgisi**: Ad, boyutlar, çözünürlük, renk modu, katman sayısı
+- **Aktif Katman Bilgisi**: Ad, tür, opaklık, karışım modu, görünürlük, kilit durumu
+- **Seçim Durumu**: Bir seçimin aktif olup olmadığı
+- **İşlem Sonucu**: Neyin değiştirildiğine ilişkin özel ayrıntılar
+
+Bu, yapay zeka asistanlarının şunların farkında kalmasını sağlar:
+- Hangi belgenin aktif olduğu
+- Üzerinde çalışılan katman
+- Mevcut katman özellikleri (opaklık, karışım modu vb.)
+- Belge boyutları ve ayarları
+
+**Örnek Yanıt:**
+```javascript
+{
+  "applied": true,
+  "filter": "Gaussian Blur",
+  "radius": 10,
+  "wasRasterized": true,
+  "context": {
+    "hasDocument": true,
+    "document": {
+      "name": "design.psd",
+      "width": 1920,
+      "height": 1080,
+      "resolution": 72,
+      "colorMode": "RGBColorMode",
+      "layerCount": 3,
+      "hasSelection": false
+    },
+    "activeLayer": {
+      "name": "Background",
+      "kind": "NORMAL",
+      "opacity": 100,
+      "blendMode": "NORMAL",
+      "visible": true,
+      "locked": false,
+      "isBackground": false
+    }
+  }
+}
+```
+
+Bu bağlam, yapay zeka asistanlarının birden fazla komut boyunca hangi belge ve katman üzerinde
+çalıştıklarını hatırlamasına yardımcı olur.
+
+---
+
+## Platforma Özgü Notlar
+
+### Windows
+
+- Photoshop ile iletişim kurmak için COM otomasyonu kullanır
+- Kurulum yolları için kayıt defteri tabanlı otomatik algılama
+- Hem 32-bit hem 64-bit sürümleri destekler
+
+### macOS
+
+- Photoshop iletişimi için AppleScript/OSA kullanır
+- Spotlight tabanlı otomatik algılama
+- Aynı anda yüklü birden fazla Photoshop sürümünü destekler
+- **CLI hesabı kimlik doğrulaması** (bağımsız UI) macOS önceliklidir: Terminal'de
+  `claude auth login` / `gemini auth login` çalıştırın; kimlik bilgileri `~/.claude/`
+  ve `~/.gemini/` altında saklanır
+
+## Desteklenen Photoshop Sürümleri
+
+- **Tüm Photoshop sürümleri** (2012–2025+): AppleScript (macOS) veya COM (Windows) aracılığıyla
+  ExtendScript API kullanır
+
+**Önemli Not**: Photoshop 2022+ eklentiler için UXP'yi desteklese de AppleScript/COM aracılığıyla
+harici otomasyon yalnızca ExtendScript kullanabilir. UXP, dahili eklentiler için tasarlanmıştır ve
+harici betiklerden çağrılamaz. Bu nedenle bu MCP sunucusu, tüm Photoshop sürümleriyle maksimum
+uyumluluk için ExtendScript kullanır.
+
+## Sorun Giderme
+
+Yaygın bağlantı, betik ve günlük kaydı sorunları:
+[`docs/troubleshooting.md`](docs/troubleshooting.md).
+
+### Bağımsız UI — CLI hesabı kimlik doğrulaması
+
+| Belirti | Olası neden | Düzeltme |
+|---|---|---|
+| `cli_not_found` | Claude Code / Gemini CLI yüklü değil | `npm i -g @anthropic-ai/claude-code` veya `npm i -g @google/gemini-cli` |
+| `not_authenticated` | OAuth oturumu yok | Terminal'de `claude auth login` veya `gemini auth login` çalıştırın |
+| `claude` / `gemini` `PATH`'de yok | Özel kurulum konumu | Ayarlar → **CLI path** → **Check connection** |
+| Sohbet IDE'de çalışıyor ama UI'da çalışmıyor (CLI modu) | OAuth tokenları yalnızca CLI'ya özgü | UI'da **CLI account** kullanın; API anahtarları ve CLI oturumları ayrıdır |
+| Gemini çok turlu konuşmalarda unutkanlık gösteriyor | Başsız CLI her turda yeni oturum açabilir | Bilinen kısıtlama; geçmiş isteme eklenir (MVP) |
+
+## Geliştirme
+
+Kaynaktan kurulum, derleme, lint, entegrasyon testleri (son sonuçlarla) ve kullanım örnekleri:
+[`docs/development.md`](docs/development.md).
+
+## Mimari
+
+Sistem tasarımı, veri akışı, platform soyutlaması ve UI ajan modları:
+[`docs/architecture.md`](docs/architecture.md).
+
+LinkedIn veya sosyal medyada paylaşıyor musunuz? OG kurulumu ve gönderi metni için
+[`images/og-social.png`](images/og-social.png) ve
+[`docs/social-preview.md`](docs/social-preview.md) kullanın.
+
+## Katkıda Bulunma
+
+Katkılar memnuniyetle karşılanır! PR açmadan önce lütfen [CONTRIBUTING.md](CONTRIBUTING.md)
+dosyasını okuyun.
+
+## Geliştirici Hakkında
+
+**[Ali Sait Teke](https://alisait.com)** — Full-Stack mühendis & yapay zeka çağı yazılım mimarı
+(Python, Go, Node.js, React, Next.js, Vue).
+
+Bu proje pratik bir sorudan doğdu: *Photoshop'u kırılgan tek seferlik betikler olmadan LLM'lerle
+nasıl güvenilir biçimde kontrol edersiniz?* 80 araçlı bir MCP sunucusuna, güvenilir çok adımlı
+iş akışları için bir tarif/istem katmanına ve yaratıcı çalışmanın bir IDE gerektirmemesi için
+yerel bir web UI'ya dönüştü.
+
+**Bu kod tabanının gösterdikleri:** TypeScript sistem tasarımı, MCP protokol entegrasyonu,
+platformlar arası masaüstü otomasyonu (macOS AppleScript / Windows COM), ajantik döngüler için
+yapılandırılmış hata kurtarma ve üretim odaklı yerel öncelikli UI (Vue 3 + Hono + SQLite).
+
+- [Portfolio](https://alisait.com) · [GitHub](https://github.com/alisaitteke) · [LinkedIn](https://www.linkedin.com/in/alisait/)
+
+## Lisans
+
+MIT
+
+## Anonim Kullanım Analitiği
+
+Ürünü geliştirmek için varsayılan olarak anonim, toplu kullanım olayları toplanır. İstediğiniz
+zaman çıkabilirsiniz. Tüm ayrıntılar:
+[`docs/anonymous-usage-analytics.md`](docs/anonymous-usage-analytics.md).
+
+## Teşekkürler
+
+- [Model Context Protocol SDK](https://github.com/modelcontextprotocol/sdk) ile geliştirildi
+- Adobe Photoshop betik yazım topluluğundan ilham alındı

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,710 @@
+# Photoshop MCP Server
+
+<p align="center">
+  <a href="https://github.com/alisaitteke/photoshop-mcp">
+    <img src="./images/readme-hero.png" alt="Photoshop MCP — AI 驱动的 Photoshop 自动化" width="100%" />
+  </a>
+</p>
+
+**语言：** [English](README.md) · 简体中文 · [Español](README.es.md) · [Deutsch](README.de.md) · [日本語](README.ja.md) · [Türkçe](README.tr.md)
+
+*v1.1+ — 配方工作流、更少的往返调用、更流畅的会话。独立 UI 附带 **Action Plan（测试版）**，支持先规划后执行的运行模式。*
+
+> **注意：** 这是一个非官方的社区维护项目，与 Adobe Inc. 无任何关联，亦未获其背书。
+
+[![npm version](https://img.shields.io/npm/v/@alisaitteke/photoshop-mcp.svg)](https://www.npmjs.com/package/@alisaitteke/photoshop-mcp)
+[![GitHub release](https://img.shields.io/github/v/release/alisaitteke/photoshop-mcp?include_prereleases)](https://github.com/alisaitteke/photoshop-mcp/releases)
+[![Action Plan](https://img.shields.io/badge/Action%20Plan-beta-amber.svg)](#action-plan-beta)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS-lightgrey.svg)]()
+
+一个模型上下文协议（MCP）服务器，使 Claude 和 Cursor 等 AI 助手能够以编程方式控制 Adobe Photoshop。通过这个工具，您可以在 IDE 中使用自然语言命令创建设计、处理图像并自动化 Photoshop 工作流——或者通过捆绑的**独立 Web UI** 进行操作，后者同时支持 API 密钥和 CLI 订阅账户（Claude Code / Gemini CLI）。该 UI 还提供可选的 **Action Plan（测试版）** 模式，可在一次 LLM 调用中规划所有 Photoshop 步骤，然后一次性执行。
+
+## 为何创建此项目
+
+设计师和开发者希望通过 AI 助手驱动 Photoshop，但原始的 ExtendScript 调用十分脆弱：代理会在试错过程中浪费大量 token，图层类型会破坏滤镜，一个失败的命令便会让文档陷入未知状态。
+
+Photoshop MCP 添加了**状态感知**（`get_state`、`get_preview`、`get_capabilities`）、**配方工具**（将多步骤操作包装为单一撤销步骤），以及**结构化错误信封**，让代理知道下一步应该尝试什么。可选的独立 UI 和 Action Plan 模式可减少较长工作流中的往返次数——让自然语言真正能够产出像素，而不仅仅是给出建议。
+
+工程深度解析：[`docs/architecture.md`](docs/architecture.md)。
+
+## 🖥️ 独立 UI（无需 IDE）
+
+不想将其接入 Claude Desktop 或 Cursor？同一个软件包附带了一个完全本地化的 Web UI，让您可以与 AI 模型聊天，并通过底层的 MCP 服务器驱动 Photoshop。使用提供商 API 密钥进行连接，**或者**对于 Anthropic 和 Google，复用 **Claude Code** 或 **Gemini CLI** 的 OAuth 会话——无需单独的 API 密钥。
+
+![独立 UI 截图](./images/frame_generic_light.png)
+
+```bash
+npx -p @alisaitteke/photoshop-mcp photoshop-mcp-ui
+```
+
+就这样。本地服务器在 `127.0.0.1`（随机空闲端口）上启动，您的默认浏览器会自动打开聊天 UI。
+
+### 支持的提供商
+
+首次启动时选择以下任意一个——使用 API 密钥**或**您现有的 CLI 订阅账户（Anthropic 和 Google）：
+
+| 提供商 | 模型 | API 密钥 | CLI 账户 |
+|---|---|---|---|
+| **Anthropic** | Claude Sonnet / Opus / Haiku | [console.anthropic.com](https://console.anthropic.com/settings/keys) | `npm i -g @anthropic-ai/claude-code` → `claude auth login` |
+| **OpenAI** | GPT-5, GPT-4.1, o-series | [platform.openai.com](https://platform.openai.com/api-keys) | — |
+| **Google** | Gemini 2.5 Pro / Flash / Flash-Lite | [aistudio.google.com](https://aistudio.google.com/apikey) | `npm i -g @google/gemini-cli` → `gemini auth login` |
+| **OpenRouter** | 100+ 来自任意提供商的模型 | [openrouter.ai](https://openrouter.ai/keys) | — |
+
+### 认证模式
+
+- **`api_key`（默认）** — 使用 Vercel AI SDK 和您的提供商 API 密钥。按 API 费率按 token 计费；UI 显示每次聊天的预估费用。
+- **`cli_account`** — 使用您本地的 Claude Code 或 Gemini CLI OAuth 会话。不存储 API 密钥；UI 通过无头模式的 `claude auth status` / `gemini` 探测验证登录状态。使用量计入您的**订阅配额**，而非 API 账单——状态栏显示"订阅已包含"。
+
+您可以在"设置"中按提供商切换认证方式，不会丢失另一种凭据（例如，保留 API 密钥的同时尝试 CLI 账户，之后再切换回来）。
+
+### Action Plan（测试版）
+
+独立 Web UI 中的可选执行模式，**仅适用于 API 密钥认证**（`cli_account` 始终使用默认的代理流程）。在 composer 中的模型选择器旁边，通过 **Action Plan** 开关开启。
+
+与逐步 ReAct 循环（模型 → 工具 → 模型 → 工具……）不同，Action Plan：
+
+1. 发起**一次** LLM 规划调用，输出包含参数的 Photoshop MCP 工具调用有序待办清单。
+2. **直接**按顺序执行这些工具——步骤之间无额外的模型往返。
+3. 若某步骤失败或存在未解决的依赖项，运行有界**修复**循环（仅重新规划剩余步骤，最多 3 次）。
+
+计划以实时待办清单的形式显示在工具调用卡片上方，附带每步状态（`pending` → `running` → `done` / `error`）。计划会持久化到聊天历史中，重载后不会丢失。开关默认关闭；禁用 Action Plan 时，现有的代理流程不受影响。
+
+适合多步骤提示词，例如*"移除背景并导出为 Web 格式"*——可减少模型调用次数，加快端到端执行速度。
+
+### 首次启动时的流程
+
+1. 选择提供商，选择 **API 密钥**或 **Uses your account**。
+2. 验证密钥或检查 CLI 连接。配置以 `~/.photoshop-mcp/data.db`（SQLite，`chmod 600`）的形式存储在本地。API 密钥永远不会离开您的设备；CLI 模式继承来自 `~/.claude/` 或 `~/.gemini/` 的 OAuth 凭据。
+3. 输入自然语言提示词。UI 实时流式传输模型回复，实时执行 Photoshop 工具调用，并将每次工具调用渲染为可检查的卡片（输入 + 结果）。
+4. 随时从设置/模型选择器切换提供商、认证方式或模型——聊天记录、费用和工具历史会跨会话持久化。
+
+### 后续切换认证方式
+
+随时从侧边栏打开**设置**：
+
+| 操作 | API 密钥模式 | CLI 账户模式 |
+|---|---|---|
+| 设置 | 粘贴密钥 → **保存** | 安装 CLI → `auth login` → **检查连接** |
+| 切换 | 选择 **API 密钥** — 已存储的密钥保留 | 选择 **Uses your account** — 密钥不会被删除 |
+| 自定义二进制路径 | — | 若 `claude` / `gemini` 不在 `PATH` 上，可填写可选的 **CLI 路径** |
+| 费用显示 | 状态栏中的按 token 预估 | **订阅已包含**徽章 |
+
+认证方式以每提供商为单位存储在 `~/.photoshop-mcp/data.db` 中（`authMethod`：`api_key` 或 `cli_account`）。不含 `authMethod` 的现有配置默认为 `api_key`，保持正常工作。
+
+### CLI 参数
+
+```
+photoshop-mcp-ui [--port 5174] [--host 127.0.0.1] [--no-open]
+```
+
+### 注意事项
+
+- 代理仅限于使用 Photoshop MCP 工具——内置的 shell、文件和网络工具已禁用。
+- 技术栈：前端使用 Vue 3 + Tailwind v4 + [shadcn-vue](https://www.shadcn-vue.com/)；后端使用 [Hono](https://hono.dev/)。API 密钥模式使用 [Vercel AI SDK](https://sdk.vercel.ai/)；CLI 账户模式使用 [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/mcp)（Anthropic）或 Gemini CLI 无头 `stream-json`（Google）。所有路径均通过 STDIO 与同一个 Photoshop MCP 服务器通信。
+- **CLI 账户限制：** Gemini 无头模式每次对话可能开启新会话（历史记录会预置到提示词中）。Anthropic CLI 账户消耗订阅配额。OAuth 登录以 macOS 优先（在终端中运行 `claude auth login` / `gemini auth login`）。
+
+---
+
+## Photoshop 的 AI/提示词层
+
+在原子化 `photoshop_*` 工具之上，服务器附带了一个有主见的 AI/提示词层，帮助宿主 LLM（Cursor、Claude Desktop 等）将模糊的用户请求转化为可靠的 Photoshop 操作：
+
+- **服务器 `instructions`** — 在 MCP `initialize` 时广播的工作流契约（ping 一次、操作前获取状态、优先使用配方、错误恢复）。参见 [`src/prompts/instructions.ts`](src/prompts/instructions.ts)。
+- **MCP `prompts` 原语** — 19 个预先设计的模板（12 个配方 + 7 个指南：`ps.enhance_portrait`、`ps.remove_background`、`ps.generative_fill`……），通过 `prompts/list` 和 `prompts/get` 获取。
+- **配方工具** — 12 个面向结果的 `photoshop_recipe_*` 工具（移除背景、增强人像、准备网络发布、导出社交媒体变体、色彩分级、频率分离、批量样机替换、整理图层、渐变淡出、天空混合、减淡与加深、移除干扰物）。每个工具将步骤包装在单一 Photoshop 历史状态中（一次撤销可还原全部）。**共 86 个工具**（74 个原子工具 + 12 个配方工具）。
+- **生成式 AI** — `photoshop_generative_fill`、`photoshop_generative_remove`、`photoshop_generative_expand`、`photoshop_generative_upscale`、`photoshop_sky_replacement`、`photoshop_generate_image`（通过 ExtendScript 调用 Firefly；需要 Adobe 账户和积分）。
+- **Neural Filters** — 通过可选的 UXP 桥接插件（`uxp-plugin/`）使用 `photoshop_neural_filter`。
+- **状态与预览** — `photoshop_get_state`（轻量快照）、`photoshop_get_preview`（用于视觉验证的 base64 JPEG）、`photoshop_get_capabilities`（版本感知功能标志）。
+- **结构化错误** — 失败时返回包含 `code` 和 `suggested_next_tool` 的 JSON 信封，用于自我纠错。
+
+完整参考：[`docs/prompt-layer.md`](docs/prompt-layer.md)。
+
+验证一致性：`npm run verify:photoshop-prompts`。最新结果：[`docs/development.md#integration-test-results`](docs/development.md#integration-test-results)。
+
+## 示例提示词
+
+以下是您在配置此 MCP 服务器后可与 AI 助手（Claude、Cursor 等）一起使用的示例提示词。对于多步骤结果，优先使用**配方工具**（`photoshop_recipe_*`）——每个配方是单一撤销步骤。仅对配方未覆盖的精细编辑使用原子 `photoshop_*` 工具。
+
+<details>
+<summary>🧠 状态感知会话（推荐的第一步）</summary>
+
+```
+连接 Photoshop 并读取我当前安装版本的功能信息。
+在做任何更改之前，先获取当前文档状态。
+打开 portrait.jpg，获取缩小的预览图，以便确认主体对象。
+每执行完一个主要配方后，再次获取预览图以确认效果。
+```
+
+</details>
+
+<details>
+<summary>👤 人像修饰（配方）</summary>
+
+```
+以中等强度对活动图层上的人像进行增强，并开启皮肤磨皮。
+使用 enhance-portrait recipe——我希望在一个可撤销的步骤内同时完成频率分离和自动色调调整。
+如果活动图层是文字或 Smart Object，请先栅格化，或选择一个栅格图层。
+完成后给我看一下预览效果。
+```
+
+等效 MCP 提示词模板：`ps.enhance_portrait`，参数为 `{ intensity: "medium", skin_smoothing: "true" }`。
+
+</details>
+
+<details>
+<summary>✂️ 背景移除（配方）</summary>
+
+```
+移除活动人像图层的背景。
+使用 Select Subject 配合 2px 羽化的图层蒙版，保留蒙版后面的原始像素。
+如果 brief 要求纯白底，填充 RGB(255,255,255)，主体居中并占画面至少 70%。
+主体必须在活动图层上——不能是纯色填充图层。
+```
+
+等效 MCP 提示词模板：`ps.remove_background`，参数为 `{ feather_px: "2", keep_shadow: "false" }`。
+
+</details>
+
+<details>
+<summary>🎨 色彩分级（配方）</summary>
+
+```
+以非破坏性调整图层的方式，对打开的文档应用暖色电影色调分级。
+使用 apply-color-grade recipe，预设选择 warm_film。
+完成后预览效果。
+```
+
+</details>
+
+<details>
+<summary>🔬 频率分离设置（配方）</summary>
+
+```
+在活动栅格图层上设置频率分离，模糊半径为 6px。
+我会自己在低频层和高频层上绘制——不要额外添加磨皮处理。
+图层堆栈准备好后，告诉我应该编辑哪些图层。
+```
+
+等效 MCP 提示词模板：`ps.frequency_separation`，参数为 `{ radius_px: "6" }`。
+
+</details>
+
+<details>
+<summary>🌐 网络准备 + 社交媒体导出（配方）</summary>
+
+```
+将活动文档准备好用于网络发布：转换为 sRGB，缩小尺寸，锐化，并将一张优化后的 JPEG 导出到 ~/.photoshop-mcp/exports。
+然后从同一文档导出 Instagram 帖子（1080×1080）、竖版 Feed（1080×1350）、Stories/Reels（1080×1920）和 X 帖子（1200×675）变体。
+将输出路径以表格形式列出。
+```
+
+等效模板：`ps.prepare_for_web`、`ps.export_social_variants`。
+
+</details>
+
+<details>
+<summary>📦 批量样机替换（配方）</summary>
+
+```
+我有一个样机 PSD 文件已打开，其中有一个名为"Screen"的 Smart Object 图层。
+将其替换为 ~/assets/mockups/ 中的每个 PNG/JPG 文件，并为每个素材导出一张 JPEG。
+不要放置普通图层——替换 Smart Object 以保留透视效果。
+```
+
+等效 MCP 提示词模板：`ps.batch_mockup_replace`。
+
+</details>
+
+<details>
+<summary>🗂️ 整理图层（配方）</summary>
+
+```
+整理图层堆栈：按类型重命名，自动将相关图层分组，保留原始内容。
+执行 organize-layers recipe，然后列出图层，以便我查看新的结构。
+```
+
+</details>
+
+<details>
+<summary>🎨 基础设计创建</summary>
+
+```
+创建一个 1920x1080 的 Photoshop 文档，使用 RGB 颜色模式。
+添加一个浅蓝色背景图层，填充 RGB(240, 248, 255)。
+添加居中文字"Welcome"，字号 64pt。
+保存为 welcome.psd 到桌面。
+```
+
+</details>
+
+<details>
+<summary>🖼️ 素材图片设计（配合 Pexels MCP）</summary>
+
+```
+在 Pexels 上搜索"mountain sunset"图片。
+创建一个 1920x1080 的 Photoshop 文档。
+将下载的图片放置进来，并适配填满整个画布。
+应用 3px 的轻微高斯模糊。
+增加亮度 15，对比度 10。
+在顶部居中添加白色文字"Adventure Awaits"，字号 72pt。
+将文字不透明度设为 90%，混合模式设为 OVERLAY。
+保存为 adventure.jpg，质量 10。
+```
+
+</details>
+
+<details>
+<summary>✨ 照片增强</summary>
+
+```
+在 Photoshop 中打开桌面上的 photo.jpg。
+获取状态，然后以低强度运行 enhance-portrait recipe。
+如果只需要快速调整色调，改为对活动图层应用自动色阶、自动对比度和 USM 锐化（120%, 1.5, 0）。
+调整色相 +15、饱和度 +15，或在准备好导出时使用 prepare-for-web。
+保存为 enhanced-photo.jpg，质量 12。
+```
+
+</details>
+
+<details>
+<summary>🎭 图层效果与混合</summary>
+
+```
+创建一个 1200x800 的文档。
+添加一个名为"Background"的新图层，填充 RGB(50, 50, 50)。
+将 logo.png 放置在 (100, 100) 位置。
+将 logo 图层缩放至当前尺寸的 50%。
+将混合模式设为 SCREEN，不透明度设为 85%。
+再添加一个图层，填充 RGB(255, 100, 50)。
+将该图层的混合模式设为 MULTIPLY，不透明度设为 60%。
+合并所有可见图层。
+保存为 composite.psd。
+```
+
+</details>
+
+<details>
+<summary>📝 文字海报设计</summary>
+
+```
+创建一个 1080x1350 的竖版文档（Instagram 故事尺寸）。
+添加一个图层，填充渐变感颜色 RGB(120, 40, 200)。
+在 (540, 300) 处添加文字"SUMMER"，字号 96pt。
+将文字颜色更改为白色 RGB(255, 255, 255)。
+将文字对齐方式设为 CENTER。
+在 (540, 450) 处再添加文字"2026"，字号 128pt，白色。
+对背景图层应用 2px 高斯模糊。
+保存为 summer-poster.png。
+```
+
+</details>
+
+<details>
+<summary>🎬 批处理</summary>
+
+```
+打开 image1.jpg。
+调整尺寸为 1920x1080。
+应用自动对比度。
+应用轻微锐化（强度 80%，半径 1.0）。
+保存为 processed-1.jpg，质量 10。
+关闭文件，不保存对原文件的修改。
+
+对 image2.jpg 和 image3.jpg 重复以上步骤。
+```
+
+</details>
+
+<details>
+<summary>🖌️ 创意操控</summary>
+
+```
+创建一个 2000x2000 的正方形文档。
+放入 abstract-pattern.jpg 并适配填满文档。
+复制该图层。
+在副本图层上，应用 45 度方向、半径 50px 的动态模糊。
+将混合模式设为 OVERLAY，不透明度设为 70%。
+居中添加白色文字"MOTION"，字号 120pt。
+创建从 (200, 200) 到 (1800, 1800) 的矩形选区。
+反选并删除（制造边框效果）。
+拼合图像。
+保存为 motion-art.jpg。
+```
+
+</details>
+
+<details>
+<summary>🎯 高级工作流</summary>
+
+```
+创建一个用于印刷的 3000x2000、300 DPI 文档。
+放入 hero-image.jpg 并适配填满画布。
+复制图像图层。
+在副本图层上，将其完全去饱和。
+将混合模式设为 LUMINOSITY，不透明度设为 50%。
+创建一个名为"Overlay"的新图层。
+填充 RGB(255, 150, 0)，将混合模式设为 SOFTLIGHT，不透明度 30%。
+在顶部居中 (1500, 200) 处添加文字"PORTFOLIO"，字号 96pt。
+将文字颜色设为白色。
+在 (1500, 320) 处添加副标题"2026 Collection"，字号 36pt。
+在文字区域周围创建矩形选区。
+在叠加图层上创建图层蒙版。
+合并可见图层。
+保存为 portfolio-cover.psd。
+导出为 portfolio-cover.jpg，质量 12。
+```
+
+</details>
+
+<details>
+<summary>🔄 使用动作</summary>
+
+```
+打开 my-photo.jpg。
+播放"My Actions"动作组中的"Vintage Look"动作。
+将亮度调低 -10，使其略微变暗。
+保存为 vintage-photo.jpg。
+```
+
+</details>
+
+<details>
+<summary>⚡ 自定义脚本执行</summary>
+
+```
+执行以下自定义 ExtendScript 代码：
+app.beep();
+alert('Processing started!');
+```
+
+</details>
+
+<details>
+<summary>⏮️ 撤销/重做操作</summary>
+
+```
+对活动图层应用 15px 的高斯模糊。
+[等待结果]
+这个模糊效果太强了，撤销这步操作。
+改为应用 5px 的高斯模糊。
+```
+
+或：
+
+```
+获取历史状态，查看已执行了哪些操作。
+撤销最后 3 步操作。
+重做 1 步，恢复其中一个操作。
+```
+
+</details>
+
+<details>
+<summary>🔁 错误恢复（结构化信封）</summary>
+
+```
+如果某个配方返回 version_unsupported 或 generative_unavailable，调用 get_capabilities 并告诉我缺少哪个 Photoshop 功能。
+如果某个工具失败并返回 suggested_next_tool，按照提示操作（例如，在执行仅限栅格的配方之前先执行 rasterize_layer）。
+不要猜测——在失败后读取 get_state，然后提出下一个单一操作步骤。
+```
+
+</details>
+
+<details>
+<summary>📱 社交媒体格式套件</summary>
+
+```
+我有一张 1:1 主视觉（2000×2000 px）已打开。
+用 prepare-for-web recipe 将活动文档准备好用于网络发布：转换为 sRGB，裁剪并导出变体。
+然后导出 Instagram Feed（1080×1350）、Stories/Reels（1080×1920，上下安全区）、LinkedIn（1200×628）和横版横幅（1200×628）变体。
+仅在 9:16 格式会裁切主体时使用生成式扩展。
+主体至少占画面 60%；logo 在右上角留 20 px 边距。
+以表格形式列出所有输出路径。
+```
+
+等效模板：`ps.prepare_for_web`、`ps.export_social_variants`。
+
+</details>
+
+<details>
+<summary>🖨️ 印刷完稿（CMYK / 出血）</summary>
+
+```
+将活动文档准备好用于胶印：
+转换为 CMYK，使用 ISO Coated v2 配置文件，四边添加 3 mm 出血，检查最终尺寸 300 dpi 分辨率。
+为印刷配置文件设置软打样，并提示色域外颜色。
+大面积深黑使用 C50 M20 Y20 K100；黑色文字仅用 K100。
+导出带嵌入配置文件的 PDF/X-4，关闭前显示预览。
+```
+
+</details>
+
+<details>
+<summary>🛍️ 生成式填充产品场景</summary>
+
+```
+活动图层上有一张已抠图的产品 PNG。
+用 photoshop_generative_fill 创建三个不同场景：暖光室内、日落户外、带水珠的反射表面。
+每个变体用 photoshop_generative_expand 扩展到 1080×1350（4:5），保持产品居中。
+每个场景完成后获取预览，检查阴影和透视。
+如果 generative_unavailable，调用 get_capabilities 并说明缺少什么。
+```
+
+</details>
+
+<details>
+<summary>🎨 统一色彩分级</summary>
+
+```
+同一项目有 30 张照片，光线各不相同。
+用 apply-color-grade recipe 和 warm_film 预设，以非破坏性调整图层应用色彩分级。
+如有需要，调整曲线和色相/饱和度，营造温暖电影感：冷色阴影、金色高光。
+准备一个动作，将每张图以 1080 px 宽、sRGB、JPEG 质量 85 导出到 ~/.photoshop-mcp/exports/grade/。
+在三张代表性图片上显示前后对比预览。
+```
+
+等效 MCP 提示词模板：`ps.apply_color_grade`，参数为 `{ preset: "warm_film" }`。
+
+</details>
+
+<details>
+<summary>🏢 批量品牌样机</summary>
+
+```
+我打开了一个样机 PSD，包含名片、A4 文档、包装和社交资料 Smart Object。
+用 ~/assets/brand/ 中的素材替换每个 Smart Object，不要拼合图层——保留透视和阴影。
+运行 batch_mockup_replace recipe，每个变体导出一张 JPEG 到 ~/.photoshop-mcp/exports/mockups/。
+以表格形式列出所有输出路径。
+```
+
+等效模板：`ps.batch_mockup_replace`。
+
+</details>
+
+<details>
+<summary>🏷️ 从主文件导出多版本</summary>
+
+```
+我有一张 1:1 主创意和 ~/assets/logos/ 中的多个 logo。
+每个变体从同一 PSD 导出 Story 9:16、Feed 4:5 和横幅 1200×628，用 Smart Object 放置 logo 和文字。
+文件命名为 变体_格式.jpg，全部保存到 ~/.photoshop-mcp/exports/variants/。
+如果某步失败，读取 get_state 并只建议下一步。
+完成后用表格列出所有路径。
+```
+
+</details>
+
+## 功能特性
+
+- **独立 Web UI** — 本地聊天界面（`photoshop-mcp-ui`）；每个提供商支持 API 密钥或 CLI 订阅认证（Anthropic、Google）
+- **Action Plan（测试版）** — Web UI 中可选的先规划后执行模式（仅 API 密钥）：一次规划调用、直接工具执行、失败时有界修复
+- **同时支持 Windows 和 macOS**
+- **支持 Photoshop 2012-2025+**
+- **ExtendScript API**：通过 AppleScript/COM 自动化实现通用兼容性
+- **自动检测**：自动在系统上找到 Photoshop 安装路径
+- **78 个工具**：66 个原子 `photoshop_*` + 12 个配方 `photoshop_recipe_*`
+- **AI/提示词层**：16 个 MCP 提示词模板（12 个配方 + 4 个指南）、服务器指令、状态/预览/能力工具
+- **文档管理**：创建、打开、保存、关闭、裁剪文档
+- **图层操作**：创建、删除、复制、合并、变换图层
+- **图层属性**：不透明度、混合模式、可见性、锁定
+- **文字格式化**：字体、大小、颜色、对齐控制
+- **图片放置**：放置图片、打开文件、适应文档
+- **滤镜**：高斯模糊、锐化、噪点、动态模糊
+- **色彩调整**：亮度/对比度、色相/饱和度、曲线、自动色阶/对比度
+- **选区与蒙版**：矩形选区、选择主体、内容感知填充、渐变蒙版、图层蒙版
+- **历史控制**：撤销/重做操作、查看历史状态
+- **动作**：播放录制的动作、执行自定义脚本
+- **自动栅格化**：在需要时自动转换图层以用于滤镜
+- **上下文追踪**：每次操作后返回文档/图层状态，以便 AI 保持上下文感知
+
+## 安装
+
+### 使用 NPX（推荐）
+
+无需安装！只需配置您的 MCP 客户端：
+
+```bash
+npx @alisaitteke/photoshop-mcp
+```
+
+如需在本地对仓库进行开发，请参阅开发指南中的[从源码安装](docs/development.md#from-source)。
+
+## 配置
+
+### 适用于 Cursor
+
+在您的 Cursor 设置（`.cursor/config.json` 或工作区设置）中添加：
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### 适用于 Claude Desktop
+
+在您的 Claude Desktop 配置（macOS 上为 `~/Library/Application Support/Claude/claude_desktop_config.json`，Windows 上为 `%APPDATA%\Claude\claude_desktop_config.json`）中添加：
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+### 环境变量
+
+- `PHOTOSHOP_PATH`：（可选）指定自定义 Photoshop 安装路径
+- `LOG_LEVEL`：日志级别（0=DEBUG，1=INFO，2=WARN，3=ERROR）
+- `ANALYTICS_DISABLED`：设置为 `1` 或 `true` 可完全禁用匿名使用分析
+- `POSTHOG_DISABLED`：`ANALYTICS_DISABLED` 的旧版别名
+- `ANALYTICS_PROVIDER`：分析后端 — `mixpanel`（默认）或 `posthog`（回滚）
+- `MIXPANEL_TOKEN`：（可选）覆盖 Mixpanel 项目令牌
+- `MIXPANEL_API_HOST`：（可选）Mixpanel 数据采集主机（默认：`https://api-eu.mixpanel.com`）
+- `POSTHOG_KEY`：（可选，旧版）PostHog 项目密钥 — 仅在 `ANALYTICS_PROVIDER=posthog` 时使用
+- `POSTHOG_API_HOST`：（可选，旧版）PostHog 数据采集主机（默认：`https://a.alisait.com`）
+- `POSTHOG_UI_HOST`：（可选，旧版）PostHog UI 主机（默认：`https://eu.posthog.com`）
+
+## 可用工具
+
+所有原子 `photoshop_*` 工具的完整参考（参数、示例和用法）：[`docs/available-tools.md`](docs/available-tools.md)。
+
+
+## 上下文追踪
+
+每个工具都会返回关于 Photoshop 当前状态的全面上下文信息，包括：
+
+- **文档信息**：名称、尺寸、分辨率、色彩模式、图层数量
+- **活动图层信息**：名称、类型、不透明度、混合模式、可见性、锁定状态
+- **选区状态**：是否有活动选区
+- **操作结果**：关于所做更改的具体详情
+
+这使 AI 助手能够保持对以下内容的感知：
+- 当前活动文档
+- 正在处理的图层
+- 当前图层属性（不透明度、混合模式等）
+- 文档尺寸与设置
+
+**响应示例：**
+```javascript
+{
+  "applied": true,
+  "filter": "Gaussian Blur",
+  "radius": 10,
+  "wasRasterized": true,
+  "context": {
+    "hasDocument": true,
+    "document": {
+      "name": "design.psd",
+      "width": 1920,
+      "height": 1080,
+      "resolution": 72,
+      "colorMode": "RGBColorMode",
+      "layerCount": 3,
+      "hasSelection": false
+    },
+    "activeLayer": {
+      "name": "Background",
+      "kind": "NORMAL",
+      "opacity": 100,
+      "blendMode": "NORMAL",
+      "visible": true,
+      "locked": false,
+      "isBackground": false
+    }
+  }
+}
+```
+
+此上下文帮助 AI 助手在多条命令中记住正在处理的文档和图层。
+
+---
+
+## 平台特定说明
+
+### Windows
+
+- 使用 COM 自动化与 Photoshop 通信
+- 基于注册表的安装路径自动检测
+- 支持 32 位和 64 位版本
+
+### macOS
+
+- 使用 AppleScript/OSA 与 Photoshop 通信
+- 基于 Spotlight 的自动检测
+- 支持同时安装多个 Photoshop 版本
+- **CLI 账户认证**（独立 UI）以 macOS 优先：在终端中运行 `claude auth login` / `gemini auth login`；凭据存储在 `~/.claude/` 和 `~/.gemini/` 下
+
+## 支持的 Photoshop 版本
+
+- **所有 Photoshop 版本**（2012-2025+）：通过 AppleScript（macOS）或 COM（Windows）使用 ExtendScript API
+
+**重要说明**：虽然 Photoshop 2022+ 支持用于插件的 UXP，但通过 AppleScript/COM 的外部自动化只能使用 ExtendScript。UXP 专为内部插件设计，无法从外部脚本调用。因此，此 MCP 服务器使用 ExtendScript 以实现跨所有 Photoshop 版本的最大兼容性。
+
+## 故障排除
+
+常见的连接、脚本和日志问题：[`docs/troubleshooting.md`](docs/troubleshooting.md)。
+
+### 独立 UI — CLI 账户认证
+
+| 症状 | 可能原因 | 修复方法 |
+|---|---|---|
+| `cli_not_found` | Claude Code / Gemini CLI 未安装 | `npm i -g @anthropic-ai/claude-code` 或 `npm i -g @google/gemini-cli` |
+| `not_authenticated` | 无 OAuth 会话 | 在终端中运行 `claude auth login` 或 `gemini auth login` |
+| `claude` / `gemini` 不在 `PATH` 上 | 自定义安装位置 | 设置 → **CLI 路径** → **检查连接** |
+| 在 IDE 中聊天正常但 UI 中无法使用（CLI 模式） | OAuth 令牌仅限 CLI | 在 UI 中使用 **CLI 账户**；API 密钥和 CLI 会话是分开的 |
+| Gemini 多轮对话感觉健忘 | 无头 CLI 每次对话可能开启新会话 | 已知限制；历史记录会预置到提示词中（MVP） |
+
+## 开发
+
+从源码设置、构建、lint、集成测试（含最新结果）和使用示例：[`docs/development.md`](docs/development.md)。
+
+## 架构
+
+系统设计、数据流、平台抽象和 UI 代理模式：[`docs/architecture.md`](docs/architecture.md)。
+
+在 LinkedIn 或社交媒体上分享？使用 [`images/og-social.png`](images/og-social.png) 和 [`docs/social-preview.md`](docs/social-preview.md) 进行 OG 设置和帖子文案。
+
+## 贡献
+
+欢迎贡献！开 PR 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+## 关于维护者
+
+**[Ali Sait Teke](https://alisait.com)** — 全栈工程师及 AI 时代软件架构师（Python、Go、Node.js、React、Next.js、Vue）。
+
+这个项目起源于一个实际问题：*如何在不依赖脆弱的一次性脚本的情况下，让 Photoshop 被 LLM 可靠地控制？* 它逐渐演变为一个拥有 80 个工具的 MCP 服务器、用于可靠多步骤工作流的配方/提示词层，以及一个无需 IDE 即可进行创意工作的本地 Web UI。
+
+**此代码库展示了：** TypeScript 系统设计、MCP 协议集成、跨平台桌面自动化（macOS AppleScript / Windows COM）、代理循环的结构化错误恢复，以及一个以生产为导向的本地优先 UI（Vue 3 + Hono + SQLite）。
+
+- [个人网站](https://alisait.com) · [GitHub](https://github.com/alisaitteke) · [LinkedIn](https://www.linkedin.com/in/alisait/)
+
+## 许可证
+
+MIT
+
+## 匿名使用分析
+
+默认情况下会收集匿名的聚合使用事件，以改进产品。您可以随时选择退出。完整详情：[`docs/anonymous-usage-analytics.md`](docs/anonymous-usage-analytics.md)。
+
+## 致谢
+
+- 基于 [Model Context Protocol SDK](https://github.com/modelcontextprotocol/sdk) 构建
+- 受 Adobe Photoshop 脚本社区的启发


### PR DESCRIPTION
## Summary

Adds locale README translations for Spanish, Simplified Chinese, German, Japanese, and Turkish, with a language switcher on the canonical English README.

## Changes

- New locale files: `README.es.md`, `README.zh-CN.md`, `README.de.md`, `README.ja.md`, `README.tr.md`
- Language banner on `README.md`
- Prompt examples use generic Photoshop workflows (social formats, print prep, generative scenes, color grading, mockups, multi-variant export) without agency/sector targeting

## Test plan

- [ ] Open each locale README on GitHub and confirm language switcher links work
- [ ] Spot-check one `<details>` prompt block per locale for natural translation
- [ ] Confirm no `src/` files changed in this PR