### PR TITLE
feat(analytics): make telemetry opt-in, no bundled tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:mcp-all": "tsx scripts/test-all-mcp-tools.ts",
     "test:intent-expansion": "tsx scripts/test-intent-expansion-local.ts",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test:unit": "vitest run"
   },
   "keywords": [
     "mcp",
@@ -98,7 +99,8 @@
     "eslint": "^9.18.0",
     "prettier": "^3.4.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/src/analytics/config.ts
+++ b/src/analytics/config.ts
@@ -1,8 +1,10 @@
-const DEFAULT_POSTHOG_KEY = 'phc_mejq4ZZ8jTNZPiusjh7vHyPzWYinzsDwVJW43SM5FEcg';
-const DEFAULT_API_HOST = 'https://a.alisait.com';
+// Agency fork: no default telemetry tokens. Analytics only runs when the
+// operator explicitly opts in via ANALYTICS_ENABLED and supplies their own keys.
+const DEFAULT_POSTHOG_KEY = '';
+const DEFAULT_API_HOST = 'https://eu.posthog.com';
 const DEFAULT_UI_HOST = 'https://eu.posthog.com';
 
-const DEFAULT_MIXPANEL_TOKEN = 'b7df8a8fde7156da7b9c99ecbb7e9862';
+const DEFAULT_MIXPANEL_TOKEN = '';
 const DEFAULT_MIXPANEL_API_HOST = 'https://api-eu.mixpanel.com';
 const DEFAULT_MIXPANEL_NODE_HOST = 'api-eu.mixpanel.com';
 
@@ -18,7 +20,10 @@ export function isPostHogDisabledByEnv(): boolean {
 }
 
 export function isAnalyticsDisabledByEnv(): boolean {
-  return envTruthy('ANALYTICS_DISABLED') || isPostHogDisabledByEnv();
+  // Opt-in model: disabled unless ANALYTICS_ENABLED is set, and the legacy
+  // disable flags always win even when it is.
+  if (envTruthy('ANALYTICS_DISABLED') || isPostHogDisabledByEnv()) return true;
+  return !envTruthy('ANALYTICS_ENABLED');
 }
 
 export function resolveAnalyticsProvider(): AnalyticsProviderName {

--- a/src/platform/macos-detector.ts
+++ b/src/platform/macos-detector.ts
@@ -68,8 +68,11 @@ export class MacOSDetector {
   private getCommonPaths(): string[] {
     const paths: string[] = [];
 
-    // Generate paths for versions 2012-2025
-    for (let year = 2025; year >= 2012; year--) {
+    // Generate paths from next year's release (Adobe ships "Photoshop N+1"
+    // in the autumn of year N) back to 2012, so new versions are found
+    // without a code change.
+    const maxYear = new Date().getFullYear() + 1;
+    for (let year = maxYear; year >= 2012; year--) {
       paths.push(
         `/Applications/Adobe Photoshop ${year}/Adobe Photoshop ${year}.app`,
         `/Applications/Adobe Photoshop CC ${year}/Adobe Photoshop CC ${year}.app`,
@@ -77,11 +80,13 @@ export class MacOSDetector {
       );
     }
 
-    // Also check for version-less installation
+    // Also check for version-less and beta installations
     paths.push(
       '/Applications/Adobe Photoshop CC/Adobe Photoshop CC.app',
       '/Applications/Adobe Photoshop/Adobe Photoshop.app',
-      '/Applications/Adobe Photoshop.app'
+      '/Applications/Adobe Photoshop.app',
+      '/Applications/Adobe Photoshop (Beta)/Adobe Photoshop (Beta).app',
+      '/Applications/Adobe Photoshop (Beta).app'
     );
 
     return paths;

--- a/src/platform/macos-executor.ts
+++ b/src/platform/macos-executor.ts
@@ -20,9 +20,44 @@ function envTruthy(name: string): boolean {
   return value === '1' || value === 'true' || value === 'yes';
 }
 
+/** Slack added to the AppleScript-side timeout beyond the tool timeout, so the
+ * JSX gets its full advertised budget plus Apple-event overhead. */
+const APPLESCRIPT_TIMEOUT_MARGIN_SECONDS = 5;
+
+/** Extra grace before Node SIGKILLs osascript, beyond the AppleScript timeout.
+ * Keeps the AppleScript timeout strictly below the hard kill so Photoshop gets
+ * a clean AppleEvent timeout error instead of a dead pipe. */
+const KILL_GRACE_MS = 5000;
+
+/** Extra time a task may sit in the serial queue behind other scripts before
+ * its caller gives up, on top of the task's own execution timeout. */
+const QUEUE_WAIT_ALLOWANCE_MS = 60_000;
+
+/**
+ * AppleScript `with timeout of N seconds` value for a given tool timeout.
+ * Without this block AppleScript's default ~120s Apple-event reply timeout
+ * silently caps every `do javascript` call regardless of the tool timeout.
+ */
+export function appleScriptTimeoutSeconds(timeoutMs: number): number {
+  return Math.ceil(timeoutMs / 1000) + APPLESCRIPT_TIMEOUT_MARGIN_SECONDS;
+}
+
+/** Hard outer bound: osascript is SIGKILLed after this many ms. Always strictly
+ * above the AppleScript timeout so the clean AppleEvent error fires first. */
+export function killTimeoutMs(timeoutMs: number): number {
+  return appleScriptTimeoutSeconds(timeoutMs) * 1000 + KILL_GRACE_MS;
+}
+
+interface QueuedScript {
+  /** Set when the caller's promise was already rejected (timed out while
+   * queued); processQueue must skip these — they must never execute. */
+  cancelled: boolean;
+  run: () => Promise<void>;
+}
+
 export class MacOSExecutor implements ScriptExecutor {
   private logger: Logger;
-  private scriptQueue: Array<() => Promise<unknown>> = [];
+  private scriptQueue: QueuedScript[] = [];
   private isProcessing = false;
   private appName: string = 'Adobe Photoshop 2025';
 
@@ -37,23 +72,47 @@ export class MacOSExecutor implements ScriptExecutor {
 
   async execute(script: string, timeout: number = 30000): Promise<unknown> {
     return new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        reject(new Error('Script execution timeout'));
-      }, timeout);
+      // Two-phase timeout. While QUEUED: a generous wait timer (timeout +
+      // queue allowance) rejects the caller AND marks the entry cancelled so
+      // it never executes later. While RUNNING: the real execution timer,
+      // started at dequeue so queue wait does not eat into script run time.
+      const entry: QueuedScript = {
+        cancelled: false,
+        run: async () => {
+          clearTimeout(waitTimer);
 
-      this.scriptQueue.push(async () => {
-        try {
-          const result = await this.executeScript(script, timeout);
-          clearTimeout(timeoutId);
-          resolve(result);
-          return result;
-        } catch (error) {
-          clearTimeout(timeoutId);
-          reject(error);
-          throw error;
-        }
-      });
+          let timedOut = false;
+          const execTimer = setTimeout(() => {
+            timedOut = true;
+            reject(new Error('Script execution timeout'));
+          }, timeout);
 
+          try {
+            const result = await this.executeScript(script, timeout);
+            clearTimeout(execTimer);
+            if (!timedOut) {
+              resolve(result);
+            }
+          } catch (error) {
+            clearTimeout(execTimer);
+            if (!timedOut) {
+              reject(error);
+            }
+            throw error;
+          }
+        },
+      };
+
+      const waitTimer = setTimeout(() => {
+        entry.cancelled = true;
+        reject(
+          new Error(
+            `Script timed out after ${timeout + QUEUE_WAIT_ALLOWANCE_MS}ms waiting in the execution queue`
+          )
+        );
+      }, timeout + QUEUE_WAIT_ALLOWANCE_MS);
+
+      this.scriptQueue.push(entry);
       this.processQueue();
     });
   }
@@ -67,12 +126,15 @@ export class MacOSExecutor implements ScriptExecutor {
 
     while (this.scriptQueue.length > 0) {
       const task = this.scriptQueue.shift();
-      if (task) {
-        try {
-          await task();
-        } catch (error) {
-          this.logger.error('Script execution failed:', error);
-        }
+      if (!task || task.cancelled) {
+        // Caller already saw a timeout for this task; running it now would
+        // mutate Photoshop state after the caller gave up.
+        continue;
+      }
+      try {
+        await task.run();
+      } catch (error) {
+        this.logger.error('Script execution failed:', error);
       }
     }
 
@@ -88,14 +150,16 @@ export class MacOSExecutor implements ScriptExecutor {
       await writeFile(tempScriptPath, prefixExtendScriptBom(script), 'utf8');
 
       // Create AppleScript that tells Photoshop to execute the JSX
-      const appleScript = this.createAppleScriptWrapper(tempScriptPath);
+      const appleScript = this.createAppleScriptWrapper(tempScriptPath, timeout);
       await writeFile(tempAppleScriptPath, appleScript, 'utf8');
 
       try {
         // Execute AppleScript via osascript; the timeout must kill the child,
-        // otherwise abandoned osascript processes pile up behind long calls
+        // otherwise abandoned osascript processes pile up behind long calls.
+        // The kill fires after the AppleScript-side timeout (see
+        // killTimeoutMs) so a clean AppleEvent timeout error comes first.
         const { stdout, stderr } = await execAsync(`osascript "${tempAppleScriptPath}"`, {
-          timeout,
+          timeout: killTimeoutMs(timeout),
           killSignal: 'SIGKILL',
         });
 
@@ -118,7 +182,7 @@ export class MacOSExecutor implements ScriptExecutor {
     }
   }
 
-  private createAppleScriptWrapper(jsxPath: string): string {
+  private createAppleScriptWrapper(jsxPath: string, timeoutMs: number = 30000): string {
     // Use POSIX file path for AppleScript
     const posixPath = jsxPath.replace(/\\/g, '/');
 
@@ -127,9 +191,16 @@ export class MacOSExecutor implements ScriptExecutor {
     // background apps fine, so only activate when explicitly requested.
     const activateLine = envTruthy('PHOTOSHOP_ACTIVATE') ? '\tactivate\n' : '';
 
+    // Without an explicit `with timeout` block, AppleScript's default ~120s
+    // Apple-event reply timeout caps every synchronous `do javascript` call,
+    // silently defeating per-tool timeouts above 120s (batch tools use 600s).
+    const timeoutSeconds = appleScriptTimeoutSeconds(timeoutMs);
+
     return `tell application "${this.appName}"
 ${activateLine}\tset jsxFile to POSIX file "${posixPath}"
-\tdo javascript "$.evalFile(decodeURI('${encodeURI(posixPath)}'))"
+\twith timeout of ${timeoutSeconds} seconds
+\t\tdo javascript "$.evalFile(decodeURI('${encodeURI(posixPath)}'))"
+\tend timeout
 end tell`;
   }
 

--- a/src/platform/macos-executor.ts
+++ b/src/platform/macos-executor.ts
@@ -10,6 +10,16 @@ import { ScriptExecutor } from './script-executor.js';
 
 const execAsync = promisify(exec);
 
+/** Escape a string for use as a pgrep -f pattern (extended regex). */
+export function escapeForPgrep(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function envTruthy(name: string): boolean {
+  const value = process.env[name]?.trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
 export class MacOSExecutor implements ScriptExecutor {
   private logger: Logger;
   private scriptQueue: Array<() => Promise<unknown>> = [];
@@ -33,7 +43,7 @@ export class MacOSExecutor implements ScriptExecutor {
 
       this.scriptQueue.push(async () => {
         try {
-          const result = await this.executeScript(script);
+          const result = await this.executeScript(script, timeout);
           clearTimeout(timeoutId);
           resolve(result);
           return result;
@@ -69,7 +79,7 @@ export class MacOSExecutor implements ScriptExecutor {
     this.isProcessing = false;
   }
 
-  private async executeScript(script: string): Promise<unknown> {
+  private async executeScript(script: string, timeout: number = 30000): Promise<unknown> {
     // For macOS, we'll use AppleScript to execute JavaScript in Photoshop
     const tempScriptPath = join(tmpdir(), `photoshop-script-${Date.now()}.jsx`);
     const tempAppleScriptPath = join(tmpdir(), `photoshop-applescript-${Date.now()}.scpt`);
@@ -82,8 +92,12 @@ export class MacOSExecutor implements ScriptExecutor {
       await writeFile(tempAppleScriptPath, appleScript, 'utf8');
 
       try {
-        // Execute AppleScript via osascript
-        const { stdout, stderr } = await execAsync(`osascript "${tempAppleScriptPath}"`);
+        // Execute AppleScript via osascript; the timeout must kill the child,
+        // otherwise abandoned osascript processes pile up behind long calls
+        const { stdout, stderr } = await execAsync(`osascript "${tempAppleScriptPath}"`, {
+          timeout,
+          killSignal: 'SIGKILL',
+        });
 
         if (stderr) {
           this.logger.warn('Script execution warning:', stderr);
@@ -107,10 +121,14 @@ export class MacOSExecutor implements ScriptExecutor {
   private createAppleScriptWrapper(jsxPath: string): string {
     // Use POSIX file path for AppleScript
     const posixPath = jsxPath.replace(/\\/g, '/');
-    
+
+    // 'activate' steals window focus on every tool call, which makes the
+    // machine unusable while an agent drives Photoshop. Apple events reach
+    // background apps fine, so only activate when explicitly requested.
+    const activateLine = envTruthy('PHOTOSHOP_ACTIVATE') ? '\tactivate\n' : '';
+
     return `tell application "${this.appName}"
-\tactivate
-\tset jsxFile to POSIX file "${posixPath}"
+${activateLine}\tset jsxFile to POSIX file "${posixPath}"
 \tdo javascript "$.evalFile(decodeURI('${encodeURI(posixPath)}'))"
 end tell`;
   }
@@ -127,7 +145,11 @@ end tell`;
 
   async isPhotoshopRunning(): Promise<boolean> {
     try {
-      const { stdout } = await execAsync('pgrep -f "Adobe Photoshop"');
+      // Match the specific app we drive, not any Photoshop — with 2025/2026/
+      // Beta installed side by side, a generic match reports "running" while
+      // the target version is not.
+      const pattern = escapeForPgrep(this.appName);
+      const { stdout } = await execAsync(`pgrep -f "${pattern}"`);
       return stdout.trim().length > 0;
     } catch {
       // pgrep returns non-zero exit code if no process found

--- a/src/utils/js-string.ts
+++ b/src/utils/js-string.ts
@@ -3,5 +3,10 @@ export function jsString(value: string): string {
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"')
     .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r');
+    .replace(/\r/g, '\\r')
+    // Remaining C0 controls plus U+2028/U+2029: ExtendScript (ES3) treats the
+    // latter as line terminators, so raw occurrences break the string literal.
+    .replace(/[\u0000-\u001f\u2028\u2029]/g, (ch) => {
+      return '\\u' + ch.charCodeAt(0).toString(16).padStart(4, '0');
+    });
 }

--- a/tests/analytics-config.test.ts
+++ b/tests/analytics-config.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  hasAnalyticsKey,
+  isAnalyticsDisabledByEnv,
+  resolveMixpanelToken,
+  resolvePostHogKey,
+} from '../src/analytics/config.js';
+
+const ENV_KEYS = [
+  'ANALYTICS_ENABLED',
+  'ANALYTICS_DISABLED',
+  'POSTHOG_DISABLED',
+  'MIXPANEL_TOKEN',
+  'POSTHOG_KEY',
+  'ANALYTICS_PROVIDER',
+];
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe('analytics opt-in model', () => {
+  it('is disabled by default with no env vars set', () => {
+    expect(isAnalyticsDisabledByEnv()).toBe(true);
+  });
+
+  it('enables only when ANALYTICS_ENABLED is truthy', () => {
+    process.env.ANALYTICS_ENABLED = '1';
+    expect(isAnalyticsDisabledByEnv()).toBe(false);
+  });
+
+  it('legacy disable flags win even when ANALYTICS_ENABLED is set', () => {
+    process.env.ANALYTICS_ENABLED = '1';
+    process.env.ANALYTICS_DISABLED = '1';
+    expect(isAnalyticsDisabledByEnv()).toBe(true);
+  });
+
+  it('ships no default telemetry tokens', () => {
+    expect(resolveMixpanelToken()).toBe('');
+    expect(resolvePostHogKey()).toBe('');
+    expect(hasAnalyticsKey()).toBe(false);
+  });
+
+  it('operator-supplied keys are still honored', () => {
+    process.env.MIXPANEL_TOKEN = 'my-own-token';
+    expect(resolveMixpanelToken()).toBe('my-own-token');
+    expect(hasAnalyticsKey()).toBe(true);
+  });
+});

--- a/tests/js-string.test.ts
+++ b/tests/js-string.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { jsString } from '../src/utils/js-string.js';
+
+// Characters built via fromCharCode so no raw control/line-terminator bytes
+// end up in this source file.
+const NUL = String.fromCharCode(0x00);
+const TAB = String.fromCharCode(0x09);
+const US = String.fromCharCode(0x1f); // unit separator, top of the C0 range
+const LS = String.fromCharCode(0x2028); // LINE SEPARATOR
+const PS = String.fromCharCode(0x2029); // PARAGRAPH SEPARATOR
+
+describe('jsString', () => {
+  it('leaves normal strings untouched', () => {
+    expect(jsString('Layer 1')).toBe('Layer 1');
+    expect(jsString('/Users/me/Design Files/final (v2).psd')).toBe(
+      '/Users/me/Design Files/final (v2).psd'
+    );
+  });
+
+  it('keeps existing escapes: backslash, quote, newline, carriage return', () => {
+    expect(jsString('a\\b')).toBe('a\\\\b');
+    expect(jsString('say "hi"')).toBe('say \\"hi\\"');
+    expect(jsString('line1\nline2')).toBe('line1\\nline2');
+    expect(jsString('line1\rline2')).toBe('line1\\rline2');
+  });
+
+  it('escapes U+2028/U+2029 — ES3/ExtendScript line terminators', () => {
+    expect(jsString(`a${LS}b`)).toBe('a\\u2028b');
+    expect(jsString(`a${PS}b`)).toBe('a\\u2029b');
+  });
+
+  it('escapes remaining C0 controls in \\uXXXX form', () => {
+    expect(jsString(`a${NUL}b`)).toBe('a\\u0000b');
+    expect(jsString(`a${TAB}b`)).toBe('a\\u0009b');
+    expect(jsString(`a${US}b`)).toBe('a\\u001fb');
+  });
+
+  it('round-trips through a double-quoted string literal', () => {
+    const nasty = `Layer "1"\\path\n\r${LS}${PS}${NUL}${TAB}${US} end`;
+    const literal = jsString(nasty);
+
+    // The emitted literal must contain no raw parse-breaking characters...
+    // eslint-disable-next-line no-control-regex
+    expect(literal).not.toMatch(/[\u0000-\u001f\u2028\u2029]/);
+
+    // ...and must evaluate back to the exact original string.
+    // eslint-disable-next-line no-eval
+    expect(eval(`"${literal}"`)).toBe(nasty);
+  });
+});

--- a/tests/macos-platform.test.ts
+++ b/tests/macos-platform.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { MacOSExecutor, escapeForPgrep } from '../src/platform/macos-executor.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MacOSExecutor,
+  appleScriptTimeoutSeconds,
+  escapeForPgrep,
+  killTimeoutMs,
+} from '../src/platform/macos-executor.js';
 import { MacOSDetector } from '../src/platform/macos-detector.js';
 
 let savedActivate: string | undefined;
@@ -27,10 +32,10 @@ describe('escapeForPgrep', () => {
 describe('AppleScript wrapper focus behavior', () => {
   // createAppleScriptWrapper is private; reach in deliberately — the wrapper
   // text is the contract that decides whether every tool call steals focus.
-  const wrapperFor = (executor: MacOSExecutor) =>
-    (executor as unknown as { createAppleScriptWrapper(p: string): string }).createAppleScriptWrapper(
-      '/tmp/test.jsx'
-    );
+  const wrapperFor = (executor: MacOSExecutor, timeoutMs?: number) =>
+    (
+      executor as unknown as { createAppleScriptWrapper(p: string, t?: number): string }
+    ).createAppleScriptWrapper('/tmp/test.jsx', timeoutMs);
 
   it('does not activate (steal focus) by default', () => {
     const executor = new MacOSExecutor();
@@ -46,6 +51,165 @@ describe('AppleScript wrapper focus behavior', () => {
     const executor = new MacOSExecutor();
     executor.setAppName('Adobe Photoshop 2026');
     expect(wrapperFor(executor)).toContain('activate');
+  });
+});
+
+describe('AppleScript wrapper timeout block', () => {
+  // Without `with timeout of N seconds`, AppleScript's default ~120s
+  // Apple-event reply timeout silently caps every `do javascript` call —
+  // batch tools advertising 600s would die at ~120s.
+  const wrapperFor = (timeoutMs?: number) => {
+    const executor = new MacOSExecutor();
+    return (
+      executor as unknown as { createAppleScriptWrapper(p: string, t?: number): string }
+    ).createAppleScriptWrapper('/tmp/test.jsx', timeoutMs);
+  };
+
+  it('scales the timeout block to the per-call timeout (600s batch case)', () => {
+    const script = wrapperFor(600_000);
+    expect(script).toContain(`with timeout of ${appleScriptTimeoutSeconds(600_000)} seconds`);
+    expect(script).toContain('end timeout');
+    expect(appleScriptTimeoutSeconds(600_000)).toBeGreaterThan(600);
+  });
+
+  it('places the timeout block inside the tell block, around do javascript', () => {
+    const script = wrapperFor(30_000);
+    const tell = script.indexOf('tell application');
+    const withTimeout = script.indexOf('with timeout of');
+    const doJs = script.indexOf('do javascript');
+    const endTimeout = script.indexOf('end timeout');
+    const endTell = script.indexOf('end tell');
+    expect(tell).toBeGreaterThanOrEqual(0);
+    expect(withTimeout).toBeGreaterThan(tell);
+    expect(doJs).toBeGreaterThan(withTimeout);
+    expect(endTimeout).toBeGreaterThan(doJs);
+    expect(endTell).toBeGreaterThan(endTimeout);
+  });
+
+  it('defaults to the 30s tool timeout when none is passed', () => {
+    expect(wrapperFor()).toContain(`with timeout of ${appleScriptTimeoutSeconds(30_000)} seconds`);
+  });
+
+  it('keeps the AppleScript timeout strictly below the Node SIGKILL bound', () => {
+    for (const timeoutMs of [1_000, 30_000, 120_000, 600_000]) {
+      expect(killTimeoutMs(timeoutMs)).toBeGreaterThan(appleScriptTimeoutSeconds(timeoutMs) * 1000);
+      // and the AppleScript timeout covers at least the advertised tool timeout
+      expect(appleScriptTimeoutSeconds(timeoutMs) * 1000).toBeGreaterThanOrEqual(timeoutMs);
+    }
+  });
+});
+
+describe('execute() queue timeout semantics', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  /** Executor with the private executeScript stubbed: records every script
+   * that actually runs, so tests can assert cancelled tasks never execute. */
+  function makeExecutor(impl: (script: string, timeout: number) => Promise<unknown>) {
+    const executor = new MacOSExecutor();
+    const executed: string[] = [];
+    (
+      executor as unknown as { executeScript(s: string, t: number): Promise<unknown> }
+    ).executeScript = (script: string, timeout: number) => {
+      executed.push(script);
+      return impl(script, timeout);
+    };
+    return { executor, executed };
+  }
+
+  it('a task that times out while queued is rejected AND never executes', async () => {
+    const long = deferred<string>();
+    const { executor, executed } = makeExecutor((script) =>
+      script === 'long' ? long.promise : Promise.resolve('short-done')
+    );
+
+    const longPromise = executor.execute('long', 200_000);
+    const shortPromise = executor.execute('short', 1_000);
+    shortPromise.catch(() => {}); // observed below; avoid unhandled rejection
+
+    // short's queue-wait allowance is timeout + 60s; blow past it while long
+    // still occupies the serial queue.
+    await vi.advanceTimersByTimeAsync(61_000);
+    await expect(shortPromise).rejects.toThrow(/waiting in the execution queue/);
+
+    // long finishes; the queue drains — the cancelled short task must be
+    // skipped, not executed with dead resolve/reject.
+    long.resolve('long-done');
+    await expect(longPromise).resolves.toBe('long-done');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(executed).toEqual(['long']);
+  });
+
+  it('the execution timer starts at dequeue, so queue wait does not eat run time', async () => {
+    const long = deferred<string>();
+    const { executor, executed } = makeExecutor((script) =>
+      script === 'long' ? long.promise : Promise.resolve('short-done')
+    );
+
+    const longPromise = executor.execute('long', 200_000);
+    const shortPromise = executor.execute('short', 5_000);
+
+    let shortSettled = false;
+    shortPromise.then(
+      () => {
+        shortSettled = true;
+      },
+      () => {
+        shortSettled = true;
+      }
+    );
+
+    // 30s in the queue: far beyond short's 5s execution timeout, within its
+    // wait allowance. Under the old enqueue-time timer this already rejected.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(shortSettled).toBe(false);
+
+    long.resolve('long-done');
+    await expect(longPromise).resolves.toBe('long-done');
+    await expect(shortPromise).resolves.toBe('short-done');
+    expect(executed).toEqual(['long', 'short']);
+  });
+
+  it('a running script that overruns its timeout still rejects', async () => {
+    const hang = deferred<string>();
+    const { executor } = makeExecutor(() => hang.promise);
+
+    const promise = executor.execute('hang', 1_000);
+    promise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(promise).rejects.toThrow('Script execution timeout');
+
+    hang.resolve('too-late');
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('resolves normally well past 120s, proving long batch timeouts are honored', async () => {
+    const batch = deferred<string>();
+    const { executor } = makeExecutor(() => batch.promise);
+
+    const promise = executor.execute('batch', 600_000);
+
+    // 500s of execution — over 4x AppleScript's old default cap.
+    await vi.advanceTimersByTimeAsync(500_000);
+    batch.resolve('batch-done');
+    await expect(promise).resolves.toBe('batch-done');
   });
 });
 

--- a/tests/macos-platform.test.ts
+++ b/tests/macos-platform.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MacOSExecutor, escapeForPgrep } from '../src/platform/macos-executor.js';
+import { MacOSDetector } from '../src/platform/macos-detector.js';
+
+let savedActivate: string | undefined;
+
+beforeEach(() => {
+  savedActivate = process.env.PHOTOSHOP_ACTIVATE;
+  delete process.env.PHOTOSHOP_ACTIVATE;
+});
+
+afterEach(() => {
+  if (savedActivate === undefined) delete process.env.PHOTOSHOP_ACTIVATE;
+  else process.env.PHOTOSHOP_ACTIVATE = savedActivate;
+});
+
+describe('escapeForPgrep', () => {
+  it('escapes regex metacharacters so Beta app names match literally', () => {
+    expect(escapeForPgrep('Adobe Photoshop (Beta)')).toBe('Adobe Photoshop \\(Beta\\)');
+  });
+
+  it('leaves plain names untouched', () => {
+    expect(escapeForPgrep('Adobe Photoshop 2026')).toBe('Adobe Photoshop 2026');
+  });
+});
+
+describe('AppleScript wrapper focus behavior', () => {
+  // createAppleScriptWrapper is private; reach in deliberately — the wrapper
+  // text is the contract that decides whether every tool call steals focus.
+  const wrapperFor = (executor: MacOSExecutor) =>
+    (executor as unknown as { createAppleScriptWrapper(p: string): string }).createAppleScriptWrapper(
+      '/tmp/test.jsx'
+    );
+
+  it('does not activate (steal focus) by default', () => {
+    const executor = new MacOSExecutor();
+    executor.setAppName('Adobe Photoshop 2026');
+    const script = wrapperFor(executor);
+    expect(script).not.toContain('activate');
+    expect(script).toContain('tell application "Adobe Photoshop 2026"');
+    expect(script).toContain('do javascript');
+  });
+
+  it('activates when PHOTOSHOP_ACTIVATE is truthy', () => {
+    process.env.PHOTOSHOP_ACTIVATE = '1';
+    const executor = new MacOSExecutor();
+    executor.setAppName('Adobe Photoshop 2026');
+    expect(wrapperFor(executor)).toContain('activate');
+  });
+});
+
+describe('detector fallback paths', () => {
+  const pathsFor = () =>
+    (new MacOSDetector() as unknown as { getCommonPaths(): string[] }).getCommonPaths();
+
+  it('covers the current-year+1 release (2026 installs today) without a code change', () => {
+    const nextYear = new Date().getFullYear() + 1;
+    const paths = pathsFor();
+    expect(paths).toContain(`/Applications/Adobe Photoshop ${nextYear}/Adobe Photoshop ${nextYear}.app`);
+    expect(paths).toContain('/Applications/Adobe Photoshop 2026/Adobe Photoshop 2026.app');
+  });
+
+  it('includes the Beta install location', () => {
+    expect(pathsFor()).toContain('/Applications/Adobe Photoshop (Beta)/Adobe Photoshop (Beta).app');
+  });
+
+  it('still covers the oldest supported year', () => {
+    expect(pathsFor()).toContain('/Applications/Adobe Photoshop CC 2012/Adobe Photoshop CC 2012.app');
+  });
+});


### PR DESCRIPTION
## What changed

Analytics is now opt-in: nothing is sent unless the operator sets `ANALYTICS_ENABLED=1` **and** supplies their own `MIXPANEL_TOKEN`/`POSTHOG_KEY`. The bundled default tokens are removed. Existing `ANALYTICS_DISABLED`/`POSTHOG_DISABLED` flags still win when set.

## Why

This server is often deployed inside client work at agencies and studios where any phone-home — however benign — needs to be a deliberate choice with the operator's own keys, not a default. Making it opt-in also removes the shared-token pattern (anyone can currently post events to the bundled tokens, polluting your dashboards).

I understand usage analytics are valuable to you as the maintainer, so no hard feelings if you'd rather keep the current default — offering this because several deployment contexts (client NDAs, enterprise policy) can't ship opt-out telemetry at all, and a fork-free path would be nice.

## How to test

`npm run test:unit` — covers: disabled by default, `ANALYTICS_ENABLED` enables, legacy disable flags override, no default tokens ship, operator-supplied keys still work.

## Notes

Stacked on #15 (includes its commits — the test harness and platform fixes). If #15 lands first this rebases to just the analytics commit.

Generated with [Claude Code](https://claude.com/claude-code)