### PR TITLE
fix: docs and CLI auth UX for open issues #17–#19

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,54 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 }
 ```
 
+**Can't find the config file?** In Claude Desktop, open **Settings → Developer → Edit Config** — it opens the correct path for your install (the `%APPDATA%` path may differ on some setups).
+
+### For Claude Code
+
+Use the [Claude Code CLI](https://code.claude.com/docs/en/agent-sdk/mcp) or the [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/mcp) with the same MCP server entry.
+
+**Recommended (CLI):**
+
+```bash
+claude mcp add photoshop -- npx -y @alisaitteke/photoshop-mcp
+```
+
+**Manual JSON** — merge into your project `.mcp.json` or Claude Code MCP settings (see [`examples/claude-code-mcp.json`](examples/claude-code-mcp.json)):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+**Agent SDK (TypeScript)** — pass the same `mcpServers` block in your `query()` options:
+
+```typescript
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+const q = query({
+  prompt: 'List open documents in Photoshop',
+  options: {
+    mcpServers: {
+      photoshop: {
+        command: 'npx',
+        args: ['-y', '@alisaitteke/photoshop-mcp'],
+        env: { LOG_LEVEL: '1' },
+      },
+    },
+    allowedTools: ['mcp__photoshop__*'],
+  },
+});
+```
+
 ### Environment Variables
 
 - `PHOTOSHOP_PATH`: (Optional) Specify custom Photoshop installation path
@@ -733,7 +781,8 @@ Common connection, scripting, and logging issues:
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `cli_not_found` | Claude Code / Gemini CLI not installed | `npm i -g @anthropic-ai/claude-code` or `npm i -g @google/gemini-cli` |
-| `not_authenticated` | No OAuth session | Run `claude auth login` or `gemini auth login` in Terminal |
+| `not_authenticated` | No CLI OAuth session (API key / SDK auth does not count) | Run `claude auth login` or `gemini auth login` in Terminal, or switch to **API key** auth |
+| SDK client works, UI CLI mode fails | SDK/API credentials are separate from Claude Code CLI OAuth | Use **API key** in the standalone UI, or log in with `claude auth login` for CLI account mode |
 | `claude` / `gemini` not on `PATH` | Custom install location | Settings → **CLI path** → **Check connection** |
 | Chat works in IDE but not UI (CLI mode) | OAuth tokens are CLI-only | Use **CLI account** in UI; API keys and CLI sessions are separate |
 | Gemini multi-turn feels forgetful | Headless CLI may start a fresh session each turn | Known limitation; history is prepended to the prompt (MVP) |

--- a/README.tr.md
+++ b/README.tr.md
@@ -608,6 +608,54 @@ Claude Desktop yapılandırmanıza ekleyin (macOS'ta `~/Library/Application Supp
 }
 ```
 
+**Yapılandırma dosyasını bulamıyor musunuz?** Claude Desktop'ta **Settings → Developer → Edit Config** yolunu kullanın — kurulumunuza uygun dosyayı açar (`%APPDATA%` yolu her zaman aynı olmayabilir).
+
+### Claude Code için
+
+[Claude Code CLI](https://code.claude.com/docs/en/agent-sdk/mcp) veya [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/mcp) ile aynı MCP sunucu girdisini kullanın.
+
+**Önerilen (CLI):**
+
+```bash
+claude mcp add photoshop -- npx -y @alisaitteke/photoshop-mcp
+```
+
+**Manuel JSON** — proje `.mcp.json` dosyanıza veya Claude Code MCP ayarlarınıza ekleyin ([`examples/claude-code-mcp.json`](examples/claude-code-mcp.json)):
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1"
+      }
+    }
+  }
+}
+```
+
+**Agent SDK (TypeScript)** — `query()` seçeneklerinde aynı `mcpServers` bloğunu geçirin:
+
+```typescript
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+const q = query({
+  prompt: 'Photoshop\'ta açık belgeleri listele',
+  options: {
+    mcpServers: {
+      photoshop: {
+        command: 'npx',
+        args: ['-y', '@alisaitteke/photoshop-mcp'],
+        env: { LOG_LEVEL: '1' },
+      },
+    },
+    allowedTools: ['mcp__photoshop__*'],
+  },
+});
+```
+
 ### Ortam Değişkenleri
 
 - `PHOTOSHOP_PATH`: (İsteğe bağlı) Özel Photoshop kurulum yolunu belirtin
@@ -717,7 +765,8 @@ Yaygın bağlantı, betik ve günlük kaydı sorunları:
 | Belirti | Olası neden | Düzeltme |
 |---|---|---|
 | `cli_not_found` | Claude Code / Gemini CLI yüklü değil | `npm i -g @anthropic-ai/claude-code` veya `npm i -g @google/gemini-cli` |
-| `not_authenticated` | OAuth oturumu yok | Terminal'de `claude auth login` veya `gemini auth login` çalıştırın |
+| `not_authenticated` | CLI OAuth oturumu yok (API anahtarı / SDK oturumu sayılmaz) | Terminal'de `claude auth login` veya `gemini auth login` çalıştırın veya **API key** moduna geçin |
+| SDK istemcisi çalışıyor, UI CLI modu başarısız | SDK/API kimlik bilgileri Claude Code CLI OAuth'tan ayrıdır | Bağımsız UI'da **API key** kullanın veya CLI hesabı için `claude auth login` çalıştırın |
 | `claude` / `gemini` `PATH`'de yok | Özel kurulum konumu | Ayarlar → **CLI path** → **Check connection** |
 | Sohbet IDE'de çalışıyor ama UI'da çalışmıyor (CLI modu) | OAuth tokenları yalnızca CLI'ya özgü | UI'da **CLI account** kullanın; API anahtarları ve CLI oturumları ayrıdır |
 | Gemini çok turlu konuşmalarda unutkanlık gösteriyor | Başsız CLI her turda yeni oturum açabilir | Bilinen kısıtlama; geçmiş isteme eklenir (MVP) |

--- a/docs/available-tools.md
+++ b/docs/available-tools.md
@@ -719,10 +719,21 @@ Execute custom ExtendScript code (advanced).
 **Parameters:**
 - `code` (string, required): ExtendScript code
 
+Your code runs inside a wrapping IIFE on the server side. Use an explicit `return` to pass data back — a bare trailing expression or assignment (e.g. `layer.name = "X"`) evaluates to `undefined`, so the tool result shows `"undefined"` even when the mutation succeeded.
+
 ```javascript
-// Example: Execute custom code
+// Example: Rename the active layer and return confirmation
 photoshop_execute_script({
-  code: "app.beep();"
+  code: `
+    var layer = app.activeDocument.activeLayer;
+    layer.name = "Renamed";
+    return { ok: true, name: layer.name };
+  `
+})
+
+// Example: Read-only query (always return a value you can inspect)
+photoshop_execute_script({
+  code: "return app.documents.length;"
 })
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,6 +29,25 @@ Common issues when connecting to or scripting Photoshop through the MCP server.
 - The default timeout is 30 seconds
 - For complex operations, consider breaking them into smaller steps
 
+### `photoshop_execute_script` returns `Result: undefined`
+
+**Symptom:** The tool succeeds but the result text is `"undefined"`, or you assume the script did not run.
+
+**Cause:** ExtendScript runs inside a server-side IIFE wrapper. Without an explicit `return`, the inner block evaluates to `undefined` — side effects (layer renames, property changes, etc.) may still have applied.
+
+**Fix:** Add an explicit return in your script:
+
+```javascript
+photoshop_execute_script({
+  code: `
+    app.activeDocument.activeLayer.name = "Updated";
+    return { ok: true };
+  `
+})
+```
+
+See also the `photoshop_execute_script` section in [`docs/available-tools.md`](available-tools.md).
+
 ### Debug Logging
 
 Enable detailed logging by setting `LOG_LEVEL=0`:

--- a/examples/claude-code-mcp.json
+++ b/examples/claude-code-mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "npx",
+      "args": ["-y", "@alisaitteke/photoshop-mcp"],
+      "env": {
+        "LOG_LEVEL": "1",
+        "PHOTOSHOP_PATH": ""
+      }
+    }
+  }
+}

--- a/src/ui/providers/anthropic.ts
+++ b/src/ui/providers/anthropic.ts
@@ -2,6 +2,10 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { resolveCliBinary, runCommand } from './cli-utils.js';
 import type { ProviderAdapter, ProviderModel } from './types.js';
 
+function sanitizeCliDetail(text: string): string {
+  return text.replace(/\s+/g, ' ').slice(0, 200);
+}
+
 // Public list pricing (USD per 1M tokens). Cache-write reflects the 5-minute
 // tier; we don't currently differentiate the 1-hour tier.
 const MODELS: ProviderModel[] = [
@@ -71,7 +75,14 @@ export const anthropicAdapter: ProviderAdapter = {
     }
     const result = await runCommand(binary, ['auth', 'status'], { timeoutMs: 15_000 });
     if (result.exitCode !== 0) {
-      return { ok: false, error: 'not_authenticated' };
+      const detail = sanitizeCliDetail(result.stderr.trim() || result.stdout.trim());
+      return {
+        ok: false,
+        error: 'not_authenticated',
+        detail: detail
+          ? `exit ${result.exitCode}: ${detail}`
+          : `exit ${result.exitCode}`,
+      };
     }
     try {
       const parsed = JSON.parse(result.stdout) as {

--- a/src/ui/providers/types.ts
+++ b/src/ui/providers/types.ts
@@ -33,6 +33,7 @@ export interface ApiKeyValidation {
 export interface CliAccountValidation {
   ok: boolean;
   error?: string;
+  detail?: string;
   accountLabel?: string;
 }
 

--- a/web/src/components/Onboarding.vue
+++ b/web/src/components/Onboarding.vue
@@ -20,6 +20,7 @@ import {
   apiSaveKey,
   apiSetActive,
   apiSetAuthMethod,
+  apiSetCliPath,
   apiValidateCli,
   apiValidateCustomProvider,
   apiValidateKey,
@@ -28,6 +29,7 @@ import {
   type ProviderInfo,
 } from '@/lib/api';
 import { capture } from '@/lib/analytics';
+import { formatCliAuthError } from '@/lib/cli-auth-errors';
 
 const emit = defineEmits<{ saved: [] }>();
 
@@ -35,6 +37,7 @@ const providers = ref<ProviderInfo[]>([]);
 const selectedId = ref<ProviderId>('anthropic');
 const authMethod = ref<AuthMethod>('api_key');
 const apiKey = ref('');
+const cliPath = ref('');
 const validating = ref(false);
 const error = ref<string | null>(null);
 
@@ -114,9 +117,17 @@ async function submitBuiltIn(): Promise<void> {
     }
     await apiSaveKey(provider.id, apiKey.value);
   } else {
+    const path = cliPath.value.trim();
+    if (path) {
+      await apiSetCliPath(provider.id, path);
+    }
     const validation = await apiValidateCli(provider.id);
     if (!validation.ok) {
-      error.value = validation.error || 'CLI is not authenticated.';
+      error.value = formatCliAuthError(
+        validation.error,
+        provider.id,
+        validation.detail
+      );
       return;
     }
   }
@@ -188,6 +199,12 @@ const canSubmit = computed(() => {
   if (authMethod.value === 'api_key') return Boolean(apiKey.value.trim());
   return true;
 });
+
+function cliPathPlaceholder(provider: ProviderInfo): string {
+  return provider.cliBinaryName
+    ? `/usr/local/bin/${provider.cliBinaryName}`
+    : 'Optional custom path';
+}
 </script>
 
 <template>
@@ -284,9 +301,22 @@ const canSubmit = computed(() => {
                 <code class="text-foreground">{{ CLI_INSTALL[selected.id]!.login }}</code>
               </p>
               <p class="mt-2">
+                Anthropic API keys and Agent SDK sessions do not apply here — use
+                <strong>API key</strong> auth if that is how you already connect.
+              </p>
+              <p class="mt-2">
                 Then click validate — usage counts against your subscription quota, not API
                 billing.
               </p>
+            </div>
+            <div class="space-y-2">
+              <Label for="cli-path">CLI path (optional)</Label>
+              <Input
+                id="cli-path"
+                v-model="cliPath"
+                :placeholder="cliPathPlaceholder(selected)"
+                :disabled="validating"
+              />
             </div>
           </template>
         </template>
@@ -345,7 +375,7 @@ const canSubmit = computed(() => {
           </div>
         </template>
 
-        <p v-if="error" class="text-sm text-destructive">{{ error }}</p>
+        <p v-if="error" class="whitespace-pre-line text-sm text-destructive">{{ error }}</p>
       </CardContent>
       <CardFooter>
         <Button class="w-full" :disabled="validating || !canSubmit" @click="submit">

--- a/web/src/components/SettingsDialog.vue
+++ b/web/src/components/SettingsDialog.vue
@@ -25,6 +25,7 @@ import {
   type ProviderInfo,
 } from '@/lib/api';
 import { refreshAnalyticsState, setAnalyticsOptOut, syncAnalyticsContext } from '@/lib/analytics';
+import { formatCliAuthError } from '@/lib/cli-auth-errors';
 import { apiSetBetaTelemetry } from '@/lib/api';
 
 const props = defineProps<{
@@ -164,7 +165,11 @@ async function validateCli(provider: ProviderInfo): Promise<void> {
     }
     const result = await apiValidateCli(provider.id);
     if (!result.ok) {
-      errors.value[provider.id] = result.error || 'CLI not authenticated';
+      errors.value[provider.id] = formatCliAuthError(
+        result.error,
+        provider.id,
+        result.detail
+      );
       return;
     }
     await refresh();
@@ -578,7 +583,7 @@ watch(
                 </div>
               </template>
 
-              <p v-if="errors[p.id]" class="mt-2 text-xs text-destructive">
+              <p v-if="errors[p.id]" class="mt-2 whitespace-pre-line text-xs text-destructive">
                 {{ errors[p.id] }}
               </p>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -222,7 +222,7 @@ export const apiSetAuthMethod = (id: ProviderId, authMethod: AuthMethod) =>
   });
 
 export const apiValidateCli = (id: ProviderId) =>
-  api<{ ok: boolean; error?: string; accountLabel?: string }>(
+  api<{ ok: boolean; error?: string; detail?: string; accountLabel?: string }>(
     `/api/providers/${id}/validate-cli`,
     { method: 'POST', body: '{}' }
   );

--- a/web/src/lib/cli-auth-errors.ts
+++ b/web/src/lib/cli-auth-errors.ts
@@ -1,0 +1,78 @@
+import type { ProviderId } from '@/lib/api';
+
+const CLI_HINTS: Partial<
+  Record<ProviderId, { install: string; login: string; binary: string }>
+> = {
+  anthropic: {
+    install: 'npm install -g @anthropic-ai/claude-code',
+    login: 'claude auth login',
+    binary: 'claude',
+  },
+  google: {
+    install: 'npm install -g @google/gemini-cli',
+    login: 'gemini auth login',
+    binary: 'gemini',
+  },
+};
+
+function machineErrorCode(error: string | undefined): string {
+  if (!error) return 'unknown';
+  const colon = error.indexOf(':');
+  return colon === -1 ? error : error.slice(0, colon);
+}
+
+/**
+ * Turn server CLI validation codes into actionable onboarding/settings copy.
+ */
+export function formatCliAuthError(
+  error: string | undefined,
+  providerId?: ProviderId,
+  detail?: string
+): string {
+  const code = machineErrorCode(error);
+  const hint = providerId ? CLI_HINTS[providerId] : undefined;
+  const detailLine = detail?.trim() ? `Details: ${detail.trim()}` : '';
+
+  switch (code) {
+    case 'not_authenticated':
+      return [
+        'CLI subscription login was not detected.',
+        hint
+          ? `Install: ${hint.install}. Then run: ${hint.login}`
+          : 'Install the provider CLI and run its login command in Terminal.',
+        'Anthropic API keys and Agent SDK sessions do not satisfy "Uses your account" mode — choose API key auth instead, or log in with the CLI.',
+        'If login works in Terminal but fails here, set an optional CLI path below (custom install location).',
+        detailLine,
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+    case 'cli_not_found':
+      return [
+        hint
+          ? `Could not find "${hint.binary}" on PATH.`
+          : 'Could not find the provider CLI on PATH.',
+        hint ? `Install: ${hint.install}` : 'Install the provider CLI globally.',
+        hint ? `Then run: ${hint.login}` : undefined,
+        'Or enter the full path to the CLI binary below.',
+        detailLine,
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+    case 'cli_probe_failed':
+      return [
+        'The CLI probe failed.',
+        hint ? `Try ${hint.login} again, then re-check the connection.` : undefined,
+        detailLine || (error && error !== code ? error : undefined),
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+    case 'cli_account_not_supported':
+      return 'This provider does not support CLI account auth. Use an API key instead.';
+
+    default:
+      return [error || 'CLI validation failed.', detailLine].filter(Boolean).join('\n');
+  }
+}


### PR DESCRIPTION
## Summary

- **#19:** Document `photoshop_execute_script` IIFE/`return` semantics in `docs/available-tools.md` and `docs/troubleshooting.md` (issue closed on GitHub).
- **#18:** Add Claude Code / Agent SDK setup to `README.md` and `README.tr.md`, plus `examples/claude-code-mcp.json` and Claude Desktop config path tip.
- **#17:** Improve standalone UI CLI auth onboarding — actionable error messages, optional CLI path during setup, richer `claude auth status` diagnostics, README troubleshooting rows for SDK vs CLI auth.

## Test plan

- [x] `npm run build:server`
- [x] `npm run build:web`
- [ ] Onboarding: select Anthropic → **Uses your account** with no CLI login → verify readable multi-line error (not raw `not_authenticated`)
- [ ] Onboarding: optional CLI path field saves and validates via Settings flow
- [ ] README: verify **For Claude Code** section and `claude mcp add` command render correctly
- [ ] Docs: `photoshop_execute_script` examples show explicit `return`

Fixes #17
Fixes #18