### PR TITLE
feat: expand to 102 tools with layer styles, color grading, data graphics, and csv-to-cards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,9 @@ publish stays manual on the maintainer machine (OTP/2FA).
    **New Contributors** when applicable (see
    [`scripts/build-release-notes.sh`](scripts/build-release-notes.sh)).
 6. From a clean `master` checkout, run `npm publish` (`prepublishOnly` runs
-   `npm run build` automatically).
+   `npm run build` and `npm run sync:server-version` automatically — the latter
+   keeps [`server.json`](server.json) version/description in lockstep with
+   `package.json`, so commit any resulting `server.json` diff).
 7. After npm publish, refresh the GitHub release so the body shows **Published on
    npm**:
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,17 @@ Note: framing is approximated from subject bounds — official acceptance is not
 
 Equivalent MCP prompt template: `ps.passport_photo` with `{ spec: "us_2x2", make_sheet: "true" }`.
 
+#### 🪪 CSV → cards (data-driven graphics)
+
+<img src="./images/recipe-csv-cards.svg" alt="CSV rows become data sets; one personalized card exported per row" width="640" />
+
+```
+Generate a name card for every row in ~/cards/speakers.csv using the open template PSD.
+PNG output to ~/cards/out — one file per row, named after the row.
+```
+
+Equivalent MCP prompt template: `ps.csv_to_cards` with `{ csv_path: "~/cards/speakers.csv", output_dir: "~/cards/out", format: "PNG" }`.
+
 ### More examples
 
 <details>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
 [![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS-lightgrey.svg)]()
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-io.github.alisaitteke%2Fphotoshop--mcp-purple.svg)](https://registry.modelcontextprotocol.io)
 
 A Model Context Protocol (MCP) server that enables AI assistants like Claude and Cursor to control Adobe Photoshop programmatically. This allows you to create designs, manipulate images, and automate Photoshop workflows through natural language commands while working in your IDE — or through the bundled **standalone web UI**, which supports both API keys and CLI subscription accounts (Claude Code / Gemini CLI). The UI also offers an opt-in **Action Plan (beta)** mode that plans every Photoshop step in one LLM call, then runs them in a single pass.
 
@@ -171,16 +172,16 @@ requests into reliable Photoshop actions:
 - **Server `instructions`** — workflow contract advertised on MCP `initialize`
   (ping once, state-before-action, prefer recipes, error recovery). See
   [`src/prompts/instructions.ts`](src/prompts/instructions.ts).
-- **MCP `prompts` primitive** — 22 pre-engineered templates (15 recipe + 7 guide:
+- **MCP `prompts` primitive** — 23 pre-engineered templates (16 recipe + 7 guide:
   `ps.enhance_portrait`, `ps.remove_background`, `ps.generative_fill`, …)
   via `prompts/list` and `prompts/get`.
-- **Recipe tools** — 15 outcome-oriented `photoshop_recipe_*` tools (remove
+- **Recipe tools** — 16 outcome-oriented `photoshop_recipe_*` tools (remove
   background, enhance portrait, prepare for web, export social variants, color
   grade, frequency separation, batch mockup, organize layers, gradient fade,
   sky blend, dodge & burn, remove distraction, split carousel, batch watermark,
-  passport photo). Each wraps steps in a single
-  Photoshop history state (one Undo reverts all). **89 tools total** (74 atomic
-  + 15 recipe).
+  passport photo, csv to cards). Each wraps steps in a single
+  Photoshop history state (one Undo reverts all). **102 tools total** (86 atomic
+  + 16 recipe).
 - **Generative AI** — `photoshop_generative_fill`, `photoshop_generative_remove`,
   `photoshop_generative_expand`, `photoshop_generative_upscale`, `photoshop_sky_replacement`,
   `photoshop_generate_image` (Firefly via ExtendScript; Adobe account + credits required).
@@ -585,15 +586,20 @@ Never guess — read get_state after a failure and propose the next single step.
 - **Supports Photoshop 2012-2025+**
 - **ExtendScript API**: Universal compatibility via AppleScript/COM automation
 - **Auto-Detection**: Automatically finds Photoshop installation on your system
-- **89 Tools**: 74 atomic `photoshop_*` + 15 recipe `photoshop_recipe_*`
-- **AI/Prompt Layer**: 22 MCP prompt templates (15 recipe + 7 guide), server instructions, state/preview/capabilities tools
+- **102 Tools**: 86 atomic `photoshop_*` + 16 recipe `photoshop_recipe_*`
+- **AI/Prompt Layer**: 23 MCP prompt templates (16 recipe + 7 guide), server instructions, state/preview/capabilities tools
 - **Document Management**: Create, open, save, close, crop documents
 - **Layer Operations**: Create, delete, duplicate, merge, transform layers
 - **Layer Properties**: Opacity, blend modes, visibility, locking
+- **Layer Styles**: Drop shadow, outer glow, stroke, bevel & emboss
 - **Text Formatting**: Font, size, color, alignment controls
 - **Image Placement**: Place images, open files, fit to document
 - **Filters**: Gaussian Blur, Sharpen, Noise, Motion Blur
 - **Color Adjustments**: Brightness/Contrast, Hue/Saturation, Curves, Auto Levels/Contrast
+- **Color Grading**: 3D LUT (Color Lookup) layers, Vibrance, Exposure, Photo Filter, Gradient Map
+- **Data-Driven Graphics**: CSV/variables XML → one image per row ("mail merge for images")
+- **Image Stacking**: Mean/median stack modes for tourist removal & noise reduction
+- **Modern Export**: PNG/JPEG plus WebP/AVIF (native, PS 23.2+)
 - **Selections & Masks**: Rectangular selections, select subject, content-aware fill, gradient mask, layer masks
 - **History Control**: Undo/Redo operations, view history states
 - **Actions**: Play recorded actions, execute custom scripts
@@ -601,6 +607,17 @@ Never guess — read get_state after a failure and propose the next single step.
 - **Context Tracking**: Returns document/layer state after each operation for AI context awareness
 
 ## Installation
+
+### One-click install
+
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=photoshop&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBhbGlzYWl0dGVrZS9waG90b3Nob3AtbWNwIl19)
+[![Install in VS Code](https://img.shields.io/badge/Install%20in-VS%20Code-0098FF)](https://vscode.dev/redirect/mcp/install?name=photoshop&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40alisaitteke%2Fphotoshop-mcp%22%5D%7D)
+
+Or from a terminal — Claude Code:
+
+```bash
+claude mcp add photoshop -- npx -y @alisaitteke/photoshop-mcp
+```
 
 ### Using NPX (Recommended)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,8 +44,8 @@ flowchart TB
 | ----- | -------------- | --------- |
 | **MCP core** | Tool/prompt registry, session, MCP protocol | `src/core/` |
 | **Platform** | Photoshop detection, script execution | `src/platform/` |
-| **Tools** | 74 atomic + 15 recipe MCP tools (+ generative & neural) | `src/tools/` |
-| **Prompt layer** | Server instructions, 22 MCP prompt templates | `src/prompts/` |
+| **Tools** | 86 atomic + 16 recipe MCP tools (+ generative & neural) | `src/tools/` |
+| **Prompt layer** | Server instructions, 23 MCP prompt templates | `src/prompts/` |
 | **Errors** | Structured envelopes for agent self-correction | `src/errors/envelope.ts` |
 | **Standalone UI** | Hono API, multi-provider agent, chat persistence | `src/ui/`, `web/` |
 | **Analytics** | Opt-out anonymous usage (Mixpanel / PostHog) | `src/analytics/` |
@@ -56,8 +56,8 @@ flowchart TB
 
 `PhotoshopMCPServer` wires the official MCP SDK with:
 
-- **89 tools** registered via `ToolRegistry` (atomic operations + outcome-oriented recipes + generative/neural AI).
-- **22 prompts** via `PromptRegistry` (`prompts/list`, `prompts/get`).
+- **102 tools** registered via `ToolRegistry` (atomic operations + outcome-oriented recipes + generative/neural AI).
+- **23 prompts** via `PromptRegistry` (`prompts/list`, `prompts/get`).
 - **Server instructions** on `initialize` — workflow contract for host LLMs (state-before-action, prefer recipes, error recovery). See [`src/prompts/instructions.ts`](../src/prompts/instructions.ts).
 - **Structured error wrapping** — every tool handler passes through `wrapToolHandler` so failures return JSON with `code` and `suggested_next_tool` for agentic repair loops.
 

--- a/docs/available-tools.md
+++ b/docs/available-tools.md
@@ -831,3 +831,96 @@ Requires `uxp-plugin/` — see [development.md](development.md).
 
 #### `photoshop_neural_filter`
 **Parameters:** `filter` (skin_smoothing|harmonize|depth_blur|super_zoom|colorize), `smoothness`, `blur`
+
+### Layer Styles
+
+#### `photoshop_apply_layer_style`
+Apply a layer effect (Action Manager `layerEffects`) to the active layer.
+
+**Parameters:**
+- `style` (string, required): `drop_shadow` | `outer_glow` | `stroke` | `bevel_emboss`
+- `red`, `green`, `blue` (number, optional): Effect color (default 0/0/0)
+- `opacity` (number, optional): 0-100 (default 60)
+- `size` (number, optional): Blur/size in px — stroke width for stroke (default 10)
+- `distance` (number, optional): Offset in px, drop shadow only (default 8)
+- `angle` (number, optional): Light angle in degrees (default 120)
+
+```javascript
+// Example: soft drop shadow on the active layer
+photoshop_apply_layer_style({ style: "drop_shadow", opacity: 55, size: 14, distance: 10 })
+```
+
+### Color Grading
+
+#### `photoshop_apply_lut`
+Color Lookup (3D LUT) adjustment layer — cinematic grades in one step.
+
+**Parameters:**
+- `lut` (string, required): Built-in LUT name (e.g. `"Crisp_Warm.3dl"`, `"Kodak 5218 Fuji 3510.3dl"`, `"Moonlight.3dl"`) or absolute path to a `.cube`/`.3dl`/`.look` file
+
+```javascript
+photoshop_apply_lut({ lut: "Crisp_Warm.3dl" })
+```
+
+#### `photoshop_adjust_vibrance`
+Vibrance adjustment layer. **Parameters:** `vibrance` (-100..100, default 40), `saturation` (-100..100, default 0)
+
+#### `photoshop_adjust_exposure`
+Exposure adjustment layer. **Parameters:** `exposure` (stops, default 0.5), `offset` (default 0), `gamma` (default 1)
+
+#### `photoshop_apply_photo_filter`
+Photo Filter adjustment layer (warming/cooling/tint). **Parameters:** `red`, `green`, `blue` (default 236/138/0 ≈ warming 85), `density` (0-100, default 25), `preserve_luminosity` (default true)
+
+#### `photoshop_apply_gradient_map`
+Gradient Map adjustment layer (black→white). **Parameters:** `reverse` (boolean, default false)
+
+### Data-Driven Graphics
+
+Photoshop's hidden "mail merge for images": template PSD with variable-bound layers (Image > Variables > Define) + data sets → one image per row.
+
+#### `photoshop_list_datasets`
+List data sets on the active document. **Returns:** `{ datasets, active, count }`
+
+#### `photoshop_import_datasets`
+Import a variables/data-sets XML file. **Parameters:** `xml_path` (required)
+
+#### `photoshop_generate_from_datasets`
+Batch-export the document once per data set.
+
+**Parameters:**
+- `output_dir` (string, required)
+- `format` (string, optional): `JPEG` | `PNG` | `PSD` (default JPEG)
+- `dataset_names` (string[], optional): subset to export (default all)
+
+```javascript
+photoshop_generate_from_datasets({ output_dir: "/Users/me/cards", format: "PNG" })
+```
+
+**One-shot alternative:** `photoshop_recipe_csv_to_cards` converts a CSV straight into data sets and exports every row (prompt template `ps.csv_to_cards`).
+
+### Image Stacking
+
+#### `photoshop_image_stack`
+Load 2+ images into one document, convert to a smart object, apply a stack mode — classic tourist removal / noise reduction without generative AI.
+
+**Parameters:**
+- `files` (string[], required): 2+ absolute image paths
+- `mode` (string, optional): `mean` | `median` | `maximum` | `minimum` | `summation` | `stddev` (default `median`)
+
+```javascript
+// Example: remove tourists from 3 aligned shots
+photoshop_image_stack({
+  files: ["/shots/a.jpg", "/shots/b.jpg", "/shots/c.jpg"],
+  mode: "median"
+})
+```
+
+### Modern Export
+
+#### `photoshop_export_as`
+Export a copy as PNG/JPEG (Save for Web) or WebP/AVIF (native, PS 23.2+). Returns `version_unsupported` when the build lacks WebP/AVIF.
+
+**Parameters:**
+- `path` (string, required): Absolute output path
+- `format` (string, optional): `PNG` | `JPEG` | `WEBP` | `AVIF` (default PNG)
+- `quality` (number, optional): 0-100 (default 80)

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,7 +77,7 @@ Local MCP integration tests run against a live Photoshop instance over stdio
 | Prompt-layer smoke | `npm run test:mcp-local` | 16 prompt templates + core recipes |
 | Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 12↔12 strict match + 4 guides |
 
-**Tool coverage:** 89 total tools (74 atomic `photoshop_*` + 15 recipe
+**Tool coverage:** 102 total tools (86 atomic `photoshop_*` + 16 recipe
 `photoshop_recipe_*`) — re-run `npm run test:mcp-all` for a fresh pass count.
 
 **Intentional skips** (environment-dependent, not regressions):

--- a/docs/prompt-layer.md
+++ b/docs/prompt-layer.md
@@ -1,7 +1,7 @@
 # AI / Prompt Layer for Photoshop
 
-The photoshop-mcp server exposes 74 atomic `photoshop_*` tools plus 15 recipe
-`photoshop_recipe_*` tools (89 total), along with a thin
+The photoshop-mcp server exposes 86 atomic `photoshop_*` tools plus 16 recipe
+`photoshop_recipe_*` tools (102 total), along with a thin
 AI/prompt layer ported from TTT: server-level instructions, MCP prompt templates,
 recipe tools, state/preview tools, version-aware capabilities, and structured
 error envelopes.

--- a/docs/social-preview.md
+++ b/docs/social-preview.md
@@ -39,7 +39,7 @@ When LLMs call Photoshop one command at a time, they burn tokens, guess layer ty
 
 **What I built (open source)**
 
-- **Photoshop MCP** — 89 tools incl. 15 recipe workflows (single-undo outcomes)
+- **Photoshop MCP** — 102 tools incl. 16 recipe workflows (single-undo outcomes)
 - Cross-platform: macOS (AppleScript) + Windows (COM)
 - Bundled **standalone web UI** — chat with Claude, GPT, or Gemini; drive Photoshop without an IDE
 - **Action Plan (beta)** — plan all steps in one LLM call, execute without per-step round-trips

--- a/images/recipe-csv-cards.svg
+++ b/images/recipe-csv-cards.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="260" viewBox="0 0 640 260" font-family="Helvetica, Arial, sans-serif">
+  <rect width="640" height="260" rx="12" fill="#f6f8fa"/>
+  <text x="320" y="30" text-anchor="middle" font-size="15" font-weight="700" fill="#1f2328">photoshop_recipe_csv_to_cards</text>
+  <text x="320" y="48" text-anchor="middle" font-size="11" fill="#57606a">CSV rows → data sets → one personalized card per row ("mail merge for images")</text>
+
+  <!-- CSV table -->
+  <g transform="translate(70,78)">
+    <rect width="200" height="130" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+    <rect width="200" height="26" rx="6" fill="#eaeef2"/>
+    <text x="14" y="17" font-size="10" font-weight="700" fill="#1f2328">name</text>
+    <text x="112" y="17" font-size="10" font-weight="700" fill="#1f2328">role</text>
+    <g font-size="10" fill="#57606a">
+      <text x="14" y="44">Ada Lovelace</text>
+      <text x="112" y="44">Engineer</text>
+      <text x="14" y="70">Grace Hopper</text>
+      <text x="112" y="70">Admiral</text>
+      <text x="14" y="96">Alan Turing</text>
+      <text x="112" y="96">Pioneer</text>
+    </g>
+    <g stroke="#d0d7de" stroke-width="1">
+      <line x1="0" y1="52" x2="200" y2="52"/>
+      <line x1="0" y1="78" x2="200" y2="78"/>
+      <line x1="0" y1="104" x2="200" y2="104"/>
+      <line x1="100" y1="0" x2="100" y2="130"/>
+    </g>
+    <text x="0" y="148" font-size="10" fill="#57606a">speakers.csv</text>
+  </g>
+
+  <!-- arrow -->
+  <g transform="translate(300,138)">
+    <line x1="0" y1="0" x2="34" y2="0" stroke="#57606a" stroke-width="1.5"/>
+    <polygon points="30,-6 44,0 30,6" fill="#57606a"/>
+  </g>
+
+  <!-- output cards -->
+  <g transform="translate(380,66)">
+    <g transform="translate(0,0)">
+      <rect width="190" height="52" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+      <circle cx="26" cy="26" r="14" fill="#eaeef2" stroke="#d0d7de" stroke-width="1"/>
+      <text x="50" y="24" font-size="11" font-weight="700" fill="#1f2328">Ada Lovelace</text>
+      <text x="50" y="40" font-size="10" fill="#57606a">Engineer</text>
+      <text x="182" y="44" text-anchor="end" font-size="8" fill="#8b949e">row_1.png</text>
+    </g>
+    <g transform="translate(0,62)">
+      <rect width="190" height="52" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+      <circle cx="26" cy="26" r="14" fill="#eaeef2" stroke="#d0d7de" stroke-width="1"/>
+      <text x="50" y="24" font-size="11" font-weight="700" fill="#1f2328">Grace Hopper</text>
+      <text x="50" y="40" font-size="10" fill="#57606a">Admiral</text>
+      <text x="182" y="44" text-anchor="end" font-size="8" fill="#8b949e">row_2.png</text>
+    </g>
+    <g transform="translate(0,124)">
+      <rect width="190" height="52" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="1.5"/>
+      <circle cx="26" cy="26" r="14" fill="#eaeef2" stroke="#d0d7de" stroke-width="1"/>
+      <text x="50" y="24" font-size="11" font-weight="700" fill="#1f2328">Alan Turing</text>
+      <text x="50" y="40" font-size="10" fill="#57606a">Pioneer</text>
+      <text x="182" y="44" text-anchor="end" font-size="8" fill="#8b949e">row_3.png</text>
+    </g>
+  </g>
+
+  <text x="320" y="248" text-anchor="middle" font-size="10" fill="#57606a">template PSD with variable-bound layers + one CSV → N exported files, original untouched</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alisaitteke/photoshop-mcp",
   "version": "1.6.0",
-  "description": "MCP server for Adobe Photoshop — 89 tools (generative AI + recipes), standalone web UI. Control Photoshop from Cursor, Claude, or natural language.",
+  "description": "MCP server for Adobe Photoshop — 102 tools (generative AI + recipes), standalone web UI. Control Photoshop from Cursor, Claude, or natural language.",
   "main": "dist/index.js",
   "type": "module",
   "bin": {
@@ -29,6 +29,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "spike:photoshop-actions": "tsx scripts/spike-photoshop-actions.ts",
+    "spike:2026": "tsx scripts/spike-2026-features.ts",
     "spike:issue-2": "tsx scripts/spike-issue-2.ts",
     "verify:photoshop-prompts": "tsx scripts/verify-photoshop-prompt-coverage.ts",
     "test:mcp-local": "tsx scripts/test-mcp-local.ts",
@@ -36,7 +37,8 @@
     "test:mcp-all": "tsx scripts/test-all-mcp-tools.ts",
     "test:intent-expansion": "tsx scripts/test-intent-expansion-local.ts",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run build",
+    "sync:server-version": "tsx scripts/sync-server-version.ts",
+    "prepublishOnly": "npm run build && npm run sync:server-version",
     "test:unit": "vitest run"
   },
   "keywords": [
@@ -92,12 +94,14 @@
   },
   "mcpName": "io.github.alisaitteke/photoshop-mcp",
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
     "concurrently": "^9.1.2",
     "eslint": "^9.18.0",
+    "globals": "^17.9.0",
     "prettier": "^3.4.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alisaitteke/photoshop-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "MCP server for Adobe Photoshop — 89 tools (generative AI + recipes), standalone web UI. Control Photoshop from Cursor, Claude, or natural language.",
   "main": "dist/index.js",
   "type": "module",

--- a/scripts/spike-2026-features.ts
+++ b/scripts/spike-2026-features.ts
@@ -1,0 +1,482 @@
+/**
+ * Dev-only ExtendScript probe runner for Photoshop 2026 (v27.x) feature research.
+ * Run: npm run spike:2026
+ *
+ * Requires Photoshop v27.6+ on macOS/Windows with an active session.
+ * Probes: reflection removal, distraction removal (wires), dynamic text,
+ * partner-model generative fill, generate similar.
+ * Writes machine-readable report to scripts/output/spike-2026-report.json and stdout.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PhotoshopConnection } from '../src/platform/connection.js';
+import { parseExtendScriptPayload } from '../src/utils/extendscript-result.js';
+
+const SPIKE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const REPORT_PATH = join(SPIKE_ROOT, 'scripts', 'output', 'spike-2026-report.json');
+
+export type SpikeStatus = 'scriptable' | 'partial' | 'manual_only';
+
+export interface SpikeRow {
+  action_id: string;
+  descriptor: string | null;
+  status: SpikeStatus;
+  ps_version_tested: string;
+  notes: string;
+}
+
+const SPIKE_RUNTIME = `
+function __spike_s2t(s) { return app.stringIDToTypeID(s); }
+function __spike_c2t(s) { return app.charIDToTypeID(s); }
+
+function __spike_newDoc() {
+  return app.documents.add(
+    UnitValue(512, 'px'),
+    UnitValue(512, 'px'),
+    72,
+    'MCP Spike 2026',
+    NewDocumentMode.RGB,
+    DocumentFill.WHITE
+  );
+}
+
+function __spike_historyIndex(doc) {
+  return doc.activeHistoryState.index;
+}
+
+function __spike_revertTo(doc, index) {
+  try {
+    doc.activeHistoryState = doc.historyStates[index];
+  } catch (e) {}
+}
+
+function __spike_fillLayer(doc) {
+  var color = new SolidColor();
+  color.rgb.red = 120;
+  color.rgb.green = 140;
+  color.rgb.blue = 160;
+  doc.selection.selectAll();
+  doc.selection.fill(color);
+  doc.selection.deselect();
+}
+
+function __spike_probeResult(actionId, descriptor, status, notes) {
+  return {
+    action_id: actionId,
+    descriptor: descriptor,
+    status: status,
+    notes: notes
+  };
+}
+
+function __spike_finish(row) {
+  return __spike_json_stringify(row);
+}
+
+function __spike_json_stringify(value) {
+  if (value === null) return 'null';
+  var t = typeof value;
+  if (t === 'boolean') return value ? 'true' : 'false';
+  if (t === 'number') return isFinite(value) ? String(value) : 'null';
+  if (t === 'string') {
+    return '"' + value
+      .replace(/\\\\/g, '\\\\\\\\')
+      .replace(/"/g, '\\\\"')
+      .replace(/\\n/g, '\\\\n')
+      .replace(/\\r/g, '\\\\r')
+      .replace(/\\t/g, '\\\\t') + '"';
+  }
+  if (value instanceof Array) {
+    var items = [];
+    for (var i = 0; i < value.length; i++) {
+      items.push(__spike_json_stringify(value[i]));
+    }
+    return '[' + items.join(',') + ']';
+  }
+  if (t === 'object') {
+    var pairs = [];
+    for (var key in value) {
+      if (!value.hasOwnProperty(key)) continue;
+      pairs.push(__spike_json_stringify(String(key)) + ':' + __spike_json_stringify(value[key]));
+    }
+    return '{' + pairs.join(',') + '}';
+  }
+  return 'null';
+}
+`;
+
+function wrapProbe(body: string): string {
+  return `
+${SPIKE_RUNTIME}
+app.displayDialogs = DialogModes.NO;
+${body}
+`.trim();
+}
+
+/** Mirror ExtendScriptPhotoshopAPI.wrapInErrorHandling so returns work via evalFile. */
+function wrapForExternalExecution(script: string): string {
+  return `
+(function() {
+  var __originalRulerUnits = null;
+  try { __originalRulerUnits = app.preferences.rulerUnits; } catch (e) {}
+
+  try {
+    try { app.preferences.rulerUnits = Units.PIXELS; } catch (e) {}
+
+    var result = (function() {
+      ${script}
+    })();
+    if (typeof result === 'object' && result !== null) {
+      return result.toSource ? result.toSource() : String(result);
+    }
+    return String(result);
+  } catch (error) {
+    return 'ERROR: ' + (error.message || String(error));
+  } finally {
+    try { if (__originalRulerUnits !== null) app.preferences.rulerUnits = __originalRulerUnits; } catch (e) {}
+  }
+})();
+`.trim();
+}
+
+const PROBES: Array<{
+  action_id: string;
+  descriptor: string;
+  timeoutMs: number;
+  script: string;
+}> = [
+  {
+    action_id: 'reflection_removal',
+    descriptor: "executeAction('removeReflections'|'deReflect') + Camera Raw filter fallback",
+    timeoutMs: 120_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      __spike_fillLayer(doc);
+      var candidates = ['removeReflections', 'reflectionRemoval', 'deReflect', 'removeReflection'];
+      var lastError = '';
+      for (var i = 0; i < candidates.length; i++) {
+        var actionId = candidates[i];
+        try {
+          executeAction(__spike_s2t(actionId), new ActionDescriptor(), DialogModes.NO);
+          return __spike_finish(__spike_probeResult(
+            'reflection_removal',
+            "executeAction('" + actionId + "')",
+            'partial',
+            'Action accepted via ' + actionId
+          ));
+        } catch (e) {
+          lastError = actionId + ': ' + (e.message || String(e));
+          __spike_revertTo(doc, hist);
+        }
+      }
+      // Camera Raw path: reflection removal shipped in ACR — probe the AM filter key.
+      try {
+        var desc = new ActionDescriptor();
+        var rawDesc = new ActionDescriptor();
+        rawDesc.putBoolean(__spike_s2t('removeReflections'), true);
+        desc.putObject(__spike_s2t('cameraRawOptions'), __spike_s2t('cameraRawOptions'), rawDesc);
+        executeAction(__spike_s2t('Adobe Camera Raw Filter'), desc, DialogModes.NO);
+        return __spike_finish(__spike_probeResult(
+          'reflection_removal',
+          "executeAction('Adobe Camera Raw Filter') w/ removeReflections option",
+          'partial',
+          'Camera Raw filter accepted reflection-removal descriptor'
+        ));
+      } catch (eAcr) {
+        lastError += ' | ACR: ' + (eAcr.message || String(eAcr));
+      }
+      try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return __spike_finish(__spike_probeResult(
+        'reflection_removal',
+        "executeAction('removeReflections')",
+        'manual_only',
+        lastError || 'No reflection-removal action ID succeeded'
+      ));
+    `),
+  },
+  {
+    action_id: 'distraction_removal_wires',
+    descriptor: "executeAction('findDistractions'|'removeDistractions') on Remove tool",
+    timeoutMs: 120_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      __spike_fillLayer(doc);
+      var candidates = [
+        'findDistractions',
+        'detectDistractions',
+        'removeDistractions',
+        'removeWiresAndCables',
+        'removeTool'
+      ];
+      var lastError = '';
+      for (var i = 0; i < candidates.length; i++) {
+        var actionId = candidates[i];
+        try {
+          executeAction(__spike_s2t(actionId), new ActionDescriptor(), DialogModes.NO);
+          return __spike_finish(__spike_probeResult(
+            'distraction_removal_wires',
+            "executeAction('" + actionId + "')",
+            'partial',
+            'Action accepted via ' + actionId
+          ));
+        } catch (e) {
+          lastError = actionId + ': ' + (e.message || String(e));
+          __spike_revertTo(doc, hist);
+        }
+      }
+      try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return __spike_finish(__spike_probeResult(
+        'distraction_removal_wires',
+        "executeAction('findDistractions')",
+        'manual_only',
+        lastError || 'No distraction-removal action ID succeeded'
+      ));
+    `),
+  },
+  {
+    action_id: 'dynamic_text',
+    descriptor: "AM 'set' textLayer with textShape circle/arch/bow",
+    timeoutMs: 30_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      try {
+        var layer = doc.artLayers.add();
+        layer.kind = LayerKind.TEXT;
+        layer.textItem.contents = 'Dynamic Text Spike';
+        var shapeCandidates = ['circle', 'arch', 'bow'];
+        var keyCandidates = ['textShape', 'dynamicTextShape', 'dynamicText'];
+        var lastError = '';
+        for (var k = 0; k < keyCandidates.length; k++) {
+          for (var s = 0; s < shapeCandidates.length; s++) {
+            try {
+              var desc = new ActionDescriptor();
+              var ref = new ActionReference();
+              ref.putEnumerated(__spike_c2t('Lyr '), __spike_c2t('Ordn'), __spike_c2t('Trgt'));
+              desc.putReference(__spike_c2t('null'), ref);
+              var textDesc = new ActionDescriptor();
+              var shapeDesc = new ActionDescriptor();
+              shapeDesc.putEnumerated(
+                __spike_s2t('textShape'),
+                __spike_s2t('textShapeType'),
+                __spike_s2t(shapeCandidates[s])
+              );
+              textDesc.putObject(__spike_s2t(keyCandidates[k]), __spike_s2t(keyCandidates[k]), shapeDesc);
+              desc.putObject(__spike_c2t('T   '), __spike_c2t('TxLr'), textDesc);
+              executeAction(__spike_c2t('setd'), desc, DialogModes.NO);
+              return __spike_finish(__spike_probeResult(
+                'dynamic_text',
+                "setd textLayer." + keyCandidates[k] + "=" + shapeCandidates[s],
+                'partial',
+                'Descriptor accepted: ' + keyCandidates[k] + '=' + shapeCandidates[s]
+              ));
+            } catch (e) {
+              lastError = keyCandidates[k] + '/' + shapeCandidates[s] + ': ' + (e.message || String(e));
+              __spike_revertTo(doc, hist);
+            }
+          }
+        }
+        return __spike_finish(__spike_probeResult(
+          'dynamic_text',
+          "setd textLayer.textShape",
+          'manual_only',
+          lastError || 'No dynamic-text descriptor accepted'
+        ));
+      } catch (eOuter) {
+        return __spike_finish(__spike_probeResult(
+          'dynamic_text',
+          "setd textLayer.textShape",
+          'manual_only',
+          eOuter.message || String(eOuter)
+        ));
+      } finally {
+        try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      }
+    `),
+  },
+  {
+    action_id: 'partner_model_generative_fill',
+    descriptor: "generative fill descriptor with model key (firefly/partner)",
+    timeoutMs: 120_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      __spike_fillLayer(doc);
+      doc.selection.select([
+        [UnitValue(128, 'px'), UnitValue(128, 'px')],
+        [UnitValue(384, 'px'), UnitValue(128, 'px')],
+        [UnitValue(384, 'px'), UnitValue(384, 'px')],
+        [UnitValue(128, 'px'), UnitValue(384, 'px')]
+      ]);
+      var fillIds = ['generativeFill', 'generativeFillEdit', 'syntheticFill'];
+      var modelKeys = ['generativeModel', 'aiModel', 'model', 'engine'];
+      var lastError = '';
+      for (var f = 0; f < fillIds.length; f++) {
+        for (var m = 0; m < modelKeys.length; m++) {
+          try {
+            var desc = new ActionDescriptor();
+            desc.putString(__spike_s2t('prompt'), 'a red apple');
+            desc.putString(__spike_s2t(modelKeys[m]), 'firefly');
+            executeAction(__spike_s2t(fillIds[f]), desc, DialogModes.NO);
+            return __spike_finish(__spike_probeResult(
+              'partner_model_generative_fill',
+              fillIds[f] + ' w/ ' + modelKeys[m] + '=firefly',
+              'partial',
+              'Fill accepted model key ' + modelKeys[m] + ' (verify model picker really switched in UI)'
+            ));
+          } catch (e) {
+            lastError = fillIds[f] + '/' + modelKeys[m] + ': ' + (e.message || String(e));
+            __spike_revertTo(doc, hist);
+            doc.selection.select([
+              [UnitValue(128, 'px'), UnitValue(128, 'px')],
+              [UnitValue(384, 'px'), UnitValue(128, 'px')],
+              [UnitValue(384, 'px'), UnitValue(384, 'px')],
+              [UnitValue(128, 'px'), UnitValue(384, 'px')]
+            ]);
+          }
+        }
+      }
+      try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return __spike_finish(__spike_probeResult(
+        'partner_model_generative_fill',
+        'generativeFill w/ model key',
+        'manual_only',
+        lastError || 'No generative-fill model key accepted'
+      ));
+    `),
+  },
+  {
+    action_id: 'generate_similar',
+    descriptor: "executeAction('generateSimilar'|'generativeVariations')",
+    timeoutMs: 120_000,
+    script: wrapProbe(`
+      var doc = __spike_newDoc();
+      var hist = __spike_historyIndex(doc);
+      __spike_fillLayer(doc);
+      var candidates = ['generateSimilar', 'generativeVariations', 'generateVariations', 'syntheticVariations'];
+      var lastError = '';
+      for (var i = 0; i < candidates.length; i++) {
+        var actionId = candidates[i];
+        try {
+          executeAction(__spike_s2t(actionId), new ActionDescriptor(), DialogModes.NO);
+          return __spike_finish(__spike_probeResult(
+            'generate_similar',
+            "executeAction('" + actionId + "')",
+            'partial',
+            'Action accepted via ' + actionId
+          ));
+        } catch (e) {
+          lastError = actionId + ': ' + (e.message || String(e));
+          __spike_revertTo(doc, hist);
+        }
+      }
+      try { doc.close(SaveOptions.DONOTSAVECHANGES); } catch (eClose) {}
+      return __spike_finish(__spike_probeResult(
+        'generate_similar',
+        "executeAction('generateSimilar')",
+        'manual_only',
+        lastError || 'No generate-similar action ID succeeded'
+      ));
+    `),
+  },
+];
+
+function parseProbePayload(raw: unknown): Omit<SpikeRow, 'ps_version_tested'> | null {
+  const payload = parseExtendScriptPayload(raw);
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload) as Record<string, unknown>;
+      return parseProbeRecord(parsed);
+    } catch {
+      return null;
+    }
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  return parseProbeRecord(payload as Record<string, unknown>);
+}
+
+function parseProbeRecord(rec: Record<string, unknown>): Omit<SpikeRow, 'ps_version_tested'> | null {
+  const status = rec.status;
+  if (status !== 'scriptable' && status !== 'partial' && status !== 'manual_only') return null;
+  return {
+    action_id: typeof rec.action_id === 'string' ? rec.action_id : 'unknown',
+    descriptor: typeof rec.descriptor === 'string' ? rec.descriptor : null,
+    status,
+    notes: typeof rec.notes === 'string' ? rec.notes : '',
+  };
+}
+
+async function runProbe(
+  connection: PhotoshopConnection,
+  probe: (typeof PROBES)[number],
+  psVersion: string
+): Promise<SpikeRow> {
+  try {
+    const raw = await connection.executeScript(
+      wrapForExternalExecution(probe.script),
+      probe.timeoutMs
+    );
+    const parsed = parseProbePayload(raw);
+    if (!parsed) {
+      return {
+        action_id: probe.action_id,
+        descriptor: probe.descriptor,
+        status: 'manual_only',
+        ps_version_tested: psVersion,
+        notes: `Unparseable probe result: ${typeof raw === 'string' ? raw.slice(0, 200) : JSON.stringify(raw)}`,
+      };
+    }
+    return { ...parsed, ps_version_tested: psVersion };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status: SpikeStatus = /timeout/i.test(message) ? 'partial' : 'manual_only';
+    return {
+      action_id: probe.action_id,
+      descriptor: probe.descriptor,
+      status,
+      ps_version_tested: psVersion,
+      notes: message,
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const connection = new PhotoshopConnection();
+  const reachable = await connection.ping();
+  if (!reachable) {
+    console.error(JSON.stringify({ error: 'Photoshop not detected on this machine.' }));
+    process.exit(1);
+  }
+
+  const psVersion = await connection.getVersion();
+  const rows: SpikeRow[] = [];
+
+  for (const probe of PROBES) {
+    const row = await runProbe(connection, probe, psVersion);
+    rows.push(row);
+  }
+
+  const report = {
+    generated_at: new Date().toISOString(),
+    ps_version: psVersion,
+    probes: rows,
+    winning_action_ids: Object.fromEntries(
+      rows
+        .filter((r) => r.status !== 'manual_only')
+        .map((r) => [r.action_id, r.descriptor])
+    ),
+  };
+
+  mkdirSync(dirname(REPORT_PATH), { recursive: true });
+  writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/sync-server-version.ts
+++ b/scripts/sync-server-version.ts
@@ -1,0 +1,25 @@
+/**
+ * Sync server.json with package.json before npm publish.
+ * Copies version + description so the MCP registry listing never goes stale.
+ * Run: npx tsx scripts/sync-server-version.ts   (wired into prepublishOnly)
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+const serverPath = join(ROOT, 'server.json');
+const server = JSON.parse(readFileSync(serverPath, 'utf8'));
+
+server.version = pkg.version;
+server.description = pkg.description;
+if (Array.isArray(server.packages)) {
+  for (const p of server.packages) {
+    if (p.registryType === 'npm') p.version = pkg.version;
+  }
+}
+
+writeFileSync(serverPath, JSON.stringify(server, null, 2) + '\n');
+console.log(`server.json synced to v${pkg.version}`);

--- a/scripts/test-mcp-local.ts
+++ b/scripts/test-mcp-local.ts
@@ -71,16 +71,20 @@ async function main(): Promise<void> {
   const expectedRecipePrompts = [
     'ps.apply_color_grade',
     'ps.batch_mockup_replace',
+    'ps.batch_watermark',
+    'ps.csv_to_cards',
     'ps.dodge_burn',
     'ps.enhance_portrait',
     'ps.export_social_variants',
     'ps.frequency_separation',
     'ps.gradient_fade',
     'ps.organize_layers',
+    'ps.passport_photo',
     'ps.prepare_for_web',
     'ps.remove_background',
     'ps.remove_distraction',
     'ps.sky_blend',
+    'ps.split_carousel',
   ];
   const expectedGuidePrompts = [
     'ps.color_correct',
@@ -91,11 +95,15 @@ async function main(): Promise<void> {
     'ps.generative_remove',
     'ps.generative_expand',
   ];
-  if (promptNames.length !== 19) fail('prompt count', String(promptNames.length));
+  const expectedPromptCount = expectedRecipePrompts.length + expectedGuidePrompts.length;
+  if (promptNames.length !== expectedPromptCount) fail('prompt count', String(promptNames.length));
   for (const name of [...expectedRecipePrompts, ...expectedGuidePrompts]) {
     if (!promptNames.includes(name)) fail('missing prompt', name);
   }
-  ok('19 prompt templates', `${expectedRecipePrompts.length} recipe + ${expectedGuidePrompts.length} guide`);
+  ok(
+    `${expectedPromptCount} prompt templates`,
+    `${expectedRecipePrompts.length} recipe + ${expectedGuidePrompts.length} guide`
+  );
 
   section('Get prompt (ps.remove_background)');
   const promptResult = await client.getPrompt({
@@ -144,6 +152,7 @@ async function main(): Promise<void> {
     'photoshop_recipe_sky_blend',
     'photoshop_recipe_dodge_burn',
     'photoshop_recipe_remove_distraction',
+    'photoshop_recipe_csv_to_cards',
     'photoshop_generative_fill',
     'photoshop_generative_remove',
     'photoshop_generative_expand',
@@ -151,6 +160,17 @@ async function main(): Promise<void> {
     'photoshop_sky_replacement',
     'photoshop_generate_image',
     'photoshop_neural_filter',
+    'photoshop_apply_layer_style',
+    'photoshop_apply_lut',
+    'photoshop_adjust_vibrance',
+    'photoshop_adjust_exposure',
+    'photoshop_apply_photo_filter',
+    'photoshop_apply_gradient_map',
+    'photoshop_list_datasets',
+    'photoshop_import_datasets',
+    'photoshop_generate_from_datasets',
+    'photoshop_image_stack',
+    'photoshop_export_as',
   ];
   for (const name of required) {
     if (!toolNames.has(name)) fail('missing tool', name);
@@ -166,14 +186,21 @@ async function main(): Promise<void> {
   section('Call photoshop_get_capabilities');
   const caps = await client.callTool({ name: 'photoshop_get_capabilities', arguments: {} });
   const capsText = textFromToolResult(caps);
-  if (caps.isError) fail('get_capabilities', capsText);
   let capsJson: Record<string, unknown> = {};
-  try {
-    capsJson = JSON.parse(capsText) as Record<string, unknown>;
-  } catch {
-    fail('get_capabilities JSON', capsText.slice(0, 200));
+  if (caps.isError) {
+    if (!photoshopReachable) {
+      console.log('  SKIP get_capabilities — Photoshop not reachable');
+    } else {
+      fail('get_capabilities', capsText);
+    }
+  } else {
+    try {
+      capsJson = JSON.parse(capsText) as Record<string, unknown>;
+    } catch {
+      fail('get_capabilities JSON', capsText.slice(0, 200));
+    }
+    ok('get_capabilities', `version=${String(capsJson.version ?? 'unknown')}`);
   }
-  ok('get_capabilities', `version=${String(capsJson.version ?? 'unknown')}`);
 
   if (photoshopReachable) {
     section('Call photoshop_get_state');

--- a/scripts/verify-photoshop-prompt-coverage.ts
+++ b/scripts/verify-photoshop-prompt-coverage.ts
@@ -58,15 +58,16 @@ const RECIPE_TO_PROMPT: Record<string, string> = {
   photoshop_recipe_split_carousel: 'ps.split_carousel',
   photoshop_recipe_batch_watermark: 'ps.batch_watermark',
   photoshop_recipe_passport_photo: 'ps.passport_photo',
+  photoshop_recipe_csv_to_cards: 'ps.csv_to_cards',
 };
 
 const promptNames = new Set(PHOTOSHOP_PROMPT_TEMPLATES.map((p) => p.name));
 const guidePromptNames = new Set<string>(PHOTOSHOP_GUIDE_PROMPT_NAMES);
 
-assert.equal(PHOTOSHOP_RECIPE_TOOL_NAMES.length, 15);
-assert.equal(Object.keys(RECIPE_TO_PROMPT).length, 15);
+assert.equal(PHOTOSHOP_RECIPE_TOOL_NAMES.length, 16);
+assert.equal(Object.keys(RECIPE_TO_PROMPT).length, 16);
 assert.equal(PHOTOSHOP_GUIDE_PROMPT_NAMES.length, 7);
-assert.equal(PHOTOSHOP_PROMPT_TEMPLATES.length, 22);
+assert.equal(PHOTOSHOP_PROMPT_TEMPLATES.length, 23);
 
 for (const recipeName of PHOTOSHOP_RECIPE_TOOL_NAMES) {
   const promptName = RECIPE_TO_PROMPT[recipeName];

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.alisaitteke/photoshop-mcp",
-  "description": "MCP server for Adobe Photoshop — 80 AI tools, recipe workflows, standalone web UI. Cross-platform automation for Cursor, Claude, and AI agents.",
+  "description": "MCP server for Adobe Photoshop — 102 tools (generative AI + recipes), standalone web UI. Control Photoshop from Cursor, Claude, or natural language.",
   "repository": {
     "url": "https://github.com/alisaitteke/photoshop-mcp",
     "source": "github"
   },
-  "version": "0.1.6",
+  "version": "1.6.0",
   "mcpName": "io.github.alisaitteke/photoshop-mcp",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@alisaitteke/photoshop-mcp",
-      "version": "0.1.6",
+      "version": "1.6.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -2458,6 +2458,558 @@ export const ExtendScriptSnippets = {
       };
     `;
   },
+
+  /**
+   * Apply a layer style (drop shadow / outer glow / stroke / bevel) via Action Manager layerEffects.
+   */
+  applyLayerStyle: (options: {
+    style: 'drop_shadow' | 'outer_glow' | 'stroke' | 'bevel_emboss';
+    red: number;
+    green: number;
+    blue: number;
+    opacity: number;
+    size: number;
+    distance: number;
+    angle: number;
+  }) => {
+    const { style, red, green, blue, opacity, size, distance, angle } = options;
+    let styleDescriptor: string;
+    if (style === 'drop_shadow') {
+      styleDescriptor = `
+      var fx = new ActionDescriptor();
+      fx.putBoolean(cTID('enab'), true);
+      fx.putEnumerated(cTID('Md  '), cTID('BlnM'), cTID('Mltp'));
+      fx.putObject(cTID('Clr '), cTID('RGBC'), rgb);
+      fx.putUnitDouble(cTID('Opct'), cTID('#Prc'), ${opacity});
+      fx.putUnitDouble(cTID('lagl'), cTID('#Ang'), ${angle});
+      fx.putUnitDouble(cTID('Dstn'), cTID('#Pxl'), ${distance});
+      fx.putUnitDouble(cTID('Ckmt'), cTID('#Pxl'), 0);
+      fx.putUnitDouble(cTID('blur'), cTID('#Pxl'), ${size});
+      fx.putBoolean(cTID('uglg'), true);
+      effects.putObject(cTID('DrSh'), fx);`;
+    } else if (style === 'outer_glow') {
+      styleDescriptor = `
+      var fx = new ActionDescriptor();
+      fx.putBoolean(cTID('enab'), true);
+      fx.putEnumerated(cTID('Md  '), cTID('BlnM'), cTID('Scrn'));
+      fx.putObject(cTID('Clr '), cTID('RGBC'), rgb);
+      fx.putUnitDouble(cTID('Opct'), cTID('#Prc'), ${opacity});
+      fx.putUnitDouble(cTID('Ckmt'), cTID('#Pxl'), 0);
+      fx.putUnitDouble(cTID('blur'), cTID('#Pxl'), ${size});
+      fx.putUnitDouble(cTID('Nose'), cTID('#Prc'), 0);
+      fx.putUnitDouble(cTID('ShdN'), cTID('#Prc'), 0);
+      fx.putBoolean(cTID('AntA'), true);
+      effects.putObject(cTID('OrGl'), fx);`;
+    } else if (style === 'stroke') {
+      styleDescriptor = `
+      var fx = new ActionDescriptor();
+      fx.putBoolean(cTID('enab'), true);
+      fx.putEnumerated(sTID('style'), sTID('frameStyle'), sTID('outsetFrame'));
+      fx.putEnumerated(sTID('paintType'), sTID('frameFill'), sTID('solidColor'));
+      fx.putEnumerated(cTID('Md  '), cTID('BlnM'), cTID('Nrml'));
+      fx.putUnitDouble(cTID('Opct'), cTID('#Prc'), ${opacity});
+      fx.putUnitDouble(cTID('Sz  '), cTID('#Pxl'), ${size});
+      fx.putObject(cTID('Clr '), cTID('RGBC'), rgb);
+      fx.putBoolean(sTID('overprint'), false);
+      effects.putObject(sTID('frameFX'), fx);`;
+    } else {
+      styleDescriptor = `
+      var fx = new ActionDescriptor();
+      fx.putBoolean(cTID('enab'), true);
+      fx.putEnumerated(cTID('bvlS'), cTID('BESL'), cTID('InrB'));
+      fx.putEnumerated(cTID('bvlT'), cTID('BSLT'), cTID('SfBl'));
+      fx.putEnumerated(cTID('bvlD'), cTID('BESD'), cTID('In  '));
+      fx.putUnitDouble(cTID('srg '), cTID('#Prc'), 100);
+      fx.putUnitDouble(cTID('blur'), cTID('#Pxl'), ${size});
+      fx.putUnitDouble(cTID('Sftn'), cTID('#Pxl'), 0);
+      fx.putUnitDouble(cTID('lagl'), cTID('#Ang'), ${angle});
+      fx.putUnitDouble(cTID('Lald'), cTID('#Ang'), 30);
+      var hiRgb = new ActionDescriptor();
+      hiRgb.putDouble(cTID('Rd  '), 255); hiRgb.putDouble(cTID('Grn '), 255); hiRgb.putDouble(cTID('Bl  '), 255);
+      fx.putEnumerated(cTID('hglM'), cTID('BlnM'), cTID('Scrn'));
+      fx.putObject(cTID('hglC'), cTID('RGBC'), hiRgb);
+      fx.putUnitDouble(cTID('hglO'), cTID('#Prc'), 75);
+      fx.putEnumerated(cTID('sdwM'), cTID('BlnM'), cTID('Mltp'));
+      fx.putObject(cTID('sdwC'), cTID('RGBC'), rgb);
+      fx.putUnitDouble(cTID('sdwO'), cTID('#Prc'), ${opacity});
+      effects.putObject(cTID('ebbl'), fx);`;
+    }
+    return `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    var doc = app.activeDocument;
+    app.displayDialogs = DialogModes.NO;
+
+    var rgb = new ActionDescriptor();
+    rgb.putDouble(cTID('Rd  '), ${red});
+    rgb.putDouble(cTID('Grn '), ${green});
+    rgb.putDouble(cTID('Bl  '), ${blue});
+
+    var effects = new ActionDescriptor();
+    effects.putUnitDouble(cTID('Scl '), cTID('#Prc'), 100);
+    ${styleDescriptor}
+
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putProperty(cTID('Prpr'), cTID('Lefx'));
+    ref.putEnumerated(cTID('Lyr '), cTID('Ordn'), cTID('Trgt'));
+    desc.putReference(cTID('null'), ref);
+    desc.putObject(cTID('T   '), cTID('Lefx'), effects);
+    executeAction(cTID('setd'), desc, DialogModes.NO);
+
+    return {
+      applied: true,
+      style: '${style}',
+      layer_name: doc.activeLayer.name
+    };
+  `;
+  },
+
+  /**
+   * Color Lookup (3D LUT) adjustment layer — cinematic grades via built-in or file-based LUTs.
+   */
+  applyLut: (lut: string) => {
+    const escaped = jsString(lut);
+    return `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    app.displayDialogs = DialogModes.NO;
+
+    var lutFile = new File("${escaped}");
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putClass(sTID('adjustmentLayer'));
+    desc.putReference(sTID('null'), ref);
+    var using = new ActionDescriptor();
+    var lookup = new ActionDescriptor();
+    lookup.putEnumerated(sTID('lookupType'), sTID('colorLookupType'), sTID('3DLUT'));
+    if (lutFile.exists) {
+      lookup.putPath(sTID('LUT3DFileName'), lutFile);
+    } else {
+      // Built-in LUT name (e.g. 'Crisp_Warm.3dl', 'Kodak 5218 Fuji 3510.3dl')
+      lookup.putString(sTID('LUT3DFileName'), "${escaped}");
+    }
+    using.putObject(sTID('type'), sTID('colorLookup'), lookup);
+    desc.putObject(sTID('using'), sTID('adjustmentLayer'), using);
+    executeAction(sTID('make'), desc, DialogModes.NO);
+
+    return {
+      created: true,
+      layer_name: app.activeDocument.activeLayer.name,
+      lut: "${escaped}",
+      lut_source: lutFile.exists ? 'file' : 'builtin'
+    };
+  `;
+  },
+
+  /**
+   * Vibrance adjustment layer.
+   */
+  adjustVibrance: (vibrance: number, saturation: number) => `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    app.displayDialogs = DialogModes.NO;
+
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putClass(sTID('adjustmentLayer'));
+    desc.putReference(sTID('null'), ref);
+    var using = new ActionDescriptor();
+    var vib = new ActionDescriptor();
+    vib.putInteger(sTID('vibrance'), ${vibrance});
+    vib.putInteger(sTID('saturation'), ${saturation});
+    using.putObject(sTID('type'), sTID('vibrance'), vib);
+    desc.putObject(sTID('using'), sTID('adjustmentLayer'), using);
+    executeAction(sTID('make'), desc, DialogModes.NO);
+
+    return {
+      created: true,
+      layer_name: app.activeDocument.activeLayer.name,
+      vibrance: ${vibrance},
+      saturation: ${saturation}
+    };
+  `,
+
+  /**
+   * Exposure adjustment layer.
+   */
+  adjustExposure: (exposure: number, offset: number, gamma: number) => `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    app.displayDialogs = DialogModes.NO;
+
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putClass(sTID('adjustmentLayer'));
+    desc.putReference(sTID('null'), ref);
+    var using = new ActionDescriptor();
+    var exp = new ActionDescriptor();
+    exp.putEnumerated(sTID('presetKind'), sTID('presetKindType'), sTID('presetKindCustom'));
+    exp.putDouble(sTID('exposure'), ${exposure});
+    exp.putDouble(sTID('offset'), ${offset});
+    exp.putDouble(sTID('gammaCorrection'), ${gamma});
+    using.putObject(sTID('type'), sTID('exposure'), exp);
+    desc.putObject(sTID('using'), sTID('adjustmentLayer'), using);
+    executeAction(sTID('make'), desc, DialogModes.NO);
+
+    return {
+      created: true,
+      layer_name: app.activeDocument.activeLayer.name,
+      exposure: ${exposure},
+      offset: ${offset},
+      gamma: ${gamma}
+    };
+  `,
+
+  /**
+   * Photo Filter adjustment layer (warming/cooling/tint with density).
+   */
+  applyPhotoFilter: (red: number, green: number, blue: number, density: number, preserveLuminosity: boolean) => `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    app.displayDialogs = DialogModes.NO;
+
+    var rgb = new ActionDescriptor();
+    rgb.putDouble(cTID('Rd  '), ${red});
+    rgb.putDouble(cTID('Grn '), ${green});
+    rgb.putDouble(cTID('Bl  '), ${blue});
+
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putClass(sTID('adjustmentLayer'));
+    desc.putReference(sTID('null'), ref);
+    var using = new ActionDescriptor();
+    var filter = new ActionDescriptor();
+    filter.putEnumerated(sTID('type'), sTID('photoFilterType'), sTID('photoFilterColor'));
+    filter.putObject(cTID('Clr '), cTID('RGBC'), rgb);
+    filter.putUnitDouble(cTID('Dns '), cTID('#Prc'), ${density});
+    filter.putBoolean(sTID('preserveLuminosity'), ${preserveLuminosity ? 'true' : 'false'});
+    using.putObject(sTID('type'), sTID('photoFilter'), filter);
+    desc.putObject(sTID('using'), sTID('adjustmentLayer'), using);
+    executeAction(sTID('make'), desc, DialogModes.NO);
+
+    return {
+      created: true,
+      layer_name: app.activeDocument.activeLayer.name,
+      color: { red: ${red}, green: ${green}, blue: ${blue} },
+      density: ${density}
+    };
+  `,
+
+  /**
+   * Gradient Map adjustment layer (black→white custom gradient by default).
+   */
+  applyGradientMap: (reverse: boolean) => `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    app.displayDialogs = DialogModes.NO;
+
+    function grayStop(location, grayValue) {
+      var stop = new ActionDescriptor();
+      var gray = new ActionDescriptor();
+      gray.putDouble(cTID('Gry '), grayValue);
+      stop.putObject(cTID('Clr '), cTID('Grsc'), gray);
+      stop.putEnumerated(cTID('Type'), cTID('Clry'), cTID('UsrS'));
+      stop.putInteger(cTID('Lctn'), location);
+      stop.putInteger(cTID('Mdpn'), 50);
+      return stop;
+    }
+    function xferStop(location) {
+      var stop = new ActionDescriptor();
+      stop.putUnitDouble(cTID('Opct'), cTID('#Prc'), 100);
+      stop.putInteger(cTID('Lctn'), location);
+      stop.putInteger(cTID('Mdpn'), 50);
+      return stop;
+    }
+
+    var grad = new ActionDescriptor();
+    grad.putString(cTID('Nm  '), 'MCP Gradient Map');
+    grad.putEnumerated(cTID('GrdF'), cTID('GrdF'), cTID('CstS'));
+    grad.putDouble(cTID('Intr'), 4096);
+    var colors = new ActionList();
+    colors.putObject(cTID('Clrt'), grayStop(${reverse ? '4096' : '0'}, 0));
+    colors.putObject(cTID('Clrt'), grayStop(${reverse ? '0' : '4096'}, 100));
+    grad.putList(cTID('Clrs'), colors);
+    var xfer = new ActionList();
+    xfer.putObject(cTID('TrnS'), xferStop(0));
+    xfer.putObject(cTID('TrnS'), xferStop(4096));
+    grad.putList(cTID('Trns'), xfer);
+
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putClass(sTID('adjustmentLayer'));
+    desc.putReference(sTID('null'), ref);
+    var using = new ActionDescriptor();
+    var gm = new ActionDescriptor();
+    gm.putObject(cTID('Grad'), cTID('Grdn'), grad);
+    using.putObject(sTID('type'), sTID('gradientMapClass'), gm);
+    desc.putObject(sTID('using'), sTID('adjustmentLayer'), using);
+    executeAction(sTID('make'), desc, DialogModes.NO);
+
+    return {
+      created: true,
+      layer_name: app.activeDocument.activeLayer.name,
+      reverse: ${reverse ? 'true' : 'false'}
+    };
+  `,
+
+  /**
+   * List data sets defined on the active document (data-driven graphics).
+   */
+  listDataSets: () => `
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    var doc = app.activeDocument;
+    var names = [];
+    try {
+      for (var i = 0; i < doc.dataSets.length; i++) {
+        names.push(doc.dataSets[i].name);
+      }
+    } catch (e) {}
+    var active = null;
+    try { active = doc.activeDataSet ? doc.activeDataSet.name : null; } catch (eActive) {}
+    return {
+      datasets: names,
+      active: active,
+      count: names.length
+    };
+  `,
+
+  /**
+   * Import variables/data sets XML (Image > Variables > Data Sets > Import).
+   */
+  importDataSets: (xmlPath: string) => {
+    const escaped = jsString(xmlPath);
+    return `
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    var xmlFile = new File("${escaped}");
+    if (!xmlFile.exists) {
+      throw new Error('variables_xml_not_found: ${escaped}');
+    }
+    var doc = app.activeDocument;
+    doc.importVariables(xmlFile);
+    var names = [];
+    try {
+      for (var i = 0; i < doc.dataSets.length; i++) {
+        names.push(doc.dataSets[i].name);
+      }
+    } catch (e) {}
+    return {
+      imported: true,
+      xml_path: "${escaped}",
+      count: names.length,
+      datasets: names
+    };
+  `;
+  },
+
+  /**
+   * Batch-export one file per data set: applies each data set then saves a copy.
+   */
+  applyDataSetsExport: (outputDir: string, format: 'JPEG' | 'PNG' | 'PSD', datasetNames: string[]) => {
+    const escapedDir = jsString(outputDir);
+    const namesJson = JSON.stringify(datasetNames);
+    return `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    var doc = app.activeDocument;
+    if (!doc.dataSets || doc.dataSets.length === 0) {
+      throw new Error('no_datasets: active document has no data sets — import a variables XML first');
+    }
+    var folder = new Folder("${escapedDir}");
+    if (!folder.exists && !folder.create()) {
+      throw new Error('output_dir_not_writable: ${escapedDir}');
+    }
+    var requested = ${namesJson};
+    var outputs = [];
+    var skipped = [];
+    for (var n = 0; n < requested.length; n++) {
+      var name = requested[n];
+      var set = null;
+      try { set = doc.dataSets.getByName(name); } catch (eFind) { set = null; }
+      if (!set) {
+        skipped.push(name);
+        continue;
+      }
+      doc.activeDataSet = set;
+      var base = "${escapedDir}/" + name.replace(/[^a-zA-Z0-9_\\-]+/g, '_');
+      if ('${format}' === 'JPEG') {
+        var jpg = new JPEGSaveOptions();
+        jpg.quality = 10;
+        doc.saveAs(new File(base + '.jpg'), jpg, true, Extension.LOWERCASE);
+        outputs.push(base + '.jpg');
+      } else if ('${format}' === 'PNG') {
+        var png = new PNGSaveOptions();
+        doc.saveAs(new File(base + '.png'), png, true, Extension.LOWERCASE);
+        outputs.push(base + '.png');
+      } else {
+        doc.saveAs(new File(base + '.psd'), new PhotoshopSaveOptions(), true, Extension.LOWERCASE);
+        outputs.push(base + '.psd');
+      }
+    }
+    return {
+      exported: outputs.length,
+      skipped: skipped,
+      output_paths: outputs,
+      output_dir: "${escapedDir}",
+      format: '${format}'
+    };
+  `;
+  },
+
+  /**
+   * Load image files into one document, convert to a smart object and apply a stack mode.
+   * Classic "remove tourists with median stack" without any generative AI.
+   */
+  imageStackMode: (files: string[], mode: string) => {
+    const filesJson = JSON.stringify(files.map((f) => jsString(f)));
+    const modeId = jsString(mode);
+    return `
+    ${helperFunctions}
+
+    var files = [${filesJson}];
+    if (files.length < 2) {
+      throw new Error('stack_needs_two_files: image stack requires at least 2 images');
+    }
+    app.displayDialogs = DialogModes.NO;
+
+    var base = null;
+    var opened = [];
+    for (var i = 0; i < files.length; i++) {
+      var f = new File(files[i]);
+      if (!f.exists) {
+        throw new Error('stack_file_not_found: ' + files[i]);
+      }
+      var d = app.open(f);
+      opened.push(d);
+      if (!base) {
+        base = d;
+      } else {
+        d.selection.selectAll();
+        d.activeLayer.copy();
+        base.paste();
+        d.close(SaveOptions.DONOTSAVECHANGES);
+      }
+    }
+    app.activeDocument = base;
+    base.activeLayer = base.layers[0];
+
+    var selDesc = new ActionDescriptor();
+    var selRef = new ActionReference();
+    selRef.putEnumerated(cTID('Lyr '), cTID('Ordn'), cTID('Trgt'));
+    selDesc.putReference(cTID('null'), selRef);
+    executeAction(sTID('selectAllLayers'), selDesc, DialogModes.NO);
+    executeAction(sTID('newPlacedLayer'), undefined, DialogModes.NO);
+
+    var setDesc = new ActionDescriptor();
+    var setRef = new ActionReference();
+    setRef.putEnumerated(cTID('Lyr '), cTID('Ordn'), cTID('Trgt'));
+    setDesc.putReference(cTID('null'), setRef);
+    var smart = new ActionDescriptor();
+    smart.putEnumerated(sTID('stackMode'), sTID('stackMode'), sTID("${modeId}"));
+    setDesc.putObject(cTID('T   '), sTID('smartObject'), smart);
+    executeAction(cTID('setd'), setDesc, DialogModes.NO);
+
+    return {
+      stacked: true,
+      file_count: files.length,
+      mode: "${modeId}",
+      layer_name: base.activeLayer.name
+    };
+  `;
+  },
+
+  /**
+   * Export a copy of the active document as PNG/JPEG (Save for Web) or WebP/AVIF (native, PS 23.2+).
+   */
+  exportAs: (filePath: string, format: 'PNG' | 'JPEG' | 'WEBP' | 'AVIF', quality: number) => {
+    const escaped = jsString(filePath);
+    const q = Math.max(0, Math.min(100, Math.round(quality)));
+    return `
+    ${helperFunctions}
+
+    if (app.documents.length === 0) {
+      throw new Error('No active document');
+    }
+    var doc = app.activeDocument;
+    app.displayDialogs = DialogModes.NO;
+    var outFile = new File("${escaped}");
+
+    if ('${format}' === 'PNG' || '${format}' === 'JPEG') {
+      var opts = new ExportOptionsSaveForWeb();
+      if ('${format}' === 'PNG') {
+        opts.format = SaveDocumentType.PNG;
+        opts.PNG8 = false;
+      } else {
+        opts.format = SaveDocumentType.JPEG;
+        opts.quality = ${q};
+      }
+      doc.exportDocument(outFile, ExportType.SAVEFORWEB, opts);
+      return {
+        exported: true,
+        path: "${escaped}",
+        format: '${format}',
+        method: 'save_for_web'
+      };
+    }
+
+    // WebP / AVIF: native Save a Copy (PS 23.2+); options classes may not exist
+    // on older DOMs, so cascade candidates and report cleanly when unsupported.
+    var saveCandidates = ${format === 'WEBP' ? `['WebPSaveOptions']` : `['AVIFSaveOptions', 'AvifSaveOptions']`};
+    var saved = false;
+    var lastError = '';
+    for (var c = 0; c < saveCandidates.length; c++) {
+      try {
+        var ctor = saveCandidates[c];
+        var opts2 = eval('new ' + ctor + '()');
+        try { opts2.quality = ${q}; } catch (eQ) {}
+        doc.saveAs(outFile, opts2, true, Extension.LOWERCASE);
+        saved = true;
+        break;
+      } catch (eSave) {
+        lastError = eSave.message || String(eSave);
+      }
+    }
+    if (!saved) {
+      return {
+        ok: false,
+        code: 'version_unsupported',
+        message: '${format} export not available in this Photoshop build: ' + lastError,
+        suggested_next_tool: 'photoshop_save_document'
+      };
+    }
+    return {
+      exported: true,
+      path: "${escaped}",
+      format: '${format}',
+      method: 'native_save_as'
+    };
+  `;
+  },
 };
 
 /**

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -32,6 +32,11 @@ import { createStateTools } from '../tools/state-tools.js';
 import { createRecipeTools } from '../tools/recipes/index.js';
 import { createGenerativeTools } from '../tools/generative-tools.js';
 import { createNeuralTools } from '../tools/neural-tools.js';
+import { createStyleTools } from '../tools/style-tools.js';
+import { createColorAdjustmentTools } from '../tools/color-adjustment-tools.js';
+import { createDataTools } from '../tools/data-tools.js';
+import { createStackTools } from '../tools/stack-tools.js';
+import { createExportTools } from '../tools/export-tools.js';
 import { ensureUxpBridgeServer } from '../platform/uxp-bridge-server.js';
 
 export interface PhotoshopMCPServerOptions {
@@ -133,6 +138,11 @@ export class PhotoshopMCPServer {
     this.registerToolDefinitions(createStateTools(connection));
     this.registerToolDefinitions(createGenerativeTools(connection));
     this.registerToolDefinitions(createNeuralTools(connection));
+    this.registerToolDefinitions(createStyleTools(connection));
+    this.registerToolDefinitions(createColorAdjustmentTools(connection));
+    this.registerToolDefinitions(createDataTools(connection));
+    this.registerToolDefinitions(createStackTools(connection));
+    this.registerToolDefinitions(createExportTools(connection));
     this.registerToolDefinitions(createRecipeTools(connection));
 
     this.logger.info(

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -22,6 +22,7 @@ import { generativeExpandTemplate } from './templates/generative-expand.js';
 import { splitCarouselTemplate } from './templates/split-carousel.js';
 import { batchWatermarkTemplate } from './templates/batch-watermark.js';
 import { passportPhotoTemplate } from './templates/passport-photo.js';
+import { csvToCardsTemplate } from './templates/csv-to-cards.js';
 
 export const PHOTOSHOP_GUIDE_PROMPT_NAMES = [
   'ps.gradient_blend',
@@ -56,6 +57,7 @@ export const PHOTOSHOP_PROMPT_TEMPLATES = [
   splitCarouselTemplate,
   batchWatermarkTemplate,
   passportPhotoTemplate,
+  csvToCardsTemplate,
 ] as const;
 
 export function registerPhotoshopPrompts(registry: PromptRegistry): void {

--- a/src/prompts/templates/csv-to-cards.ts
+++ b/src/prompts/templates/csv-to-cards.ts
@@ -1,0 +1,48 @@
+import { argEnum, userPrompt, type PhotoshopPromptTemplate } from '../_shared.js';
+
+const FORMATS = ['JPEG', 'PNG'] as const;
+
+export const csvToCardsTemplate: PhotoshopPromptTemplate = {
+  name: 'ps.csv_to_cards',
+  description:
+    'Generate one image per CSV row from the active template PSD (data-driven graphics / "mail merge for images"): name cards, badges, certificates, personalized banners. Users often say: csv to images, batch cards, sertifika bas.',
+  arguments: [
+    {
+      name: 'csv_path',
+      description: 'Absolute path to the CSV file (first row = variable names matching the template variables).',
+      required: true,
+    },
+    {
+      name: 'output_dir',
+      description: 'Directory where generated files are written.',
+      required: true,
+    },
+    {
+      name: 'format',
+      description: 'JPEG or PNG. Default JPEG.',
+      required: false,
+    },
+  ],
+  handler: (args) => {
+    const csvPath = typeof args.csv_path === 'string' ? args.csv_path : '';
+    const outputDir = typeof args.output_dir === 'string' ? args.output_dir : '';
+    const format = argEnum(args, 'format', FORMATS, 'JPEG');
+
+    const toolArgs = { csv_path: csvPath, output_dir: outputDir, format };
+
+    const text = [
+      `Goal: Generate one ${format} per CSV row from the active template document (data-driven graphics).`,
+      ``,
+      `Plan:`,
+      `1. Call \`photoshop_get_state\` to confirm an active document (the template PSD).`,
+      `2. Call \`photoshop_recipe_csv_to_cards\` with ${JSON.stringify(toolArgs)}.`,
+      `   - The recipe converts the CSV into a Photoshop variables/data-sets XML, imports it, applies each row and saves a copy per row.`,
+      `3. If the recipe reports no data sets, remind the user that the template needs variable-bound layers first (Photoshop menu: Image > Variables > Define) whose names match the CSV header.`,
+      `4. Present the generated file paths.`,
+      ``,
+      `End state: template document is unchanged; one ${format} per CSV row exists under the output directory.`,
+    ].join('\n');
+
+    return userPrompt(`Generate ${format} cards from ${csvPath}.`, text);
+  },
+};

--- a/src/tools/color-adjustment-tools.ts
+++ b/src/tools/color-adjustment-tools.ts
@@ -1,0 +1,205 @@
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { ExtendScriptSnippets } from '../api/extendscript.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  return Math.max(min, Math.min(max, n));
+}
+
+export function createColorAdjustmentTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_apply_lut',
+        description:
+          'Apply a Color Lookup (3D LUT) adjustment layer for cinematic color grading. Accepts a built-in LUT name (e.g. "Crisp_Warm.3dl", "Kodak 5218 Fuji 3510.3dl", "Moonlight.3dl") or an absolute path to a .cube/.3dl/.look file.\n\n' +
+          'Users often say: cinematic grade, film look, teal and orange, apply LUT, sinematik renk.\n\n' +
+          'Use when: stylistic non-destructive color grade in one step.\n' +
+          'Do NOT use when: basic tonal fixes — use photoshop_adjust_curves or photoshop_auto_levels.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, lut, lut_source } }.\n' +
+          'Preconditions: active document. Side effects: adds a Color Lookup adjustment layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            lut: {
+              type: 'string',
+              description:
+                'Built-in LUT file name (e.g. "Crisp_Warm.3dl") or absolute path to a .cube/.3dl/.look file',
+            },
+          },
+          required: ['lut'],
+        },
+      },
+      handler: async (args) => applyLut(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_adjust_vibrance',
+        description:
+          'Create a Vibrance adjustment layer. Vibrance boosts muted colors while protecting skin tones.\n\n' +
+          'Users often say: make colors pop (safely), boost saturation without clown look.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, vibrance, saturation } }.\n' +
+          'Preconditions: active document. Side effects: adds a Vibrance adjustment layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            vibrance: { type: 'number', description: 'Vibrance (-100 to 100)', minimum: -100, maximum: 100, default: 40 },
+            saturation: { type: 'number', description: 'Saturation (-100 to 100)', minimum: -100, maximum: 100, default: 0 },
+          },
+        },
+      },
+      handler: async (args) => adjustVibrance(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_adjust_exposure',
+        description:
+          'Create an Exposure adjustment layer (stops, offset, gamma correction).\n\n' +
+          'Users often say: fix underexposed photo, brighten by a stop, gamma fix.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, exposure, offset, gamma } }.\n' +
+          'Preconditions: active document. Side effects: adds an Exposure adjustment layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            exposure: { type: 'number', description: 'Exposure in stops (-20 to 20)', minimum: -20, maximum: 20, default: 0.5 },
+            offset: { type: 'number', description: 'Offset (-0.5 to 0.5)', minimum: -0.5, maximum: 0.5, default: 0 },
+            gamma: { type: 'number', description: 'Gamma correction (0.01 to 9.99)', minimum: 0.01, maximum: 9.99, default: 1 },
+          },
+        },
+      },
+      handler: async (args) => adjustExposure(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_apply_photo_filter',
+        description:
+          'Create a Photo Filter adjustment layer (warming/cooling/custom tint with density control).\n\n' +
+          'Users often say: warm it up, cool it down, add a tint, golden hour look.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, color, density } }.\n' +
+          'Preconditions: active document. Side effects: adds a Photo Filter adjustment layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            red: { type: 'number', description: 'Filter color red (0-255); warming ≈ 236', minimum: 0, maximum: 255, default: 236 },
+            green: { type: 'number', description: 'Filter color green (0-255); warming ≈ 138', minimum: 0, maximum: 255, default: 138 },
+            blue: { type: 'number', description: 'Filter color blue (0-255); warming ≈ 0', minimum: 0, maximum: 255, default: 0 },
+            density: { type: 'number', description: 'Filter density percent (0-100)', minimum: 0, maximum: 100, default: 25 },
+            preserve_luminosity: { type: 'boolean', description: 'Preserve luminosity (default true)', default: true },
+          },
+        },
+      },
+      handler: async (args) => applyPhotoFilter(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_apply_gradient_map',
+        description:
+          'Create a Gradient Map adjustment layer (black→white by default) for duotone/B&W tonal remapping.\n\n' +
+          'Users often say: duotone look, gradient map B&W, remap tones.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, reverse } }.\n' +
+          'Preconditions: active document. Side effects: adds a Gradient Map adjustment layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            reverse: { type: 'boolean', description: 'Reverse the gradient (white→black)', default: false },
+          },
+        },
+      },
+      handler: async (args) => applyGradientMap(connection, args),
+    },
+  ];
+}
+
+async function runAdjustmentSnippet(
+  connection: PhotoshopConnection,
+  script: string,
+  summary: string
+): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, script);
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable adjustment result: ${String(raw)}`));
+    }
+    return atomicSuccess(summary, parsed);
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function applyLut(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const lut = typeof args.lut === 'string' ? args.lut.trim() : '';
+  if (!lut) {
+    return atomicFailureFromError(new Error('lut parameter is required'));
+  }
+  return runAdjustmentSnippet(
+    connection,
+    ExtendScriptSnippets.applyLut(lut),
+    `Color Lookup adjustment layer created (${lut})`
+  );
+}
+
+async function adjustVibrance(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const vibrance = clampNumber(args.vibrance, -100, 100, 40);
+  const saturation = clampNumber(args.saturation, -100, 100, 0);
+  return runAdjustmentSnippet(
+    connection,
+    ExtendScriptSnippets.adjustVibrance(vibrance, saturation),
+    `Vibrance adjustment layer created (vibrance ${vibrance}, saturation ${saturation})`
+  );
+}
+
+async function adjustExposure(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const exposure = clampNumber(args.exposure, -20, 20, 0.5);
+  const offset = clampNumber(args.offset, -0.5, 0.5, 0);
+  const gamma = clampNumber(args.gamma, 0.01, 9.99, 1);
+  return runAdjustmentSnippet(
+    connection,
+    ExtendScriptSnippets.adjustExposure(exposure, offset, gamma),
+    `Exposure adjustment layer created (${exposure} stops)`
+  );
+}
+
+async function applyPhotoFilter(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const red = clampNumber(args.red, 0, 255, 236);
+  const green = clampNumber(args.green, 0, 255, 138);
+  const blue = clampNumber(args.blue, 0, 255, 0);
+  const density = clampNumber(args.density, 0, 100, 25);
+  const preserve = args.preserve_luminosity !== false;
+  return runAdjustmentSnippet(
+    connection,
+    ExtendScriptSnippets.applyPhotoFilter(red, green, blue, density, preserve),
+    `Photo Filter adjustment layer created (density ${density}%)`
+  );
+}
+
+async function applyGradientMap(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const reverse = args.reverse === true;
+  return runAdjustmentSnippet(
+    connection,
+    ExtendScriptSnippets.applyGradientMap(reverse),
+    `Gradient Map adjustment layer created${reverse ? ' (reversed)' : ''}`
+  );
+}

--- a/src/tools/data-tools.ts
+++ b/src/tools/data-tools.ts
@@ -1,0 +1,154 @@
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { ExtendScriptSnippets } from '../api/extendscript.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+const EXPORT_FORMATS = ['JPEG', 'PNG', 'PSD'] as const;
+type DatasetExportFormat = (typeof EXPORT_FORMATS)[number];
+
+export function createDataTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_list_datasets',
+        description:
+          'List the data sets defined on the active document (Image > Variables > Data Sets).\n\n' +
+          'Use when: before applying data sets or debugging a data-driven template.\n\n' +
+          'Returns: JSON { ok, summary, details: { datasets, active, count } }.\n' +
+          'Preconditions: active document with variables/data sets defined.',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      handler: async () => listDataSets(connection),
+    },
+    {
+      tool: {
+        name: 'photoshop_import_datasets',
+        description:
+          'Import a Photoshop variables/data-sets XML file into the active document (the same file Image > Variables > Data Sets > Import accepts).\n\n' +
+          'Users often say: load data sets, import variables XML, data-driven graphics.\n\n' +
+          'Use when: the template PSD already has variable-bound layers and you want to load rows from an XML file.\n' +
+          'Do NOT use when: generating a batch from a CSV directly — use photoshop_recipe_csv_to_cards.\n\n' +
+          'Returns: JSON { ok, summary, details: { count, datasets } }.\n' +
+          'Preconditions: active document with variables defined (Image > Variables > Define).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            xml_path: { type: 'string', description: 'Absolute path to the variables/data-sets XML file' },
+          },
+          required: ['xml_path'],
+        },
+      },
+      handler: async (args) => importDataSets(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_generate_from_datasets',
+        description:
+          'Batch-export the active document once per data set: applies each data set, saves a copy, moves on. "Mail merge for images".\n\n' +
+          'Users often say: generate all variants, batch personalize, render every row.\n\n' +
+          'Use when: data sets are already imported (photoshop_import_datasets) and you want one file per row.\n\n' +
+          'Returns: JSON { ok, summary, details: { exported, skipped, output_paths } }.\n' +
+          'Preconditions: active document with data sets. Side effects: writes files to output_dir.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            output_dir: { type: 'string', description: 'Directory for generated files (created if missing)' },
+            format: { type: 'string', enum: EXPORT_FORMATS, description: 'Output format', default: 'JPEG' },
+            dataset_names: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Subset of data set names to export (default: all)',
+            },
+          },
+          required: ['output_dir'],
+        },
+      },
+      handler: async (args) => generateFromDataSets(connection, args),
+    },
+  ];
+}
+
+async function listDataSets(connection: PhotoshopConnection): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.listDataSets());
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable datasets result: ${String(raw)}`));
+    }
+    const count = typeof parsed.count === 'number' ? parsed.count : 0;
+    return atomicSuccess(`${count} data set(s) on active document`, parsed, 'photoshop_generate_from_datasets');
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function importDataSets(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const xmlPath = typeof args.xml_path === 'string' ? args.xml_path.trim() : '';
+  if (!xmlPath) {
+    return atomicFailureFromError(new Error('xml_path parameter is required'));
+  }
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.importDataSets(xmlPath));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable import result: ${String(raw)}`));
+    }
+    const count = typeof parsed.count === 'number' ? parsed.count : 0;
+    return atomicSuccess(`Imported ${count} data set(s)`, parsed, 'photoshop_generate_from_datasets');
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function generateFromDataSets(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const outputDir = typeof args.output_dir === 'string' ? args.output_dir.trim() : '';
+  if (!outputDir) {
+    return atomicFailureFromError(new Error('output_dir parameter is required'));
+  }
+  const format: DatasetExportFormat = EXPORT_FORMATS.includes(args.format as DatasetExportFormat)
+    ? (args.format as DatasetExportFormat)
+    : 'JPEG';
+
+  let names: string[] = [];
+  if (Array.isArray(args.dataset_names)) {
+    names = args.dataset_names.filter((n): n is string => typeof n === 'string');
+  } else {
+    const listed = await runSnippet(connection, ExtendScriptSnippets.listDataSets());
+    const parsed = parseSnippetResult(listed);
+    if (parsed && Array.isArray(parsed.datasets)) {
+      names = parsed.datasets.filter((n): n is string => typeof n === 'string');
+    }
+  }
+  if (names.length === 0) {
+    return atomicFailureFromError(new Error('No data sets to export — import a variables XML first'));
+  }
+
+  try {
+    const raw = await runSnippet(
+      connection,
+      ExtendScriptSnippets.applyDataSetsExport(outputDir, format, names)
+    );
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable dataset export result: ${String(raw)}`));
+    }
+    if (parsed.ok === false) {
+      return atomicFailureFromError(new Error(String(parsed.message || 'Data set export failed')));
+    }
+    const exported = typeof parsed.exported === 'number' ? parsed.exported : 0;
+    return atomicSuccess(`Exported ${exported} file(s) from data sets`, parsed);
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}

--- a/src/tools/export-tools.ts
+++ b/src/tools/export-tools.ts
@@ -1,0 +1,80 @@
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { ExtendScriptSnippets } from '../api/extendscript.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+const EXPORT_FORMATS = ['PNG', 'JPEG', 'WEBP', 'AVIF'] as const;
+type ExportFormat = (typeof EXPORT_FORMATS)[number];
+
+export function createExportTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_export_as',
+        description:
+          'Export a copy of the active document as PNG, JPEG, WebP or AVIF without changing the open document. WebP/AVIF require Photoshop 23.2+/recent builds and return a clear error when unsupported.\n\n' +
+          'Users often say: export for web, save as webp, quick export png.\n\n' +
+          'Use when: web-ready delivery formats are needed (WebP/AVIF/modern pipelines).\n' +
+          'Do NOT use when: saving the working document itself — use photoshop_save_document.\n\n' +
+          'Returns: JSON { ok, summary, details: { path, format, method } }.\n' +
+          'Preconditions: active document. Side effects: writes one file to path.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: { type: 'string', description: 'Absolute output file path (extension should match format)' },
+            format: { type: 'string', enum: EXPORT_FORMATS, description: 'Export format', default: 'PNG' },
+            quality: { type: 'number', description: 'Quality 0-100 (JPEG/WebP/AVIF)', minimum: 0, maximum: 100, default: 80 },
+          },
+          required: ['path'],
+        },
+      },
+      handler: async (args) => exportAs(connection, args),
+    },
+  ];
+}
+
+async function exportAs(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const filePath = typeof args.path === 'string' ? args.path.trim() : '';
+  if (!filePath) {
+    return atomicFailureFromError(new Error('path parameter is required'));
+  }
+  const format: ExportFormat = EXPORT_FORMATS.includes(args.format as ExportFormat)
+    ? (args.format as ExportFormat)
+    : 'PNG';
+  const quality =
+    typeof args.quality === 'number' && Number.isFinite(args.quality)
+      ? Math.max(0, Math.min(100, Math.round(args.quality)))
+      : 80;
+
+  try {
+    const raw = await runSnippet(
+      connection,
+      ExtendScriptSnippets.exportAs(filePath, format, quality)
+    );
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable export result: ${String(raw)}`));
+    }
+    if (parsed.ok === false) {
+      return atomicFailureFromError(new Error(String(parsed.message || 'Export failed')), {
+        code: 'version_unsupported',
+        suggested_next_tool: 'photoshop_save_document',
+      });
+    }
+    return atomicSuccess(`Exported ${format} to ${filePath}`, {
+      path: filePath,
+      format,
+      method: parsed.method,
+    });
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}

--- a/src/tools/recipes/csv-to-cards.ts
+++ b/src/tools/recipes/csv-to-cards.ts
@@ -1,0 +1,271 @@
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ToolDefinition, ToolResult } from '../../core/tool-registry.js';
+import { PhotoshopConnection } from '../../platform/connection.js';
+import { executeStandaloneRecipe, jsString } from './_shared.js';
+import { readFileSync } from 'node:fs';
+
+const TOOL_NAME = 'photoshop_recipe_csv_to_cards';
+
+const OUTPUT_FORMATS = ['JPEG', 'PNG'] as const;
+
+export function bindCsvToCards(connection: PhotoshopConnection): ToolDefinition {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      description:
+        'Data-driven graphics batch: convert a CSV file into Photoshop data sets, apply each row to the active template document and export one image per row. "Mail merge for images" — name cards, badges, certificates, personalized banners.\n' +
+        '\n' +
+        'Users often say: csv to images, batch name cards, personalized banners, generate badges from spreadsheet, sertifika bastır.\n' +
+        '\n' +
+        'CSV rules: first row = variable names matching the variables defined in the template PSD (Image > Variables > Define). ' +
+        'A cell holding an absolute path to an image file (.png/.jpg/.webp/.tif/.psd) is treated as a pixel-replacement variable.\n' +
+        '\n' +
+        'Use when: the user has a template PSD with variable-bound layers and a CSV of rows.\n' +
+        'Do NOT use when: the document has no variables defined — define them in Photoshop first (Image > Variables > Define).\n' +
+        '\n' +
+        'Returns: { ok, summary, details: { rows, exported, output_paths, xml_path } }.\n' +
+        '\n' +
+        'Preconditions: active document with variable-bound layers; readable CSV file.\n' +
+        'Side effects: writes a temp variables XML and one output file per row into output_dir.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          csv_path: {
+            type: 'string',
+            description: 'Absolute path to the CSV file (first row = variable names)',
+          },
+          output_dir: {
+            type: 'string',
+            description: 'Directory for generated files (created if missing)',
+          },
+          format: {
+            type: 'string',
+            enum: OUTPUT_FORMATS,
+            description: 'Output format (default JPEG)',
+            default: 'JPEG',
+          },
+        },
+        required: ['csv_path', 'output_dir'],
+      },
+    },
+    handler: async (args) => runCsvToCards(connection, args),
+  };
+}
+
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      row.push(field);
+      field = '';
+    } else if (ch === '\n' || ch === '\r') {
+      if (ch === '\r' && text[i + 1] === '\n') i++;
+      row.push(field);
+      field = '';
+      if (row.length > 1 || row[0] !== '') rows.push(row);
+      row = [];
+    } else {
+      field += ch;
+    }
+  }
+  row.push(field);
+  if (row.length > 1 || row[0] !== '') rows.push(row);
+  return rows;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const IMAGE_CELL = /\.(png|jpe?g|webp|tiff?|psd|gif)$/i;
+
+function buildVariablesXml(columns: string[], dataRows: string[][]): string {
+  const lines: string[] = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE variables PUBLIC "-//Adobe//DTD Variables 1.0//EN" "variables.dtd">',
+    '<variables xmlns:v="http://ns.adobe.com/Variables/1.0/">',
+  ];
+  for (const col of columns) {
+    lines.push(
+      `  <variable var="${xmlEscape(col)}" kind="text" visibility="visible" trait="textcontent" category=""></variable>`
+    );
+  }
+  lines.push('  <dataSetSet>');
+  dataRows.forEach((cells, idx) => {
+    lines.push(`    <dataSet v:name="row_${idx + 1}">`);
+    columns.forEach((col, c) => {
+      const value = cells[c] ?? '';
+      if (IMAGE_CELL.test(value.trim())) {
+        lines.push(
+          `      <variable var="${xmlEscape(col)}" kind="pixel" trait="fileref" category="image"><value>${xmlEscape(value.trim())}</value></variable>`
+        );
+      } else {
+        lines.push(
+          `      <variable var="${xmlEscape(col)}"><value>${xmlEscape(value)}</value></variable>`
+        );
+      }
+    });
+    lines.push('    </dataSet>');
+  });
+  lines.push('  </dataSetSet>', '</variables>');
+  return lines.join('\n');
+}
+
+async function runCsvToCards(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const csvPath = typeof args.csv_path === 'string' ? args.csv_path.trim() : '';
+  const outputDir = typeof args.output_dir === 'string' ? args.output_dir.trim() : '';
+  const format = OUTPUT_FORMATS.includes(args.format as (typeof OUTPUT_FORMATS)[number])
+    ? (args.format as (typeof OUTPUT_FORMATS)[number])
+    : 'JPEG';
+
+  if (!csvPath || !outputDir) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: false,
+            code: 'invalid_args',
+            message: 'csv_path and output_dir are required',
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  let csvText: string;
+  try {
+    csvText = readFileSync(csvPath, 'utf8');
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: false,
+            code: 'file_not_found',
+            message: `Cannot read CSV: ${error instanceof Error ? error.message : String(error)}`,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const rows = parseCsv(csvText);
+  if (rows.length < 2) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: false,
+            code: 'empty_csv',
+            message: 'CSV needs a header row plus at least one data row',
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const columns = rows[0].map((c) => c.trim()).filter(Boolean);
+  const dataRows = rows.slice(1);
+  const xml = buildVariablesXml(columns, dataRows);
+  const xmlPath = join(tmpdir(), `photoshop-mcp-datasets-${Date.now()}.xml`);
+  writeFileSync(xmlPath, xml, 'utf8');
+
+  const ext = format === 'PNG' ? 'png' : 'jpg';
+  const body = `
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_active_document', message: 'Open the template PSD first', suggested_next_tool: 'photoshop_open_image' };
+    }
+    var doc = app.activeDocument;
+    var xmlFile = new File("${jsString(xmlPath)}");
+    if (!xmlFile.exists) {
+      return { ok: false, code: 'file_not_found', message: 'variables XML missing: ${jsString(xmlPath)}' };
+    }
+    var folder = new Folder("${jsString(outputDir)}");
+    if (!folder.exists && !folder.create()) {
+      return { ok: false, code: 'output_dir_not_writable', message: 'Cannot create output_dir: ${jsString(outputDir)}' };
+    }
+
+    try {
+      doc.importVariables(xmlFile);
+    } catch (eImport) {
+      return {
+        ok: false,
+        code: 'import_failed',
+        message: 'importVariables failed (does the template have variable-bound layers?): ' + (eImport.message || eImport),
+        suggested_next_tool: 'photoshop_list_datasets'
+      };
+    }
+    if (!doc.dataSets || doc.dataSets.length === 0) {
+      return {
+        ok: false,
+        code: 'no_datasets',
+        message: 'XML imported but no data sets appeared — verify variable names match the template (Image > Variables > Define)',
+        suggested_next_tool: 'photoshop_list_datasets'
+      };
+    }
+
+    var outputs = [];
+    for (var i = 0; i < doc.dataSets.length; i++) {
+      var set = doc.dataSets[i];
+      doc.activeDataSet = set;
+      var base = "${jsString(outputDir)}/" + set.name.replace(/[^a-zA-Z0-9_\\-]+/g, '_');
+      if ('${format}' === 'PNG') {
+        doc.saveAs(new File(base + '.${ext}'), new PNGSaveOptions(), true, Extension.LOWERCASE);
+      } else {
+        var jpg = new JPEGSaveOptions();
+        jpg.quality = 10;
+        doc.saveAs(new File(base + '.${ext}'), jpg, true, Extension.LOWERCASE);
+      }
+      outputs.push(base + '.${ext}');
+    }
+
+    return {
+      ok: true,
+      summary: 'Generated ' + outputs.length + ' card(s) from CSV rows',
+      undo_history_states_consumed: 0,
+      next_suggested_tool: 'photoshop_get_preview',
+      details: {
+        rows: ${dataRows.length},
+        exported: outputs.length,
+        output_paths: outputs,
+        output_dir: "${jsString(outputDir)}",
+        format: '${format}',
+        xml_path: "${jsString(xmlPath)}"
+      }
+    };
+  `;
+
+  return executeStandaloneRecipe(connection, body);
+}

--- a/src/tools/recipes/index.ts
+++ b/src/tools/recipes/index.ts
@@ -15,6 +15,7 @@ import { bindRemoveDistraction } from './remove-distraction.js';
 import { bindSplitCarousel } from './split-carousel.js';
 import { bindBatchWatermark } from './batch-watermark.js';
 import { bindPassportPhoto } from './passport-photo.js';
+import { bindCsvToCards } from './csv-to-cards.js';
 
 export function createRecipeTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
@@ -33,6 +34,7 @@ export function createRecipeTools(connection: PhotoshopConnection): ToolDefiniti
     bindSplitCarousel(connection),
     bindBatchWatermark(connection),
     bindPassportPhoto(connection),
+    bindCsvToCards(connection),
   ];
 }
 
@@ -52,4 +54,5 @@ export const PHOTOSHOP_RECIPE_TOOL_NAMES = [
   'photoshop_recipe_split_carousel',
   'photoshop_recipe_batch_watermark',
   'photoshop_recipe_passport_photo',
+  'photoshop_recipe_csv_to_cards',
 ] as const;

--- a/src/tools/stack-tools.ts
+++ b/src/tools/stack-tools.ts
@@ -1,0 +1,90 @@
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { ExtendScriptSnippets } from '../api/extendscript.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+const STACK_MODES = {
+  mean: 'stackModeMean',
+  median: 'stackModeMedian',
+  maximum: 'stackModeMaximum',
+  minimum: 'stackModeMinimum',
+  summation: 'stackModeSummation',
+  stddev: 'stackModeStandardDeviation',
+} as const;
+type StackMode = keyof typeof STACK_MODES;
+
+export function createStackTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_image_stack',
+        description:
+          'Load 2+ image files into one document, convert to a smart object and apply a stack mode (mean/median/max/min/...). Classic "remove tourists from N shots" or noise reduction — no generative AI involved.\n\n' +
+          'Users often say: remove tourists, median stack, average these photos, noise stack, turistleri sil.\n\n' +
+          'Use when: the user has multiple aligned shots of the same scene and wants a statistical blend.\n' +
+          'Do NOT use when: removing a single object from one photo — use photoshop_generative_remove or photoshop_content_aware_fill.\n\n' +
+          'Returns: JSON { ok, summary, details: { file_count, mode, layer_name } }.\n' +
+          'Preconditions: 2+ existing image files. Side effects: opens the files; the stacked result becomes the active document.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            files: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Absolute paths of the images to stack (min 2)',
+              minItems: 2,
+            },
+            mode: {
+              type: 'string',
+              enum: Object.keys(STACK_MODES),
+              description: 'Stack mode — median removes transient objects, mean reduces noise',
+              default: 'median',
+            },
+          },
+          required: ['files'],
+        },
+      },
+      handler: async (args) => imageStack(connection, args),
+    },
+  ];
+}
+
+async function imageStack(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const files = Array.isArray(args.files)
+    ? args.files.filter((f): f is string => typeof f === 'string' && f.trim().length > 0)
+    : [];
+  if (files.length < 2) {
+    return atomicFailureFromError(new Error('files must contain at least 2 image paths'));
+  }
+  const mode: StackMode =
+    typeof args.mode === 'string' && args.mode in STACK_MODES ? (args.mode as StackMode) : 'median';
+
+  try {
+    const raw = await runSnippet(
+      connection,
+      ExtendScriptSnippets.imageStackMode(files, STACK_MODES[mode])
+    );
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable image stack result: ${String(raw)}`));
+    }
+    if (parsed.ok === false) {
+      return atomicFailureFromError(new Error(String(parsed.message || 'Image stack failed')));
+    }
+    return atomicSuccess(`Image stack applied (${mode}, ${files.length} files)`, {
+      mode,
+      file_count: files.length,
+      layer_name: parsed.layer_name,
+    });
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}

--- a/src/tools/style-tools.ts
+++ b/src/tools/style-tools.ts
@@ -1,0 +1,91 @@
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import { ExtendScriptSnippets } from '../api/extendscript.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+const LAYER_STYLES = ['drop_shadow', 'outer_glow', 'stroke', 'bevel_emboss'] as const;
+type LayerStyle = (typeof LAYER_STYLES)[number];
+
+function parseStyle(value: unknown): LayerStyle {
+  if (typeof value === 'string' && LAYER_STYLES.includes(value as LayerStyle)) {
+    return value as LayerStyle;
+  }
+  return 'drop_shadow';
+}
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  return Math.max(min, Math.min(max, Math.round(n)));
+}
+
+export function createStyleTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_apply_layer_style',
+        description:
+          'Apply a layer style (drop shadow, outer glow, stroke, bevel & emboss) to the active layer via Action Manager layer effects.\n\n' +
+          'Users often say: add shadow, glow effect, outline this layer, stroke, bevel, 3D button look, katmana gölge ver.\n\n' +
+          'Use when: quick presentational effects on the active layer (cards, buttons, mockups, text pop).\n' +
+          'Do NOT use when: you need full custom layer-effects control — use photoshop_execute_script with a custom layerEffects descriptor.\n\n' +
+          'Returns: JSON { ok, summary, details: { style, layer_name } }.\n' +
+          'Preconditions: active document with an active pixel/text layer. Side effects: sets the chosen effect on the active layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            style: {
+              type: 'string',
+              enum: LAYER_STYLES,
+              description: 'Which effect to apply',
+              default: 'drop_shadow',
+            },
+            red: { type: 'number', description: 'Effect color red (0-255)', minimum: 0, maximum: 255, default: 0 },
+            green: { type: 'number', description: 'Effect color green (0-255)', minimum: 0, maximum: 255, default: 0 },
+            blue: { type: 'number', description: 'Effect color blue (0-255)', minimum: 0, maximum: 255, default: 0 },
+            opacity: { type: 'number', description: 'Effect opacity (0-100)', minimum: 0, maximum: 100, default: 60 },
+            size: { type: 'number', description: 'Blur/size in pixels (stroke width for stroke)', minimum: 0, maximum: 250, default: 10 },
+            distance: { type: 'number', description: 'Offset distance in pixels (drop shadow only)', minimum: 0, maximum: 250, default: 8 },
+            angle: { type: 'number', description: 'Light angle in degrees (drop shadow / bevel)', minimum: -360, maximum: 360, default: 120 },
+          },
+        },
+      },
+      handler: async (args) => applyLayerStyle(connection, args),
+    },
+  ];
+}
+
+async function applyLayerStyle(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const style = parseStyle(args.style);
+  const options = {
+    style,
+    red: clampNumber(args.red, 0, 255, 0),
+    green: clampNumber(args.green, 0, 255, 0),
+    blue: clampNumber(args.blue, 0, 255, 0),
+    opacity: clampNumber(args.opacity, 0, 100, 60),
+    size: clampNumber(args.size, 0, 250, 10),
+    distance: clampNumber(args.distance, 0, 250, 8),
+    angle: clampNumber(args.angle, -360, 360, 120),
+  };
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.applyLayerStyle(options));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable layer-style result: ${String(raw)}`));
+    }
+    return atomicSuccess(`Layer style ${style} applied`, {
+      style,
+      layer_name: parsed.layer_name,
+    });
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}

--- a/src/utils/js-string.ts
+++ b/src/utils/js-string.ts
@@ -6,6 +6,7 @@ export function jsString(value: string): string {
     .replace(/\r/g, '\\r')
     // Remaining C0 controls plus U+2028/U+2029: ExtendScript (ES3) treats the
     // latter as line terminators, so raw occurrences break the string literal.
+    // eslint-disable-next-line no-control-regex -- stripping control chars is the point
     .replace(/[\u0000-\u001f\u2028\u2029]/g, (ch) => {
       return '\\u' + ch.charCodeAt(0).toString(16).padStart(4, '0');
     });


### PR DESCRIPTION
## Summary

- Adds 13 atomic tools: layer styles, color grading (LUT/vibrance/exposure/photo filter/gradient map), data-driven graphics (list/import/generate datasets), image stacking, and modern export (WebP/AVIF).
- Adds `photoshop_recipe_csv_to_cards` recipe and `ps.csv_to_cards` prompt template — 16 recipes / 23 prompts / 102 tools total.
- Bumps version to 1.6.0, syncs `server.json` via new `sync:server-version` script, and updates README/docs (one-click install badges, MCP Registry link, removes competitor comparison section).

## Test plan

- [ ] `npm run build`
- [ ] `npm run verify:photoshop-prompts`
- [ ] `npm run test:mcp-local` (with Photoshop running)
- [ ] Smoke-test new tools: `photoshop_apply_layer_style`, `photoshop_apply_lut`, `photoshop_list_datasets`, `photoshop_image_stack`, `photoshop_export_as`
- [ ] Smoke-test `photoshop_recipe_csv_to_cards` with a sample CSV + template PSD
- [ ] Confirm `server.json` version/description matches `package.json` after `npm run sync:server-version`