### PR TITLE
uxp-plugin: register panel in manifest; use index.html and explicit network origins

### DIFF
--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,14 +2,15 @@
   "id": "com.photoshop-mcp.uxp-bridge",
   "name": "Photoshop MCP UXP Bridge",
   "version": "1.0.0",
-  "main": "main.js",
+  "manifestVersion": 4,
+  "main": "index.html",
   "host": {
     "app": "PS",
     "minVersion": "24.0.0"
   },
   "requiredPermissions": {
     "network": {
-      "domains": ["127.0.0.1", "localhost"]
+      "domains": ["http://127.0.0.1:38452", "http://localhost:38452"]
     },
     "localFileSystem": "request"
   },


### PR DESCRIPTION
Fixes #26\n\nAdd manifestVersion 4, set main to index.html, and update network.domains to full origins with port 38452. This registers the UXP panel and allows the UXP bridge to reach the MCP poll server.