### PR TITLE
Expand atomic tools to 118 and sync agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
 
 **Prerequisites:** Photoshop running on Windows or macOS, Node.js 18+. This is unofficial and not affiliated with Adobe.
 
+**Tool surface:** 118 MCP tools — 102 atomic `photoshop_*` + 16 recipe `photoshop_recipe_*`; 23 MCP prompt templates (`ps.*`).
+
 ## Architecture (agent view)
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.3] - 2026-08-25
+
+[v1.7.2...v1.7.3](https://github.com/alisaitteke/photoshop-mcp/compare/v1.7.2...v1.7.3)
+
+### Features
+
+- feat(analytics): revert to PostHog-only and remove Mixpanel (`6041ea9`)
+
+### Fixes
+
+- fix(ci): install deps before MCP registry sync workflow (`d1af8e1`)
+
+### Other
+
+- ci: add MCP registry-only workflow and resilient npm publish (`6cfc560`)
+
+### Version bumps
+
+- 1.7.3 (`53c25b5`)
+
 ## [1.7.2] - 2026-08-25
 
 [v1.7.1...v1.7.2](https://github.com/alisaitteke/photoshop-mcp/compare/v1.7.1...v1.7.2)
@@ -359,19 +379,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 1.1.0 (`6e1c1f0`)
 - 1.0.0 (`17d8d91`)
 
-## [1.7.3] - 2026-08-25
+## [1.7.4] - 2026-08-29
 
-[v1.7.2...HEAD](https://github.com/alisaitteke/photoshop-mcp/compare/v1.7.2...HEAD) *(pending tag v1.7.3)*
-
-### Features
-
-- feat(analytics): revert to PostHog-only and remove Mixpanel (`6041ea9`)
-
-### Fixes
-
-- fix(ci): install deps before MCP registry sync workflow (`d1af8e1`)
+[v1.7.3...HEAD](https://github.com/alisaitteke/photoshop-mcp/compare/v1.7.3...HEAD) *(pending tag v1.7.4)*
 
 ### Other
 
-- ci: add MCP registry-only workflow and resilient npm publish (`6cfc560`)
+- Expand atomic tool surface to 118 tools and sync agent documentation. (`5a9d3cd`)
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ requests into reliable Photoshop actions:
   grade, frequency separation, batch mockup, organize layers, gradient fade,
   sky blend, dodge & burn, remove distraction, split carousel, batch watermark,
   passport photo, csv to cards). Each wraps steps in a single
-  Photoshop history state (one Undo reverts all). **102 tools total** (86 atomic
+  Photoshop history state (one Undo reverts all). **118 tools total** (102 atomic
   + 16 recipe).
 - **Generative AI** — `photoshop_generative_fill`, `photoshop_generative_remove`,
   `photoshop_generative_expand`, `photoshop_generative_upscale`, `photoshop_sky_replacement`,
@@ -599,7 +599,7 @@ Never guess — read get_state after a failure and propose the next single step.
 - **Supports Photoshop 2012-2025+**
 - **ExtendScript API**: Universal compatibility via AppleScript/COM automation
 - **Auto-Detection**: Automatically finds Photoshop installation on your system
-- **102 Tools**: 86 atomic `photoshop_*` + 16 recipe `photoshop_recipe_*`
+- **118 Tools**: 102 atomic `photoshop_*` + 16 recipe `photoshop_recipe_*`
 - **AI/Prompt Layer**: 23 MCP prompt templates (16 recipe + 7 guide), server instructions, state/preview/capabilities tools
 - **Document Management**: Create, open, save, close, crop documents
 - **Layer Operations**: Create, delete, duplicate, merge, transform layers
@@ -607,7 +607,7 @@ Never guess — read get_state after a failure and propose the next single step.
 - **Layer Styles**: Drop shadow, outer glow, stroke, bevel & emboss
 - **Text Formatting**: Font, size, color, alignment controls
 - **Image Placement**: Place images, open files, fit to document
-- **Filters**: Gaussian Blur, Sharpen, Noise, Motion Blur
+- **Filters**: Gaussian Blur, Sharpen, Noise, Motion Blur, High Pass, Smart Blur
 - **Color Adjustments**: Brightness/Contrast, Hue/Saturation, Curves, Auto Levels/Contrast
 - **Color Grading**: 3D LUT (Color Lookup) layers, Vibrance, Exposure, Photo Filter, Gradient Map
 - **Data-Driven Graphics**: CSV/variables XML → one image per row ("mail merge for images")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ flowchart TB
 | ----- | -------------- | --------- |
 | **MCP core** | Tool/prompt registry, session, MCP protocol | `src/core/` |
 | **Platform** | Photoshop detection, script execution | `src/platform/` |
-| **Tools** | 86 atomic + 16 recipe MCP tools (+ generative & neural) | `src/tools/` |
+| **Tools** | 102 atomic + 16 recipe (118 total) | `src/tools/` |
 | **Prompt layer** | Server instructions, 23 MCP prompt templates | `src/prompts/` |
 | **Errors** | Structured envelopes for agent self-correction | `src/errors/envelope.ts` |
 | **Standalone UI** | Hono API, multi-provider agent, chat persistence | `src/ui/`, `web/` |
@@ -56,7 +56,7 @@ flowchart TB
 
 `PhotoshopMCPServer` wires the official MCP SDK with:
 
-- **102 tools** registered via `ToolRegistry` (atomic operations + outcome-oriented recipes + generative/neural AI).
+- **118 tools** registered via `ToolRegistry` (atomic operations + outcome-oriented recipes + generative/neural AI).
 - **23 prompts** via `PromptRegistry` (`prompts/list`, `prompts/get`).
 - **Server instructions** on `initialize` — workflow contract for host LLMs (state-before-action, prefer recipes, error recovery). See [`src/prompts/instructions.ts`](../src/prompts/instructions.ts).
 - **Structured error wrapping** — every tool handler passes through `wrapToolHandler` so failures return JSON with `code` and `suggested_next_tool` for agentic repair loops.

--- a/docs/available-tools.md
+++ b/docs/available-tools.md
@@ -1,5 +1,7 @@
 # Available Tools
 
+**118 tools total** — 102 atomic `photoshop_*` tools plus 16 recipe `photoshop_recipe_*` workflows (single undo step each).
+
 Reference for all atomic `photoshop_*` MCP tools exposed by this server (parameters, examples, and return shapes).
 
 ← Back to [README](../README.md)
@@ -49,6 +51,32 @@ Get information about the active document.
 ```javascript
 // Example: Get current document details
 photoshop_get_document_info()
+```
+
+#### `photoshop_list_documents`
+List all open documents with id, name, dimensions, resolution, and active-tab flag (read-only).
+
+**Parameters:** none
+
+```javascript
+// Example: Discover document_id values before switching tabs
+photoshop_list_documents()
+```
+
+#### `photoshop_set_active_document`
+Switch the active document tab. Provide exactly one identifier.
+
+**Parameters:**
+- `document_id` (number, optional): Unique id from `photoshop_list_documents` (preferred)
+- `index` (number, optional): Zero-based tab order (leftmost is 0)
+- `document_name` (string, optional): Document name (ambiguous if multiple tabs share the name)
+
+```javascript
+// Example: Activate by unique id
+photoshop_set_active_document({ document_id: 42 })
+
+// Example: Activate leftmost tab
+photoshop_set_active_document({ index: 0 })
 ```
 
 #### `photoshop_save_document`
@@ -406,6 +434,40 @@ photoshop_apply_motion_blur({
 })
 ```
 
+#### `photoshop_apply_high_pass`
+Apply High Pass filter to the active raster layer (edge/detail extraction).
+
+**Parameters:**
+- `radius` (number, required): Edge retention radius in pixels (0.1-250)
+
+```javascript
+// Example: Apply 5px high pass for sharpening workflow
+photoshop_apply_high_pass({ radius: 5 })
+```
+
+**Returns:** JSON `{ ok, summary, details: { filter, radius, context } }`. Fails on text, Smart Object, or Background layers — rasterize first.
+
+#### `photoshop_apply_smart_blur`
+Apply Smart Blur filter (edge-preserving blur) to the active raster layer.
+
+**Parameters:**
+- `radius` (number, required): Blur radius (0.1-100)
+- `threshold` (number, required): Blur threshold (0.1-100)
+- `mode` (string, optional): NORMAL, EDGEONLY, or OVERLAYEDGE (default: NORMAL)
+- `quality` (string, optional): LOW, MEDIUM, or HIGH (default: MEDIUM)
+
+```javascript
+// Example: Subtle edge-preserving blur
+photoshop_apply_smart_blur({
+  radius: 10,
+  threshold: 25,
+  mode: "NORMAL",
+  quality: "MEDIUM"
+})
+```
+
+**Returns:** JSON `{ ok, summary, details: { filter, radius, threshold, mode, quality, context } }`.
+
 ### Color Adjustments
 
 #### `photoshop_adjust_brightness_contrast`
@@ -557,6 +619,16 @@ photoshop_update_text_content({ text: "New Text" })
 
 ### Selections & Masks
 
+#### `photoshop_get_selection_bounds`
+Read the active pixel selection bounds in document pixels (read-only). Does not create or modify selections.
+
+**Returns:** JSON `{ ok, summary, details: { has_selection, bounds?, context } }` where `bounds` is `{ left, top, right, bottom, width, height }` in pixels when `has_selection` is true.
+
+```javascript
+// Example: Verify selection before creating a mask
+photoshop_get_selection_bounds()
+```
+
 #### `photoshop_select_rectangle`
 Create a rectangular selection.
 
@@ -571,6 +643,76 @@ photoshop_select_rectangle({
   right: 500,
   bottom: 400
 })
+```
+
+#### `photoshop_select_ellipse`
+Create an elliptical pixel selection from a bounding box (anti-aliased).
+
+**Parameters:**
+- `left`, `top`, `right`, `bottom` (number, required): Bounding box in pixels (`right` > `left`, `bottom` > `top`)
+
+**Returns:** JSON `{ ok, summary, details: { shape, bounds?, context } }`
+
+```javascript
+// Example: Oval selection for vignette
+photoshop_select_ellipse({
+  left: 50,
+  top: 50,
+  right: 200,
+  bottom: 200
+})
+```
+
+#### `photoshop_expand_selection`
+Expand the active pixel selection outward by pixels.
+
+**Parameters:**
+- `pixels` (number, required): Amount to expand (minimum 1)
+
+**Returns:** JSON `{ ok, summary, details: { pixels, bounds?, context } }`
+
+```javascript
+// Example: Grow a tight subject selection
+photoshop_expand_selection({ pixels: 5 })
+```
+
+#### `photoshop_contract_selection`
+Shrink the active pixel selection inward by pixels.
+
+**Parameters:**
+- `pixels` (number, required): Amount to contract (minimum 1)
+
+**Returns:** JSON `{ ok, summary, details: { pixels, bounds?, context } }`
+
+```javascript
+// Example: Tighten a loose selection
+photoshop_contract_selection({ pixels: 3 })
+```
+
+#### `photoshop_feather_selection`
+Feather (soften) the edges of the active pixel selection.
+
+**Parameters:**
+- `pixels` (number, required): Feather radius in pixels (minimum 1)
+
+**Returns:** JSON `{ ok, summary, details: { pixels, bounds?, context } }`
+
+```javascript
+// Example: Soften edges before fill
+photoshop_feather_selection({ pixels: 2 })
+```
+
+#### `photoshop_save_selection`
+Save the active pixel selection to a new alpha channel.
+
+**Parameters:**
+- `channel_name` (string, optional): Name for the new channel (auto-generated if omitted)
+
+**Returns:** JSON `{ ok, summary, details: { channel_name, context } }`
+
+```javascript
+// Example: Preserve selection for later
+photoshop_save_selection({ channel_name: 'MCP_Test_Sel' })
 ```
 
 #### `photoshop_select_all`
@@ -656,6 +798,31 @@ photoshop_apply_gradient_mask({
   start_pct: 0,
   end_pct: 100
 })
+```
+
+#### `photoshop_create_clipping_mask`
+Create a clipping mask on the active layer (or a named layer). The target layer must sit directly above the base layer it clips into.
+
+**Parameters:**
+- `layer_name` (string, optional): Exact layer name (recursive search). Default: active layer.
+
+```javascript
+// Example: Clip the active layer to the one below
+photoshop_create_clipping_mask()
+
+// Example: Clip a named layer
+photoshop_create_clipping_mask({ layer_name: 'Texture' })
+```
+
+#### `photoshop_release_clipping_mask`
+Release (remove) the clipping mask from the active layer (or a named layer).
+
+**Parameters:**
+- `layer_name` (string, optional): Exact layer name (recursive search). Default: active layer.
+
+```javascript
+// Example: Unclip the active layer
+photoshop_release_clipping_mask()
 ```
 
 ### History & Undo/Redo
@@ -897,6 +1064,55 @@ photoshop_generate_from_datasets({ output_dir: "/Users/me/cards", format: "PNG" 
 ```
 
 **One-shot alternative:** `photoshop_recipe_csv_to_cards` converts a CSV straight into data sets and exports every row (prompt template `ps.csv_to_cards`).
+
+### Smart Objects
+
+#### `photoshop_convert_to_smart_object`
+Convert the active or named layer to an embedded Smart Object (`newPlacedLayer`). Background layers are rejected.
+
+**Parameters:**
+- `layer_name` (string, optional): exact layer name (recursive search)
+
+```javascript
+photoshop_convert_to_smart_object({ layer_name: "Logo" })
+```
+
+#### `photoshop_replace_smart_object_contents`
+Replace embedded Smart Object pixels from a file (`placedLayerReplaceContents`). Preserves transforms and Smart Filters on the layer.
+
+**Parameters:**
+- `file_path` (string, required): absolute path to replacement image
+- `layer_name` (string, optional): Smart Object layer name
+
+```javascript
+photoshop_replace_smart_object_contents({
+  layer_name: "Screen",
+  file_path: "/Users/me/designs/hero.png"
+})
+```
+
+#### `photoshop_edit_smart_object_contents`
+Open Smart Object embedded contents for editing (`placedLayerEditContents`). **Active document becomes the embedded .psb** until you save and close it.
+
+**Parameters:**
+- `layer_name` (string, optional): Smart Object layer name
+
+**Returns:** `parent_document`, `embedded_document`, `layer_name`
+
+```javascript
+photoshop_edit_smart_object_contents({ layer_name: "Product" })
+// ... edit embedded doc, then save/close to return to parent
+```
+
+#### `photoshop_create_smart_object_via_copy`
+Create an independent Smart Object duplicate (`placedLayerMakeCopy`) — unlinked from the original embedded data.
+
+**Parameters:**
+- `layer_name` (string, optional): source Smart Object layer name
+
+```javascript
+photoshop_create_smart_object_via_copy({ layer_name: "Logo" })
+```
 
 ### Image Stacking
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,7 +77,7 @@ Local MCP integration tests run against a live Photoshop instance over stdio
 | Prompt-layer smoke | `npm run test:mcp-local` | 16 prompt templates + core recipes |
 | Prompt ↔ recipe parity | `npm run verify:photoshop-prompts` | 12↔12 strict match + 4 guides |
 
-**Tool coverage:** 102 total tools (86 atomic `photoshop_*` + 16 recipe
+**Tool coverage:** 118 total tools (102 atomic `photoshop_*` + 16 recipe
 `photoshop_recipe_*`) — re-run `npm run test:mcp-all` for a fresh pass count.
 
 **Intentional skips** (environment-dependent, not regressions):

--- a/docs/prompt-layer.md
+++ b/docs/prompt-layer.md
@@ -1,7 +1,7 @@
 # AI / Prompt Layer for Photoshop
 
-The photoshop-mcp server exposes 86 atomic `photoshop_*` tools plus 16 recipe
-`photoshop_recipe_*` tools (102 total), along with a thin
+The photoshop-mcp server exposes 102 atomic `photoshop_*` tools plus 16 recipe
+`photoshop_recipe_*` tools (118 total), along with a thin
 AI/prompt layer ported from TTT: server-level instructions, MCP prompt templates,
 recipe tools, state/preview tools, version-aware capabilities, and structured
 error envelopes.
@@ -16,10 +16,10 @@ prompt discovery, `~/.photoshop-mcp/exports` conventions, and error recovery con
 
 ## 2. MCP `prompts` primitive
 
-Twenty-two templates in [`src/prompts/templates/`](../src/prompts/templates/), registered via
+Twenty-three templates in [`src/prompts/templates/`](../src/prompts/templates/), registered via
 [`src/prompts/registry.ts`](../src/prompts/registry.ts).
 
-### Recipe prompts (15 — 1:1 with `photoshop_recipe_*`)
+### Recipe prompts (16 — 1:1 with `photoshop_recipe_*`)
 
 | Prompt | Recipe tool |
 |--------|-------------|
@@ -38,6 +38,7 @@ Twenty-two templates in [`src/prompts/templates/`](../src/prompts/templates/), r
 | `ps.split_carousel` | `photoshop_recipe_split_carousel` |
 | `ps.batch_watermark` | `photoshop_recipe_batch_watermark` |
 | `ps.passport_photo` | `photoshop_recipe_passport_photo` |
+| `ps.csv_to_cards` | `photoshop_recipe_csv_to_cards` |
 
 ### Guide prompts (7 — no recipe pair)
 
@@ -57,7 +58,7 @@ and returns a `GetPromptResult` with `description` + structured Goal/Plan/End st
 
 ## 3. Recipe tools
 
-Fifteen recipes in [`src/tools/recipes/`](../src/tools/recipes/), sharing
+Sixteen recipes in [`src/tools/recipes/`](../src/tools/recipes/), sharing
 [`src/tools/recipes/_shared.ts`](../src/tools/recipes/_shared.ts) (`executeRecipe`,
 `executeStandaloneRecipe`, `suspendHistory`, uniform `{ ok, summary, ... }` envelope).
 
@@ -78,7 +79,7 @@ when the standalone UI passes `PHOTOSHOP_EXPORT_CHAT_ID` to the MCP child).
 npm run verify:photoshop-prompts
 ```
 
-Strict **15↔15** recipe/prompt parity plus separate guide prompt registration check.
+Strict **16↔16** recipe/prompt parity plus separate guide prompt registration check.
 
 ## Backwards compatibility
 

--- a/docs/social-preview.md
+++ b/docs/social-preview.md
@@ -39,7 +39,7 @@ When LLMs call Photoshop one command at a time, they burn tokens, guess layer ty
 
 **What I built (open source)**
 
-- **Photoshop MCP** — 102 tools incl. 16 recipe workflows (single-undo outcomes)
+- **Photoshop MCP** — 118 tools incl. 16 recipe workflows (single-undo outcomes)
 - Cross-platform: macOS (AppleScript) + Windows (COM)
 - Bundled **standalone web UI** — chat with Claude, GPT, or Gemini; drive Photoshop without an IDE
 - **Action Plan (beta)** — plan all steps in one LLM call, execute without per-step round-trips

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # photoshop-mcp
 
-> MCP server for Adobe Photoshop — 1.7.2 — 102 tools (generative AI + recipes), standalone web UI, and state-aware agent workflows. Unofficial; not affiliated with Adobe.
+> MCP server for Adobe Photoshop — 1.7.3 — 118 tools (generative AI + recipes), standalone web UI, and state-aware agent workflows. Unofficial; not affiliated with Adobe.
 
 **Website:** https://alisaitteke.github.io/photoshop-mcp/
 **llms.txt (site):** https://alisaitteke.github.io/photoshop-mcp/llms.txt
@@ -48,7 +48,7 @@ claude mcp add photoshop -- npx -y @alisaitteke/photoshop-mcp
 
 ## Tool surface
 
-- **102 tools** — 86 atomic + 16 recipe (`photoshop_recipe_*`)
+- **118 tools** — 102 atomic + 16 recipe (`photoshop_recipe_*`)
 - **23 MCP prompts** — `ps.remove_background`, `ps.enhance_portrait`, `ps.generative_fill`, …
 - **Generative AI** — fill, remove, expand, upscale, sky replacement, generate image (Adobe account)
 - **State** — `photoshop_get_state`, `photoshop_get_preview`, `photoshop_get_capabilities`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alisaitteke/photoshop-mcp",
   "version": "1.7.3",
-  "description": "MCP server for Adobe Photoshop — 102 tools (generative AI + recipes), standalone web UI. Control Photoshop from Cursor, Claude, or natural language.",
+  "description": "MCP server for Adobe Photoshop — 118 tools (generative AI + recipes), standalone web UI. Control Photoshop from Cursor, Claude, or natural language.",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alisaitteke/photoshop-mcp",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "MCP server for Adobe Photoshop — 118 tools (generative AI + recipes), standalone web UI. Control Photoshop from Cursor, Claude, or natural language.",
   "main": "dist/index.js",
   "type": "module",

--- a/scripts/generate-site-discoverability.ts
+++ b/scripts/generate-site-discoverability.ts
@@ -28,7 +28,7 @@ function llmsTxt(): string {
   const v = pkg.version;
   return `# Photoshop MCP
 
-> MCP server for Adobe Photoshop — ${v} — 102 tools (generative AI + 16 recipe workflows), standalone web UI, and state-aware agent workflows. Control Photoshop from Cursor, Claude Desktop, Claude Code, or natural language. Unofficial; not affiliated with Adobe.
+> MCP server for Adobe Photoshop — ${v} — 118 tools (generative AI + 16 recipe workflows), standalone web UI, and state-aware agent workflows. Control Photoshop from Cursor, Claude Desktop, Claude Code, or natural language. Unofficial; not affiliated with Adobe.
 
 Important notes:
 
@@ -96,7 +96,7 @@ function rootLlmsTxt(): string {
   const v = pkg.version;
   return `# photoshop-mcp
 
-> MCP server for Adobe Photoshop — ${v} — 102 tools (generative AI + recipes), standalone web UI, and state-aware agent workflows. Unofficial; not affiliated with Adobe.
+> MCP server for Adobe Photoshop — ${v} — 118 tools (generative AI + recipes), standalone web UI, and state-aware agent workflows. Unofficial; not affiliated with Adobe.
 
 **Website:** ${SITE_URL}/
 **llms.txt (site):** ${SITE_URL}/llms.txt
@@ -144,7 +144,7 @@ claude mcp add photoshop -- npx -y @alisaitteke/photoshop-mcp
 
 ## Tool surface
 
-- **102 tools** — 86 atomic + 16 recipe (\`photoshop_recipe_*\`)
+- **118 tools** — 102 atomic + 16 recipe (\`photoshop_recipe_*\`)
 - **23 MCP prompts** — \`ps.remove_background\`, \`ps.enhance_portrait\`, \`ps.generative_fill\`, …
 - **Generative AI** — fill, remove, expand, upscale, sky replacement, generate image (Adobe account)
 - **State** — \`photoshop_get_state\`, \`photoshop_get_preview\`, \`photoshop_get_capabilities\`

--- a/scripts/test-all-mcp-tools.ts
+++ b/scripts/test-all-mcp-tools.ts
@@ -256,6 +256,130 @@ async function main(): Promise<void> {
   await t.run('photoshop_rotate_layer', { degrees: 2 });
   await t.run('photoshop_fit_layer_to_document', { fillDocument: false });
 
+  console.log('\n=== Phase 4b: Document session ===');
+  await t.run('photoshop_create_document', { width: 400, height: 300 });
+  {
+    const listResult = await client.callTool({ name: 'photoshop_list_documents', arguments: {} });
+    const listBody = textFrom(listResult);
+    if (listResult.isError) {
+      t.recordPrompt('assert:list_documents_after_create', 'fail', short(listBody), 0);
+      console.log(`  FAIL assert:list_documents_after_create — ${short(listBody)}`);
+    } else {
+      try {
+        const payload = parseJsonFromToolText(listBody) as {
+          ok?: boolean;
+          details?: {
+            count?: number;
+            documents?: Array<{ is_active?: boolean }>;
+          };
+        };
+        const docs = payload.details?.documents ?? [];
+        const activeCount = docs.filter((d) => d.is_active).length;
+        const ok =
+          payload.ok === true &&
+          (payload.details?.count ?? 0) >= 1 &&
+          activeCount === 1;
+        t.recordPrompt(
+          'assert:list_documents_after_create',
+          ok ? 'pass' : 'fail',
+          ok
+            ? `count=${payload.details?.count}, one is_active`
+            : JSON.stringify(payload.details),
+          0
+        );
+        console.log(
+          `  ${ok ? 'OK' : 'FAIL'}  assert:list_documents_after_create — ${ok ? `count=${payload.details?.count}` : short(JSON.stringify(payload.details))}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        t.recordPrompt('assert:list_documents_after_create', 'fail', msg, 0);
+        console.log(`  FAIL assert:list_documents_after_create — ${msg}`);
+      }
+    }
+  }
+
+  await t.run('photoshop_open_image', { filePath: testPng });
+  let switchTargetId: number | undefined;
+  {
+    const listResult = await client.callTool({ name: 'photoshop_list_documents', arguments: {} });
+    const listBody = textFrom(listResult);
+    if (listResult.isError) {
+      t.recordPrompt('assert:list_documents_multi', 'fail', short(listBody), 0);
+      console.log(`  FAIL assert:list_documents_multi — ${short(listBody)}`);
+    } else {
+      try {
+        const payload = parseJsonFromToolText(listBody) as {
+          ok?: boolean;
+          details?: {
+            count?: number;
+            documents?: Array<{ id?: number; is_active?: boolean }>;
+          };
+        };
+        const docs = payload.details?.documents ?? [];
+        const inactive = docs.find((d) => d.is_active !== true);
+        switchTargetId = inactive?.id;
+        const ok = payload.ok === true && (payload.details?.count ?? 0) >= 2;
+        t.recordPrompt(
+          'assert:list_documents_multi',
+          ok ? 'pass' : 'fail',
+          ok ? `count=${payload.details?.count}` : JSON.stringify(payload.details),
+          0
+        );
+        console.log(
+          `  ${ok ? 'OK' : 'FAIL'}  assert:list_documents_multi — ${ok ? `count=${payload.details?.count}` : short(JSON.stringify(payload.details))}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        t.recordPrompt('assert:list_documents_multi', 'fail', msg, 0);
+        console.log(`  FAIL assert:list_documents_multi — ${msg}`);
+      }
+    }
+  }
+
+  if (switchTargetId !== undefined) {
+    await t.run('photoshop_set_active_document', { document_id: switchTargetId }, { required: true });
+    {
+      const docInfoResult = await client.callTool({
+        name: 'photoshop_get_document_info',
+        arguments: {},
+      });
+      const docInfoBody = textFrom(docInfoResult);
+      if (docInfoResult.isError) {
+        t.recordPrompt('assert:set_active_by_id', 'fail', short(docInfoBody), 0);
+        console.log(`  FAIL assert:set_active_by_id — ${short(docInfoBody)}`);
+      } else {
+        try {
+          const payload = parseJsonFromToolText(docInfoBody) as {
+            document?: { width?: number; height?: number };
+          };
+          const ok = payload.document?.width === 400 && payload.document?.height === 300;
+          t.recordPrompt(
+            'assert:set_active_by_id',
+            ok ? 'pass' : 'fail',
+            ok
+              ? `active doc 400x300 (id ${switchTargetId})`
+              : JSON.stringify(payload.document),
+            0
+          );
+          console.log(
+            `  ${ok ? 'OK' : 'FAIL'}  assert:set_active_by_id — ${ok ? '400x300 document active' : short(JSON.stringify(payload.document))}`
+          );
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          t.recordPrompt('assert:set_active_by_id', 'fail', msg, 0);
+          console.log(`  FAIL assert:set_active_by_id — ${msg}`);
+        }
+      }
+    }
+  } else {
+    t.recordPrompt('assert:set_active_by_id', 'fail', 'no inactive document id captured', 0);
+    console.log('  FAIL assert:set_active_by_id — no inactive document id captured');
+  }
+
+  await t.run('photoshop_set_active_document', { index: 0 }, { required: true });
+  await t.run('photoshop_set_active_document', {}, { expectError: true });
+  await t.run('photoshop_set_active_document', { document_id: 999999999 }, { expectError: true });
+
   console.log('\n=== Phase 5: Layer ordering ===');
   await t.run('photoshop_move_layer_up');
   await t.run('photoshop_move_layer_down');
@@ -270,6 +394,202 @@ async function main(): Promise<void> {
   await t.run('photoshop_execute_script', {
     code: `app.activeDocument.activeLayer = app.activeDocument.artLayers.getByName("MCP_Paint_Renamed"); return { active: app.activeDocument.activeLayer.name };`,
   });
+
+  console.log('\n--- Phase 6a: get_selection_bounds ---');
+  await t.run('photoshop_deselect');
+  {
+    const boundsResult = await client.callTool({ name: 'photoshop_get_selection_bounds', arguments: {} });
+    const boundsBody = textFrom(boundsResult);
+    if (boundsResult.isError) {
+      t.recordPrompt('assert:get_selection_bounds_no_sel', 'fail', short(boundsBody), 0);
+      console.log(`  FAIL assert:get_selection_bounds_no_sel — ${short(boundsBody)}`);
+    } else {
+      try {
+        const payload = parseJsonFromToolText(boundsBody) as {
+          ok?: boolean;
+          details?: { has_selection?: boolean };
+        };
+        const ok = payload.ok === true && payload.details?.has_selection === false;
+        t.recordPrompt(
+          'assert:get_selection_bounds_no_sel',
+          ok ? 'pass' : 'fail',
+          ok ? 'has_selection=false' : JSON.stringify(payload.details),
+          0
+        );
+        console.log(
+          `  ${ok ? 'OK' : 'FAIL'}  assert:get_selection_bounds_no_sel — ${ok ? 'has_selection=false' : short(JSON.stringify(payload.details))}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        t.recordPrompt('assert:get_selection_bounds_no_sel', 'fail', msg, 0);
+        console.log(`  FAIL assert:get_selection_bounds_no_sel — ${msg}`);
+      }
+    }
+  }
+
+  const selLeft = 100;
+  const selTop = 100;
+  const selRight = 250;
+  const selBottom = 250;
+  await t.run('photoshop_select_rectangle', {
+    left: selLeft,
+    top: selTop,
+    right: selRight,
+    bottom: selBottom,
+  });
+  {
+    const boundsResult = await client.callTool({ name: 'photoshop_get_selection_bounds', arguments: {} });
+    const boundsBody = textFrom(boundsResult);
+    if (boundsResult.isError) {
+      t.recordPrompt('assert:get_selection_bounds_rect', 'fail', short(boundsBody), 0);
+      console.log(`  FAIL assert:get_selection_bounds_rect — ${short(boundsBody)}`);
+    } else {
+      try {
+        const payload = parseJsonFromToolText(boundsBody) as {
+          ok?: boolean;
+          details?: {
+            has_selection?: boolean;
+            bounds?: { left?: number; top?: number; right?: number; bottom?: number };
+          };
+        };
+        const b = payload.details?.bounds;
+        const ok =
+          payload.ok === true &&
+          payload.details?.has_selection === true &&
+          b?.left === selLeft &&
+          b?.top === selTop &&
+          b?.right === selRight &&
+          b?.bottom === selBottom;
+        t.recordPrompt(
+          'assert:get_selection_bounds_rect',
+          ok ? 'pass' : 'fail',
+          ok ? `bounds=[${selLeft},${selTop},${selRight},${selBottom}]` : JSON.stringify(b),
+          0
+        );
+        console.log(
+          `  ${ok ? 'OK' : 'FAIL'}  assert:get_selection_bounds_rect — ${ok ? `bounds match rectangle` : short(JSON.stringify(b))}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        t.recordPrompt('assert:get_selection_bounds_rect', 'fail', msg, 0);
+        console.log(`  FAIL assert:get_selection_bounds_rect — ${msg}`);
+      }
+    }
+  }
+  await t.run('photoshop_get_selection_bounds');
+  await t.run('photoshop_get_state', {}, { required: true });
+
+  console.log('\n--- Phase 6b: Selection modifiers ---');
+  await t.run('photoshop_select_rectangle', {
+    left: selLeft,
+    top: selTop,
+    right: selRight,
+    bottom: selBottom,
+  });
+  await t.run('photoshop_expand_selection', { pixels: 5 });
+  {
+    const boundsResult = await client.callTool({ name: 'photoshop_get_selection_bounds', arguments: {} });
+    const boundsBody = textFrom(boundsResult);
+    if (boundsResult.isError) {
+      t.recordPrompt('assert:expand_selection_bounds', 'fail', short(boundsBody), 0);
+      console.log(`  FAIL assert:expand_selection_bounds — ${short(boundsBody)}`);
+    } else {
+      try {
+        const payload = parseJsonFromToolText(boundsBody) as {
+          ok?: boolean;
+          details?: {
+            has_selection?: boolean;
+            bounds?: { left?: number; top?: number; right?: number; bottom?: number };
+          };
+        };
+        const b = payload.details?.bounds;
+        const ok =
+          payload.ok === true &&
+          payload.details?.has_selection === true &&
+          b?.left === selLeft - 5 &&
+          b?.top === selTop - 5 &&
+          b?.right === selRight + 5 &&
+          b?.bottom === selBottom + 5;
+        t.recordPrompt(
+          'assert:expand_selection_bounds',
+          ok ? 'pass' : 'fail',
+          ok ? 'expanded bounds match' : JSON.stringify(b),
+          0
+        );
+        console.log(
+          `  ${ok ? 'OK' : 'FAIL'}  assert:expand_selection_bounds — ${ok ? 'expanded bounds match' : short(JSON.stringify(b))}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        t.recordPrompt('assert:expand_selection_bounds', 'fail', msg, 0);
+        console.log(`  FAIL assert:expand_selection_bounds — ${msg}`);
+      }
+    }
+  }
+
+  await t.run('photoshop_contract_selection', { pixels: 3 });
+  await t.run('photoshop_feather_selection', { pixels: 2 });
+  await t.run('photoshop_get_selection_bounds');
+
+  const ellLeft = 50;
+  const ellTop = 50;
+  const ellRight = 200;
+  const ellBottom = 200;
+  await t.run('photoshop_select_ellipse', {
+    left: ellLeft,
+    top: ellTop,
+    right: ellRight,
+    bottom: ellBottom,
+  });
+  {
+    const boundsResult = await client.callTool({ name: 'photoshop_get_selection_bounds', arguments: {} });
+    const boundsBody = textFrom(boundsResult);
+    if (boundsResult.isError) {
+      t.recordPrompt('assert:select_ellipse_bounds', 'fail', short(boundsBody), 0);
+      console.log(`  FAIL assert:select_ellipse_bounds — ${short(boundsBody)}`);
+    } else {
+      try {
+        const payload = parseJsonFromToolText(boundsBody) as {
+          ok?: boolean;
+          details?: {
+            has_selection?: boolean;
+            bounds?: { left?: number; top?: number; right?: number; bottom?: number };
+          };
+        };
+        const b = payload.details?.bounds;
+        const ok =
+          payload.ok === true &&
+          payload.details?.has_selection === true &&
+          b?.left === ellLeft &&
+          b?.top === ellTop &&
+          b?.right === ellRight &&
+          b?.bottom === ellBottom;
+        t.recordPrompt(
+          'assert:select_ellipse_bounds',
+          ok ? 'pass' : 'fail',
+          ok ? 'ellipse bounds match' : JSON.stringify(b),
+          0
+        );
+        console.log(
+          `  ${ok ? 'OK' : 'FAIL'}  assert:select_ellipse_bounds — ${ok ? 'ellipse bounds match' : short(JSON.stringify(b))}`
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        t.recordPrompt('assert:select_ellipse_bounds', 'fail', msg, 0);
+        console.log(`  FAIL assert:select_ellipse_bounds — ${msg}`);
+      }
+    }
+  }
+
+  await t.run('photoshop_save_selection', { channel_name: 'MCP_Test_Sel' });
+  await t.run('photoshop_deselect');
+  await t.run('photoshop_expand_selection', { pixels: 5 }, { expectError: true });
+  await t.run(
+    'photoshop_select_ellipse',
+    { left: 200, top: 50, right: 50, bottom: 200 },
+    { expectError: true }
+  );
+
   await t.run('photoshop_select_rectangle', { left: 50, top: 50, right: 300, bottom: 300 });
   await t.run('photoshop_content_aware_fill');
   await t.run('photoshop_select_all');
@@ -285,6 +605,19 @@ async function main(): Promise<void> {
   await t.run('photoshop_delete_layer_mask');
   await t.run('photoshop_deselect');
 
+  console.log('\n--- Phase 6c: Clipping mask ---');
+  await t.run('photoshop_create_document', { width: 200, height: 200 });
+  await t.run('photoshop_create_layer', { name: 'MCP_Clip_Base' });
+  await t.run('photoshop_fill_layer', { red: 200, green: 200, blue: 50 });
+  await t.run('photoshop_create_layer', { name: 'MCP_Clip_Top' });
+  await t.run('photoshop_fill_layer', { red: 40, green: 120, blue: 220 });
+  await t.run('photoshop_select_layer_by_name', { name: 'MCP_Clip_Top' }, { required: true });
+  await t.run('photoshop_create_clipping_mask', { layer_name: 'MCP_Clip_Top' });
+  await t.run('photoshop_release_clipping_mask', { layer_name: 'MCP_Clip_Top' });
+  await t.run('photoshop_create_document', { width: 100, height: 100 });
+  await t.run('photoshop_create_clipping_mask', {}, { expectError: true });
+  await t.run('photoshop_set_active_document', { index: 0 }, { required: true });
+
   console.log('\n=== Phase 7: Adjustments ===');
   await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint_Renamed copy' });
   await t.run('photoshop_execute_script', {
@@ -298,6 +631,12 @@ async function main(): Promise<void> {
   await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint_Renamed copy' });
   await t.run('photoshop_desaturate');
   await t.run('photoshop_invert');
+
+  console.log('\n--- Phase 7b: Filters (high pass, smart blur) ---');
+  await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint_Renamed copy' });
+  await t.run('photoshop_apply_high_pass', { radius: 5 });
+  await t.run('photoshop_apply_smart_blur', { radius: 10, threshold: 25 });
+  await t.run('photoshop_apply_high_pass', { radius: 0 }, { expectError: true });
 
   console.log('\n=== Phase 8: Filters ===');
   await t.run('photoshop_select_layer_by_name', { name: 'MCP_Paint_Renamed copy' });
@@ -329,6 +668,64 @@ async function main(): Promise<void> {
   await t.run('photoshop_execute_script', {
     code: `for (var i=0;i<app.documents.length;i++){var d=app.documents[i]; if(d.width.as('px')===800&&d.height.as('px')===600){app.activeDocument=d;break;}} return {active:app.activeDocument.name,width:app.activeDocument.width.as('px')};`,
   }, { required: true });
+
+  console.log('\n=== Phase 10b: Smart Objects ===');
+  await t.run('photoshop_create_layer', { name: 'MCP_SO_Convert' });
+  await t.run('photoshop_fill_layer', { red: 0, green: 180, blue: 80 });
+  await t.run('photoshop_convert_to_smart_object', { layer_name: 'MCP_SO_Convert' });
+  await t.run('photoshop_execute_script', {
+    code: `var doc=app.activeDocument; var target=null; for(var i=0;i<doc.layers.length;i++){var L=doc.layers[i]; if(String(L.kind)==='LayerKind.SMARTOBJECT'){target=L;break;}} if(!target) throw new Error('No Smart Object layer found'); doc.activeLayer=target; return {active:target.name,kind:String(target.kind)};`,
+  });
+  await t.run('photoshop_replace_smart_object_contents', {
+    file_path: join(assetsDir, 'asset-b.png'),
+  });
+  await t.run('photoshop_create_smart_object_via_copy');
+  {
+    const started = Date.now();
+    const editCall = await client.callTool({
+      name: 'photoshop_edit_smart_object_contents',
+      arguments: {},
+    });
+    const editBody = textFrom(editCall);
+    const ms = Date.now() - started;
+    let hasEmbeddedDoc = false;
+    try {
+      const payload = parseJsonFromToolText(editBody) as {
+        ok?: boolean;
+        details?: { embedded_document?: unknown };
+        embedded_document?: unknown;
+      };
+      hasEmbeddedDoc =
+        payload.details?.embedded_document !== undefined ||
+        payload.embedded_document !== undefined ||
+        editBody.includes('embedded_document');
+    } catch {
+      hasEmbeddedDoc = editBody.includes('embedded_document');
+    }
+    if (editCall.isError) {
+      t.recordPrompt('photoshop_edit_smart_object_contents', 'fail', short(editBody), ms);
+      console.log(`  FAIL photoshop_edit_smart_object_contents (${ms}ms) — ${short(editBody)}`);
+    } else if (!hasEmbeddedDoc) {
+      t.recordPrompt(
+        'photoshop_edit_smart_object_contents',
+        'fail',
+        'missing embedded_document in response',
+        ms
+      );
+      console.log(`  FAIL photoshop_edit_smart_object_contents (${ms}ms) — missing embedded_document`);
+    } else {
+      t.recordPrompt('photoshop_edit_smart_object_contents', 'pass', short(editBody), ms);
+      console.log(`  OK   photoshop_edit_smart_object_contents (${ms}ms) — ${short(editBody)}`);
+    }
+  }
+  await t.run('photoshop_execute_script', {
+    code: `app.activeDocument.save(); app.activeDocument.close(SaveOptions.SAVECHANGES); return { closed: true, active: app.activeDocument.name };`,
+  });
+  await t.run('photoshop_execute_script', {
+    code: `var doc=app.activeDocument; var target=null; function findNorm(c){for(var i=0;i<c.layers.length;i++){var L=c.layers[i]; if(L.typename==='LayerSet'){var n=findNorm(L);if(n)return n;} else if(String(L.kind)==='LayerKind.NORMAL'&&!L.isBackgroundLayer){return L;}} return null;} target=findNorm(doc); if(!target) throw new Error('No normal layer'); doc.activeLayer=target; return {active:target.name,kind:String(target.kind)};`,
+  });
+  await t.run('photoshop_replace_smart_object_contents', { file_path: testPng }, { expectError: true });
+  await t.run('photoshop_replace_smart_object_contents', {}, { expectError: true });
 
   console.log('\n=== Phase 11: Image document ops ===');
   await t.run('photoshop_resize_image', { width: 640, height: 480 });
@@ -439,7 +836,7 @@ async function main(): Promise<void> {
   console.log('\n=== Phase 17: Cleanup ===');
   await t.run('photoshop_close_document', { save: false });
 
-  console.log('\n=== Phase 18: Prompt templates (15 recipes) ===');
+  console.log('\n=== Phase 18: Prompt templates (16 recipes) ===');
   const prompts = [
     ['ps.remove_background', { feather_px: '1', keep_shadow: 'false' }],
     ['ps.enhance_portrait', { intensity: 'medium', skin_smoothing: 'true' }],

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/alisaitteke/photoshop-mcp",
     "source": "github"
   },
-  "version": "1.7.3",
+  "version": "1.7.4",
   "mcpName": "io.github.alisaitteke/photoshop-mcp",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@alisaitteke/photoshop-mcp",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.alisaitteke/photoshop-mcp",
-  "description": "MCP server for Adobe Photoshop — 102 tools (generative AI + recipes), standalone web UI. Control Ph…",
+  "description": "MCP server for Adobe Photoshop — 118 tools (generative AI + recipes), standalone web UI. Control Ph…",
   "repository": {
     "url": "https://github.com/alisaitteke/photoshop-mcp",
     "source": "github"

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -14,7 +14,7 @@ const LLMS_FULL_URL = `${SITE_URL}/llms-full.txt`;
 const SITE_NAME = 'Photoshop MCP';
 const DEFAULT_TITLE = 'Photoshop MCP — Control Adobe Photoshop with AI';
 const DEFAULT_DESCRIPTION =
-  'MCP server for Cursor, Claude Desktop, and natural language. 102 tools, recipe workflows, generative AI, and standalone web UI. Windows and macOS.';
+  'MCP server for Cursor, Claude Desktop, and natural language. 118 tools, recipe workflows, generative AI, and standalone web UI. Windows and macOS.';
 const KEYWORDS =
   'photoshop mcp, cursor photoshop, claude photoshop, adobe photoshop automation, model context protocol, mcp server, ai photoshop, extendscript, generative fill';
 
@@ -63,7 +63,7 @@ const jsonLd = {
   applicationCategory: 'DeveloperApplication',
   operatingSystem: 'Windows, macOS',
   description:
-    'MCP server for Adobe Photoshop — 102 tools, generative AI, recipe workflows, and standalone web UI. Control Photoshop from Cursor, Claude, or natural language.',
+    'MCP server for Adobe Photoshop — 118 tools, generative AI, recipe workflows, and standalone web UI. Control Photoshop from Cursor, Claude, or natural language.',
   url: SITE_URL,
   downloadUrl: 'https://www.npmjs.com/package/@alisaitteke/photoshop-mcp',
   softwareVersion: pkg.version,
@@ -139,7 +139,7 @@ const docsSidebar = [
 export default defineConfig({
   title: 'Photoshop MCP',
   description:
-    'Control Adobe Photoshop with AI — MCP server for Cursor, Claude Desktop, and natural language. 102 tools, recipes, standalone web UI.',
+    'Control Adobe Photoshop with AI — MCP server for Cursor, Claude Desktop, and natural language. 118 tools, recipes, standalone web UI.',
   lang: 'en-US',
   srcDir: 'content',
   cleanUrls: true,

--- a/site/content/de/index.md
+++ b/site/content/de/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Photoshop MCP
   text: Photoshop mit KI steuern
-  tagline: MCP-Server für Cursor, Claude Desktop und natürliche Sprache — 102 Tools, Recipe-Workflows, eigenständige Web-UI.
+  tagline: MCP-Server für Cursor, Claude Desktop und natürliche Sprache — 118 Tools, Recipe-Workflows, eigenständige Web-UI.
   image:
     src: /images/readme-hero.png
     alt: Photoshop MCP — KI-gesteuerte Photoshop-Automatisierung
@@ -24,8 +24,8 @@ features:
     title: Zustandsbewusste Agenten
     details: get_state, get_preview und get_capabilities vor jeder Aktion.
   - icon: 🧩
-    title: 102 MCP-Tools
-    details: 86 atomische Tools + 16 Recipe-Workflows mit einem Undo-Schritt.
+    title: 118 MCP-Tools
+    details: 102 atomische Tools + 16 Recipe-Workflows mit einem Undo-Schritt.
   - icon: 🖥️
     title: Eigenständige Web-UI
     details: Chat mit Claude, GPT oder Gemini — ohne IDE.

--- a/site/content/es/index.md
+++ b/site/content/es/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Photoshop MCP
   text: Controla Photoshop con IA
-  tagline: Servidor MCP para Cursor, Claude Desktop y lenguaje natural — 102 herramientas, flujos recipe y UI web independiente.
+  tagline: Servidor MCP para Cursor, Claude Desktop y lenguaje natural — 118 herramientas, flujos recipe y UI web independiente.
   image:
     src: /images/readme-hero.png
     alt: Photoshop MCP — Automatización de Photoshop con IA
@@ -24,8 +24,8 @@ features:
     title: Agentes con contexto
     details: get_state, get_preview y get_capabilities antes de cada acción.
   - icon: 🧩
-    title: 102 herramientas MCP
-    details: 86 herramientas atómicas + 16 recipes con un solo paso de deshacer.
+    title: 118 herramientas MCP
+    details: 102 herramientas atómicas + 16 recipes con un solo paso de deshacer.
   - icon: 🖥️
     title: UI web independiente
     details: Chatea con Claude, GPT o Gemini sin IDE.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Photoshop MCP
   text: Control Adobe Photoshop with AI
-  tagline: MCP server for Cursor, Claude Desktop, and natural language — 102 tools, recipe workflows, standalone web UI.
+  tagline: MCP server for Cursor, Claude Desktop, and natural language — 118 tools, recipe workflows, standalone web UI.
   image:
     src: /images/readme-hero.png
     alt: Photoshop MCP — AI-driven Photoshop automation
@@ -24,8 +24,8 @@ features:
     title: State-aware agents
     details: get_state, get_preview, and get_capabilities so AI assistants know the document before they act — fewer brittle ExtendScript guesses.
   - icon: 🧩
-    title: 102 MCP tools
-    details: 86 atomic tools plus 16 recipe workflows (remove background, export for web, portrait enhance, and more) — each recipe is a single undo step.
+    title: 118 MCP tools
+    details: 102 atomic tools plus 16 recipe workflows (remove background, export for web, portrait enhance, and more) — each recipe is a single undo step.
   - icon: 🖥️
     title: Standalone web UI
     details: Chat with Claude, GPT, or Gemini and drive Photoshop without an IDE. API keys or Claude Code / Gemini CLI accounts.

--- a/site/content/ja/index.md
+++ b/site/content/ja/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Photoshop MCP
   text: AIでPhotoshopを操作
-  tagline: Cursor、Claude Desktop、自然言語向けMCPサーバー — 102ツール、レシピワークフロー、スタンドアロンWeb UI。
+  tagline: Cursor、Claude Desktop、自然言語向けMCPサーバー — 118ツール、レシピワークフロー、スタンドアロンWeb UI。
   image:
     src: /images/readme-hero.png
     alt: Photoshop MCP — AI駆動のPhotoshop自動化
@@ -24,8 +24,8 @@ features:
     title: 状態認識エージェント
     details: get_state、get_preview、get_capabilitiesで操作前にドキュメントを把握。
   - icon: 🧩
-    title: 102 MCPツール
-    details: 86の原子ツール + 16レシープ（1回のUndoで元に戻せる）。
+    title: 118 MCPツール
+    details: 102の原子ツール + 16レシープ（1回のUndoで元に戻せる）。
   - icon: 🖥️
     title: スタンドアロンUI
     details: IDE不要でClaude、GPT、Geminiとチャット。

--- a/site/content/tr/index.md
+++ b/site/content/tr/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Photoshop MCP
   text: Photoshop'u yapay zeka ile yönetin
-  tagline: Cursor, Claude Desktop ve doğal dil için MCP sunucusu — 102 araç, tarif iş akışları, bağımsız web UI.
+  tagline: Cursor, Claude Desktop ve doğal dil için MCP sunucusu — 118 araç, tarif iş akışları, bağımsız web UI.
   image:
     src: /images/readme-hero.png
     alt: Photoshop MCP — Yapay zeka destekli Photoshop otomasyonu
@@ -24,8 +24,8 @@ features:
     title: Durum farkındalığı
     details: get_state, get_preview ve get_capabilities — ajanlar hareket etmeden önce belgeyi bilir.
   - icon: 🧩
-    title: 102 MCP aracı
-    details: 86 atomik araç ve 16 tarif iş akışı; her tarif tek geri alma adımı.
+    title: 118 MCP aracı
+    details: 102 atomik araç ve 16 tarif iş akışı; her tarif tek geri alma adımı.
   - icon: 🖥️
     title: Bağımsız web UI
     details: IDE olmadan Claude, GPT veya Gemini ile sohbet edin; Photoshop'u doğal dille yönetin.

--- a/site/content/zh/index.md
+++ b/site/content/zh/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Photoshop MCP
   text: 用 AI 控制 Adobe Photoshop
-  tagline: 适用于 Cursor、Claude Desktop 和自然语言的 MCP 服务器 — 102 个工具、配方工作流、独立 Web UI。
+  tagline: 适用于 Cursor、Claude Desktop 和自然语言的 MCP 服务器 — 118 个工具、配方工作流、独立 Web UI。
   image:
     src: /images/readme-hero.png
     alt: Photoshop MCP — AI 驱动的 Photoshop 自动化
@@ -24,8 +24,8 @@ features:
     title: 状态感知
     details: get_state、get_preview 和 get_capabilities — AI 在操作前了解文档状态。
   - icon: 🧩
-    title: 102 个 MCP 工具
-    details: 86 个原子工具 + 16 个配方工作流，每个配方对应一次撤销。
+    title: 118 个 MCP 工具
+    details: 102 个原子工具 + 16 个配方工作流，每个配方对应一次撤销。
   - icon: 🖥️
     title: 独立 Web UI
     details: 无需 IDE，通过 Claude、GPT 或 Gemini 聊天驱动 Photoshop。

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -14,6 +14,81 @@ function sTID(s) { return app.stringIDToTypeID(s); }
 `;
 
 /**
+ * Selection helpers shared by getSelectionBounds and selection modifier snippets.
+ * @see https://stackoverflow.com/questions/41552883/determine-if-selection-is-present
+ * @see https://www.indesignjs.de/extendscriptAPI/photoshop-latest/Selection.html
+ */
+const selectionHelpers = `
+function __mcp_hasSelection() {
+  var ref10 = new ActionReference();
+  ref10.putProperty(sTID('property'), sTID('selection'));
+  ref10.putEnumerated(cTID('Dcmn'), cTID('Ordn'), cTID('Trgt'));
+  var docDesc = executeActionGet(ref10);
+  return docDesc.hasKey(sTID('selection'));
+}
+
+function __mcp_requireSelection() {
+  if (!__mcp_hasSelection()) {
+    return { ok: false, code: 'selection_required', message: 'Active pixel selection required' };
+  }
+  return null;
+}
+
+function __mcp_readSelectionBounds(doc) {
+  try {
+    var b = doc.selection.bounds;
+    var left = b[0].as('px');
+    var top = b[1].as('px');
+    var right = b[2].as('px');
+    var bottom = b[3].as('px');
+    return {
+      left: left,
+      top: top,
+      right: right,
+      bottom: bottom,
+      width: right - left,
+      height: bottom - top
+    };
+  } catch (eBounds) {
+    return null;
+  }
+}
+`;
+
+/**
+ * Shared guard for filter snippets that require a raster (non-background) layer.
+ */
+const filterLayerHelpers = `
+function __mcp_requireFilterableLayer(layer) {
+  if (layer.isBackgroundLayer) {
+    return {
+      ok: false,
+      code: 'background_layer',
+      message: 'Cannot apply filters to the Background layer — convert to a normal layer first (photoshop_rasterize_layer).',
+      suggested_next_tool: 'photoshop_rasterize_layer'
+    };
+  }
+  if (layer.kind === LayerKind.TEXT || layer.kind === LayerKind.SMARTOBJECT) {
+    return {
+      ok: false,
+      code: 'layer_not_raster',
+      message: 'Cannot apply filters to text or Smart Object layers — rasterize first (photoshop_rasterize_layer).',
+      suggested_next_tool: 'photoshop_rasterize_layer'
+    };
+  }
+  if (layer.kind !== LayerKind.NORMAL) {
+    return {
+      ok: false,
+      code: 'layer_not_raster',
+      message: 'Can only apply filters to normal (raster) layers. Layer kind: ' + layer.kind + '. Rasterize first (photoshop_rasterize_layer).',
+      suggested_next_tool: 'photoshop_rasterize_layer'
+    };
+  }
+  return null;
+}
+`;
+
+/**
  * Resolve a display or PostScript font name to the PostScript name required by TextItem.font.
  * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/TextItem/font.html
  * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/TextFont.html
@@ -153,6 +228,71 @@ function __mcp_c2t(s) { return cTID(s); }
  * @see https://community.adobe.com/t5/photoshop-ecosystem-discussions/is-it-possible-to-make-a-layer-mask-with-the-current-selection-using-extendscript/td-p/10872052
  * @see https://github.com/LeZuse/photoshop-scripts/blob/master/default/Stack%20Scripts%20Only/StackSupport.jsx
  */
+/**
+ * Smart Object helpers — newPlacedLayer, placedLayerReplaceContents, placedLayerEditContents,
+ * placedLayerMakeCopy (Adobe Community, Photopea, laryn gist, c.pfaffenbichler).
+ * Requires `helperFunctions` (cTID/sTID) in the enclosing script.
+ */
+export const MCP_SMART_OBJECT_HELPERS = `
+function __mcp_findLayer(container, name) {
+  for (var i = 0; i < container.layers.length; i++) {
+    var l = container.layers[i];
+    if (l.name === name) return l;
+  }
+  for (var j = 0; j < container.layerSets.length; j++) {
+    var nested = __mcp_findLayer(container.layerSets[j], name);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+function __mcp_activateLayerByName(layerName) {
+  var doc = app.activeDocument;
+  if (!layerName) {
+    if (!doc.activeLayer) {
+      return { ok: false, code: 'layer_not_found', message: 'No active layer' };
+    }
+    return { ok: true, layer: doc.activeLayer };
+  }
+  var target = __mcp_findLayer(doc, layerName);
+  if (!target) {
+    return {
+      ok: false,
+      code: 'layer_not_found',
+      message: 'Layer not found: ' + layerName,
+      suggested_next_tool: 'photoshop_get_layers'
+    };
+  }
+  doc.activeLayer = target;
+  return { ok: true, layer: target };
+}
+
+function __mcp_replaceSmartObjectContents(filePath) {
+  var layer = app.activeDocument.activeLayer;
+  if (layer.kind !== LayerKind.SMARTOBJECT) {
+    return {
+      ok: false,
+      code: 'unsupported_layer_kind',
+      message: 'Target layer "' + layer.name + '" is not a Smart Object (kind=' + layer.kind + ').',
+      suggested_next_tool: 'photoshop_get_layers'
+    };
+  }
+  var assetFile = new File(filePath);
+  if (!assetFile.exists) {
+    return { ok: false, code: 'file_not_found', message: 'Replacement file not found: ' + filePath };
+  }
+  var replaceDesc = new ActionDescriptor();
+  replaceDesc.putPath(cTID('null'), assetFile);
+  replaceDesc.putInteger(cTID('PgNm'), 1);
+  executeAction(sTID('placedLayerReplaceContents'), replaceDesc, DialogModes.NO);
+  return {
+    ok: true,
+    layerName: app.activeDocument.activeLayer.name,
+    filePath: filePath
+  };
+}
+`;
+
 export const MCP_LAYER_MASK_HELPERS = `
 function __mcp_hasLayerMaskAM() {
   var ref = new ActionReference();
@@ -248,6 +388,34 @@ function __mcp_gradientFillLayerMask(fromXPx, fromYPx, toXPx, toYPx, reverseGrad
 }
 `;
 
+/**
+ * Clipping mask helpers — groupEvent AM create; grouped DOM release.
+ * @see https://stackoverflow.com/questions/13842581/photoshop-js-script-to-create-and-apply-a-layer-mask
+ * @see https://community.adobe.com/t5/photoshop-ecosystem-discussions/clipping-mask-script-issues-in-ps-2025-on-mac/td-p/1178313
+ * @see https://www.ps-scripts.com/viewtopic.php?t=10955 (layer.grouped property)
+ */
+export const MCP_CLIPPING_MASK_HELPERS = `
+function __mcp_getLayerBelow(layer) {
+  var container = layer.parent;
+  var stack = container.layers;
+  for (var i = 0; i < stack.length; i++) {
+    if (stack[i] === layer) {
+      if (i >= stack.length - 1) return null;
+      return stack[i + 1];
+    }
+  }
+  return null;
+}
+
+function __mcp_createClippingMaskAM() {
+  var desc = new ActionDescriptor();
+  var ref = new ActionReference();
+  ref.putEnumerated(sTID('layer'), sTID('ordinal'), sTID('targetEnum'));
+  desc.putReference(sTID('null'), ref);
+  executeAction(sTID('groupEvent'), desc, DialogModes.NO);
+}
+`;
+
 export type CurvesPreset = 'auto_tone' | 'neutral';
 
 export type GradientMaskDirection =
@@ -298,6 +466,132 @@ export const ExtendScriptSnippets = {
     var context = getContextInfo();
     return context;
   `,
+
+  /**
+   * List all open documents (read-only).
+   * @see https://developer.adobe.com/photoshop/uxp/ps_reference/classes/documents/
+   */
+  listDocuments: () => `
+    ${getContextInfo}
+
+    var docs = [];
+    var activeId = null;
+    try {
+      if (app.documents.length > 0) {
+        activeId = app.activeDocument.id;
+      }
+    } catch (eActive) {
+      activeId = null;
+    }
+
+    for (var i = 0; i < app.documents.length; i++) {
+      var d = app.documents[i];
+      var entry = {
+        id: d.id,
+        name: d.name,
+        is_active: false
+      };
+      try { entry.width = d.width.as('px'); } catch (eW) {}
+      try { entry.height = d.height.as('px'); } catch (eH) {}
+      try { entry.resolution = d.resolution; } catch (eR) {}
+      try { entry.is_active = activeId !== null && d.id === activeId; } catch (eA) {}
+      docs.push(entry);
+    }
+
+    return {
+      ok: true,
+      count: docs.length,
+      documents: docs,
+      active_document_id: activeId,
+      context: getContextInfo()
+    };
+  `,
+
+  /**
+   * Activate an open document by id, tab index, or name.
+   * @see https://stackoverflow.com/questions/4537506/how-to-switch-between-open-documents-in-photoshop-using-javascript
+   */
+  setActiveDocument: (params: {
+    documentId?: number;
+    documentName?: string;
+    index?: number;
+  }) => {
+    let modeBlock = '';
+    if (params.documentId !== undefined) {
+      modeBlock = `var __mode = 'id'; var __targetId = ${params.documentId};`;
+    } else if (params.index !== undefined) {
+      modeBlock = `var __mode = 'index'; var __targetIndex = ${params.index};`;
+    } else {
+      modeBlock = `var __mode = 'name'; var __targetName = "${jsString(params.documentName!)}";`;
+    }
+
+    return `
+    ${getContextInfo}
+    ${modeBlock}
+
+    var targetDoc = null;
+
+    if (__mode === 'id') {
+      for (var i = 0; i < app.documents.length; i++) {
+        if (app.documents[i].id === __targetId) {
+          targetDoc = app.documents[i];
+          break;
+        }
+      }
+      if (!targetDoc) {
+        return {
+          ok: false,
+          code: 'document_not_found',
+          message: 'No open document with id ' + __targetId
+        };
+      }
+    } else if (__mode === 'index') {
+      if (__targetIndex < 0 || __targetIndex >= app.documents.length) {
+        return {
+          ok: false,
+          code: 'document_not_found',
+          message: 'Document index out of range: ' + __targetIndex + ' (open count: ' + app.documents.length + ')'
+        };
+      }
+      targetDoc = app.documents[__targetIndex];
+    } else {
+      var matches = [];
+      for (var j = 0; j < app.documents.length; j++) {
+        if (app.documents[j].name === __targetName) {
+          matches.push(app.documents[j]);
+        }
+      }
+      if (matches.length === 0) {
+        return {
+          ok: false,
+          code: 'document_not_found',
+          message: 'No open document named "' + __targetName + '"'
+        };
+      }
+      if (matches.length > 1) {
+        var matchIds = [];
+        for (var k = 0; k < matches.length; k++) {
+          matchIds.push(matches[k].id);
+        }
+        return {
+          ok: false,
+          code: 'ambiguous_name',
+          message: 'Multiple open documents named "' + __targetName + '". Use document_id instead.',
+          matching_document_ids: matchIds
+        };
+      }
+      targetDoc = matches[0];
+    }
+
+    app.activeDocument = targetDoc;
+
+    return {
+      ok: true,
+      activated: { id: targetDoc.id, name: targetDoc.name },
+      context: getContextInfo()
+    };
+  `;
+  },
 
   /**
    * Create a text layer
@@ -1066,6 +1360,83 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
+   * Apply High Pass filter via Action Manager.
+   * @see https://community.adobe.com/t5/photoshop-ecosystem-discussions/high-pass-filter-using-javascript/td-p/1144836
+   * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/ArtLayer/applyHighPass.html
+   */
+  applyHighPass: (radius: number) => `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${filterLayerHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var layer = app.activeDocument.activeLayer;
+    var layerErr = __mcp_requireFilterableLayer(layer);
+    if (layerErr) return layerErr;
+
+    try {
+      var desc = new ActionDescriptor();
+      desc.putUnitDouble(cTID('Rds '), cTID('#Pxl'), ${radius});
+      executeAction(sTID('highPass'), desc, DialogModes.NO);
+    } catch (eFilter) {
+      return {
+        ok: false,
+        code: 'filter_failed',
+        message: 'High Pass filter failed: ' + eFilter.message + '. If the layer is text or a Smart Object, rasterize first (photoshop_rasterize_layer).',
+        suggested_next_tool: 'photoshop_rasterize_layer'
+      };
+    }
+
+    return {
+      ok: true,
+      filter: 'High Pass',
+      radius: ${radius},
+      context: getContextInfo()
+    };
+  `,
+
+  /**
+   * Apply Smart Blur filter.
+   * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/ArtLayer/applySmartBlur.html
+   */
+  applySmartBlur: (radius: number, threshold: number, mode: string, quality: string) => `
+    ${getContextInfo}
+    ${filterLayerHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var layer = app.activeDocument.activeLayer;
+    var layerErr = __mcp_requireFilterableLayer(layer);
+    if (layerErr) return layerErr;
+
+    try {
+      layer.applySmartBlur(${radius}, ${threshold}, SmartBlurQuality.${quality}, SmartBlurMode.${mode});
+    } catch (eFilter) {
+      return {
+        ok: false,
+        code: 'filter_failed',
+        message: 'Smart Blur filter failed: ' + eFilter.message + '. If the layer is text or a Smart Object, rasterize first (photoshop_rasterize_layer).',
+        suggested_next_tool: 'photoshop_rasterize_layer'
+      };
+    }
+
+    return {
+      ok: true,
+      filter: 'Smart Blur',
+      radius: ${radius},
+      threshold: ${threshold},
+      mode: '${mode}',
+      quality: '${quality}',
+      context: getContextInfo()
+    };
+  `,
+
+  /**
    * Adjust brightness and contrast
    */
   adjustBrightnessContrast: (brightness: number, contrast: number) => `
@@ -1442,6 +1813,211 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
+   * Read active pixel selection bounds (read-only).
+   * Uses executeActionGet hasSelection (c.pfaffenbichler) then bounds[].as('px').
+   * @see https://stackoverflow.com/questions/41552883/determine-if-selection-is-present
+   * @see https://community.adobe.com/t5/photoshop-ecosystem-discussions/can-the-presence-of-a-selection-be-set-to-a-boolean/td-p/1144178
+   * @see https://community.adobe.com/t5/photoshop-ecosystem-discussions/selection-bounds-operation/td-p/1101762
+   */
+  getSelectionBounds: () => `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${selectionHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var doc = app.activeDocument;
+    var hasSel = __mcp_hasSelection();
+    var result = {
+      ok: true,
+      has_selection: hasSel,
+      context: getContextInfo()
+    };
+
+    if (hasSel) {
+      var boundsRead = __mcp_readSelectionBounds(doc);
+      if (!boundsRead) {
+        return {
+          ok: false,
+          code: 'selection_bounds_error',
+          message: 'Failed to read selection bounds'
+        };
+      }
+      result.bounds = boundsRead;
+    }
+
+    return result;
+  `,
+
+  /**
+   * Create elliptical marquee selection via Action Manager (setd + Elps).
+   * @see https://stackoverflow.com/questions/37082583/elliptical-marquee-selection-then-fill-with-color-in-photoshop-using-javascript
+   * @see https://stackoverflow.com/questions/35235191/how-do-i-create-a-circular-or-elliptical-selections-in-javascript-for-use-in-pho
+   */
+  selectEllipse: (left: number, top: number, right: number, bottom: number) => `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${selectionHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var doc = app.activeDocument;
+    var desc = new ActionDescriptor();
+    var ref = new ActionReference();
+    ref.putProperty(cTID('Chnl'), cTID('fsel'));
+    desc.putReference(cTID('null'), ref);
+    var elps = new ActionDescriptor();
+    elps.putUnitDouble(cTID('Top '), cTID('#Pxl'), ${top});
+    elps.putUnitDouble(cTID('Left'), cTID('#Pxl'), ${left});
+    elps.putUnitDouble(cTID('Btom'), cTID('#Pxl'), ${bottom});
+    elps.putUnitDouble(cTID('Rght'), cTID('#Pxl'), ${right});
+    desc.putObject(cTID('T   '), cTID('Elps'), elps);
+    desc.putBoolean(cTID('AntA'), true);
+    executeAction(cTID('setd'), desc, DialogModes.NO);
+
+    var result = {
+      ok: true,
+      has_selection: true,
+      shape: 'ellipse',
+      context: getContextInfo()
+    };
+    var boundsRead = __mcp_readSelectionBounds(doc);
+    if (boundsRead) result.bounds = boundsRead;
+    return result;
+  `,
+
+  /**
+   * Expand the active selection by pixels.
+   * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/Selection/expand.html
+   */
+  expandSelection: (pixels: number) => `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${selectionHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var doc = app.activeDocument;
+    var selErr = __mcp_requireSelection();
+    if (selErr) return selErr;
+
+    doc.selection.expand(new UnitValue(${pixels}, 'px'));
+
+    var result = {
+      ok: true,
+      has_selection: true,
+      pixels: ${pixels},
+      operation: 'expand',
+      context: getContextInfo()
+    };
+    var boundsRead = __mcp_readSelectionBounds(doc);
+    if (boundsRead) result.bounds = boundsRead;
+    return result;
+  `,
+
+  /**
+   * Contract the active selection by pixels.
+   * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/Selection/contract.html
+   */
+  contractSelection: (pixels: number) => `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${selectionHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var doc = app.activeDocument;
+    var selErr = __mcp_requireSelection();
+    if (selErr) return selErr;
+
+    doc.selection.contract(new UnitValue(${pixels}, 'px'));
+
+    var result = {
+      ok: true,
+      has_selection: true,
+      pixels: ${pixels},
+      operation: 'contract',
+      context: getContextInfo()
+    };
+    var boundsRead = __mcp_readSelectionBounds(doc);
+    if (boundsRead) result.bounds = boundsRead;
+    return result;
+  `,
+
+  /**
+   * Feather the active selection edges by pixels.
+   * @see https://www.indesignjs.de/extendscriptAPI/photoshop-latest/Selection.html
+   */
+  featherSelection: (pixels: number) => `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${selectionHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var doc = app.activeDocument;
+    var selErr = __mcp_requireSelection();
+    if (selErr) return selErr;
+
+    doc.selection.feather(new UnitValue(${pixels}, 'px'));
+
+    var result = {
+      ok: true,
+      has_selection: true,
+      pixels: ${pixels},
+      operation: 'feather',
+      context: getContextInfo()
+    };
+    var boundsRead = __mcp_readSelectionBounds(doc);
+    if (boundsRead) result.bounds = boundsRead;
+    return result;
+  `,
+
+  /**
+   * Save the active selection to a new alpha channel.
+   * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/Selection/store.html
+   */
+  saveSelection: (channelName?: string) => {
+    const channelNameLiteral = channelName ? jsString(channelName) : 'null';
+    return `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${selectionHelpers}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+
+    var doc = app.activeDocument;
+    var selErr = __mcp_requireSelection();
+    if (selErr) return selErr;
+
+    var channelName = ${channelNameLiteral};
+    var name = channelName || ('MCP Selection ' + (new Date().getTime()));
+    var chan = doc.channels.add();
+    chan.name = name;
+    chan.kind = ChannelType.SELECTEDAREA;
+    doc.selection.store(chan, SelectionType.REPLACE);
+
+    return {
+      ok: true,
+      channel_name: chan.name,
+      context: getContextInfo()
+    };
+  `;
+  },
+
+  /**
    * Create rectangular selection
    */
   selectRectangle: (left: number, top: number, right: number, bottom: number) => `
@@ -1698,6 +2274,124 @@ export const ExtendScriptSnippets = {
       maskDeleted: true
     };
   `,
+
+  /**
+   * Create a clipping mask on the active or named layer (groupEvent AM).
+   * Active layer must sit directly above the layer to clip into.
+   */
+  createClippingMask: (layerName?: string) => {
+    const layerSelect = layerName
+      ? `var sel = __mcp_activateLayerByName("${jsString(layerName)}"); if (!sel.ok) return sel;`
+      : '';
+    return `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${MCP_SMART_OBJECT_HELPERS}
+    ${MCP_CLIPPING_MASK_HELPERS}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+    app.displayDialogs = DialogModes.NO;
+    var doc = app.activeDocument;
+    ${layerSelect}
+    if (!doc.activeLayer) {
+      return {
+        ok: false,
+        code: 'no_active_layer',
+        message: 'No active layer',
+        suggested_next_tool: 'photoshop_get_layers'
+      };
+    }
+    var layer = doc.activeLayer;
+    if (!__mcp_getLayerBelow(layer)) {
+      return {
+        ok: false,
+        code: 'no_base_layer_below',
+        message: 'No base layer below the active layer — nothing to clip into. The target layer must sit directly above the layer it should clip to.',
+        suggested_next_tool: 'photoshop_get_layers'
+      };
+    }
+    if (layer.grouped === true) {
+      return {
+        ok: true,
+        layer_name: layer.name,
+        is_clipping: true,
+        already_clipping: true,
+        context: getContextInfo()
+      };
+    }
+    try {
+      __mcp_createClippingMaskAM();
+    } catch (eClip) {
+      return {
+        ok: false,
+        code: 'extendscript_runtime_error',
+        message: 'Create clipping mask failed: ' + (eClip.message || eClip)
+      };
+    }
+    return {
+      ok: true,
+      layer_name: app.activeDocument.activeLayer.name,
+      is_clipping: true,
+      context: getContextInfo()
+    };
+  `;
+  },
+
+  /**
+   * Release clipping mask on the active or named layer (layer.grouped = false).
+   */
+  releaseClippingMask: (layerName?: string) => {
+    const layerSelect = layerName
+      ? `var sel = __mcp_activateLayerByName("${jsString(layerName)}"); if (!sel.ok) return sel;`
+      : '';
+    return `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${MCP_SMART_OBJECT_HELPERS}
+    ${MCP_CLIPPING_MASK_HELPERS}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+    app.displayDialogs = DialogModes.NO;
+    var doc = app.activeDocument;
+    ${layerSelect}
+    if (!doc.activeLayer) {
+      return {
+        ok: false,
+        code: 'no_active_layer',
+        message: 'No active layer',
+        suggested_next_tool: 'photoshop_get_layers'
+      };
+    }
+    var layer = doc.activeLayer;
+    if (layer.grouped !== true) {
+      return {
+        ok: false,
+        code: 'not_clipping',
+        message: 'Layer "' + layer.name + '" is not a clipping mask',
+        suggested_next_tool: 'photoshop_get_layers'
+      };
+    }
+    try {
+      layer.grouped = false;
+    } catch (eRelease) {
+      return {
+        ok: false,
+        code: 'extendscript_runtime_error',
+        message: 'Release clipping mask failed: ' + (eRelease.message || eRelease)
+      };
+    }
+    return {
+      ok: true,
+      layer_name: layer.name,
+      is_clipping: false,
+      context: getContextInfo()
+    };
+  `;
+  },
 
   /**
    * Apply layer mask
@@ -2877,6 +3571,185 @@ export const ExtendScriptSnippets = {
       output_paths: outputs,
       output_dir: "${escapedDir}",
       format: '${format}'
+    };
+  `;
+  },
+
+  /**
+   * Convert the active or named layer to an embedded Smart Object (newPlacedLayer).
+   */
+  convertToSmartObject: (layerName?: string) => {
+    const layerSelect = layerName
+      ? `var sel = __mcp_activateLayerByName("${jsString(layerName)}"); if (!sel.ok) return sel;`
+      : '';
+    return `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${MCP_SMART_OBJECT_HELPERS}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+    app.displayDialogs = DialogModes.NO;
+    ${layerSelect}
+    var layer = app.activeDocument.activeLayer;
+    if (layer.isBackgroundLayer) {
+      return {
+        ok: false,
+        code: 'background_layer',
+        message: 'Cannot convert background layer to Smart Object. Unlock or duplicate it first.'
+      };
+    }
+    if (layer.kind === LayerKind.SMARTOBJECT) {
+      return {
+        ok: true,
+        already_smart_object: true,
+        layer_name: layer.name,
+        kind: String(layer.kind),
+        context: getContextInfo()
+      };
+    }
+    try {
+      executeAction(sTID('newPlacedLayer'), undefined, DialogModes.NO);
+    } catch (eConvert) {
+      return {
+        ok: false,
+        code: 'smart_object_error',
+        message: 'Convert to Smart Object failed: ' + (eConvert.message || eConvert)
+      };
+    }
+    var converted = app.activeDocument.activeLayer;
+    return {
+      ok: true,
+      layer_name: converted.name,
+      kind: String(converted.kind),
+      context: getContextInfo()
+    };
+  `;
+  },
+
+  /**
+   * Replace Smart Object contents from a file (placedLayerReplaceContents + PgNm).
+   */
+  replaceSmartObjectContents: (filePath: string, layerName?: string) => {
+    const layerSelect = layerName
+      ? `var sel = __mcp_activateLayerByName("${jsString(layerName)}"); if (!sel.ok) return sel;`
+      : '';
+    return `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${MCP_SMART_OBJECT_HELPERS}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+    app.displayDialogs = DialogModes.NO;
+    ${layerSelect}
+    var rep = __mcp_replaceSmartObjectContents("${jsString(filePath)}");
+    if (!rep.ok) return rep;
+    return {
+      ok: true,
+      layer_name: rep.layerName,
+      file_path: rep.filePath,
+      context: getContextInfo()
+    };
+  `;
+  },
+
+  /**
+   * Open Smart Object embedded contents for editing (placedLayerEditContents).
+   * Active document becomes the embedded .psb until saved and closed.
+   */
+  editSmartObjectContents: (layerName?: string) => {
+    const layerSelect = layerName
+      ? `var sel = __mcp_activateLayerByName("${jsString(layerName)}"); if (!sel.ok) return sel;`
+      : '';
+    return `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${MCP_SMART_OBJECT_HELPERS}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+    app.displayDialogs = DialogModes.NO;
+    ${layerSelect}
+    var layer = app.activeDocument.activeLayer;
+    if (layer.kind !== LayerKind.SMARTOBJECT) {
+      return {
+        ok: false,
+        code: 'unsupported_layer_kind',
+        message: 'Target layer "' + layer.name + '" is not a Smart Object (kind=' + layer.kind + ').',
+        suggested_next_tool: 'photoshop_get_layers'
+      };
+    }
+    var parentDoc = app.activeDocument;
+    var parentName = parentDoc.name;
+    var parentId = parentDoc.id;
+    var soLayerName = layer.name;
+    try {
+      executeAction(sTID('placedLayerEditContents'), new ActionDescriptor(), DialogModes.NO);
+    } catch (eEdit) {
+      return {
+        ok: false,
+        code: 'smart_object_error',
+        message: 'Edit Smart Object contents failed: ' + (eEdit.message || eEdit)
+      };
+    }
+    var embedded = app.activeDocument;
+    return {
+      ok: true,
+      parent_document: { name: parentName, id: parentId },
+      embedded_document: { name: embedded.name, id: embedded.id },
+      layer_name: soLayerName,
+      context: getContextInfo()
+    };
+  `;
+  },
+
+  /**
+   * Create an independent Smart Object copy (placedLayerMakeCopy).
+   */
+  createSmartObjectViaCopy: (layerName?: string) => {
+    const layerSelect = layerName
+      ? `var sel = __mcp_activateLayerByName("${jsString(layerName)}"); if (!sel.ok) return sel;`
+      : '';
+    return `
+    ${helperFunctions}
+    ${getContextInfo}
+    ${MCP_SMART_OBJECT_HELPERS}
+
+    if (app.documents.length === 0) {
+      return { ok: false, code: 'no_document', message: 'No active document' };
+    }
+    app.displayDialogs = DialogModes.NO;
+    ${layerSelect}
+    var source = app.activeDocument.activeLayer;
+    if (source.kind !== LayerKind.SMARTOBJECT) {
+      return {
+        ok: false,
+        code: 'unsupported_layer_kind',
+        message: 'Target layer "' + source.name + '" is not a Smart Object (kind=' + source.kind + ').',
+        suggested_next_tool: 'photoshop_get_layers'
+      };
+    }
+    var sourceName = source.name;
+    try {
+      executeAction(sTID('placedLayerMakeCopy'), undefined, DialogModes.NO);
+    } catch (eCopy) {
+      return {
+        ok: false,
+        code: 'smart_object_error',
+        message: 'New Smart Object via Copy failed: ' + (eCopy.message || eCopy)
+      };
+    }
+    var copyLayer = app.activeDocument.activeLayer;
+    return {
+      ok: true,
+      source_layer_name: sourceName,
+      new_layer_name: copyLayer.name,
+      kind: String(copyLayer.kind),
+      context: getContextInfo()
     };
   `;
   },

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -18,6 +18,7 @@ import { createDocumentTools } from '../tools/document-tools.js';
 import { createLayerTools } from '../tools/layer-tools.js';
 import { createImageTools } from '../tools/image-tools.js';
 import { createImagePlacementTools } from '../tools/image-placement-tools.js';
+import { createSmartObjectTools } from '../tools/smart-object-tools.js';
 import { createLayerTransformTools } from '../tools/layer-transform-tools.js';
 import { createLayerPropertiesTools } from '../tools/layer-properties-tools.js';
 import { createFilterTools } from '../tools/filter-tools.js';
@@ -125,6 +126,7 @@ export class PhotoshopMCPServer {
     this.registerToolDefinitions(createLayerTools(connection));
     this.registerToolDefinitions(createImageTools(connection));
     this.registerToolDefinitions(createImagePlacementTools(connection));
+    this.registerToolDefinitions(createSmartObjectTools(connection));
     this.registerToolDefinitions(createLayerTransformTools(connection));
     this.registerToolDefinitions(createLayerPropertiesTools(connection));
     this.registerToolDefinitions(createFilterTools(connection));

--- a/src/errors/envelope.ts
+++ b/src/errors/envelope.ts
@@ -6,6 +6,9 @@ export type PhotoshopErrorCode =
   | 'no_active_document'
   | 'no_active_layer'
   | 'layer_not_found'
+  | 'document_not_found'
+  | 'ambiguous_name'
+  | 'invalid_arguments'
   | 'selection_required'
   | 'version_unsupported'
   | 'generative_unavailable'
@@ -17,6 +20,8 @@ export type PhotoshopErrorCode =
   | 'file_not_found'
   | 'font_not_found'
   | 'unsupported_color_mode'
+  | 'no_base_layer_below'
+  | 'not_clipping'
   | 'unknown';
 
 export interface PhotoshopErrorEnvelope {
@@ -36,6 +41,8 @@ const ERROR_PATTERNS: Array<{
   { pattern: /no documents/i, code: 'no_active_document', suggested_next_tool: 'photoshop_get_state' },
   { pattern: /no active layer/i, code: 'no_active_layer', suggested_next_tool: 'photoshop_get_layers' },
   { pattern: /layer not found/i, code: 'layer_not_found', suggested_next_tool: 'photoshop_get_layers' },
+  { pattern: /no base layer below|nothing to clip into/i, code: 'no_base_layer_below', suggested_next_tool: 'photoshop_get_layers' },
+  { pattern: /not clipping|not a clipping mask/i, code: 'not_clipping', suggested_next_tool: 'photoshop_get_layers' },
   { pattern: /selection/i, code: 'selection_required', suggested_next_tool: 'photoshop_get_state' },
   { pattern: /version_unsupported|not supported.*version/i, code: 'version_unsupported', suggested_next_tool: 'photoshop_get_capabilities' },
   { pattern: /generative.*credit|quota|sign in/i, code: 'generative_credits_exhausted', suggested_next_tool: 'photoshop_get_capabilities' },

--- a/src/prompts/instructions.ts
+++ b/src/prompts/instructions.ts
@@ -28,7 +28,8 @@ Recipe tools over atomic chains
   "prepare for web", "export Instagram variants", "apply cinematic color grade",
   "make it pop", "frequency separation", "replace mockup", "organize layers",
   "replace sky", "fade into background", "gradient mask", "dodge and burn",
-  "remove that person", "erase distraction"), prefer the matching
+  "remove that person", "erase distraction", "csv to cards", "batch cards",
+  "data-driven graphics"), prefer the matching
   \`photoshop_recipe_*\` tool over composing 5+ atomic calls yourself. Recipes
   are wrapped in a single history step and are deterministically reversible
   with one undo.
@@ -100,6 +101,9 @@ User intent glossary
   → \`photoshop_recipe_batch_watermark\`
 - id.passport — "passport photo", "visa photo", "ID photo", "vesikalık", "biyometrik"
   → \`photoshop_recipe_passport_photo\`
+- batch.csv_cards — "csv to cards", "batch cards", "data-driven graphics",
+  "mail merge for images", "name badges from spreadsheet", "sertifika bas"
+  → \`photoshop_recipe_csv_to_cards\`; prompt \`ps.csv_to_cards\`
 
 Degrade paths
 - Generative remove / distraction — prefer \`photoshop_generative_remove\`; degrade to
@@ -131,7 +135,7 @@ Guide prompts (MCP prompts/get)
   \`ps.apply_color_grade\`, \`ps.frequency_separation\`, \`ps.batch_mockup_replace\`,
   \`ps.organize_layers\`, \`ps.gradient_fade\`, \`ps.sky_blend\`, \`ps.dodge_burn\`,
   \`ps.remove_distraction\`, \`ps.split_carousel\`, \`ps.batch_watermark\`,
-  \`ps.passport_photo\`
+  \`ps.passport_photo\`, \`ps.csv_to_cards\`
 - Guide prompts (no recipe pair): \`ps.gradient_blend\` — fade via mask gradient;
   \`ps.color_correct\` — tone / contrast fix chain; \`ps.dodge_burn_guide\` — 50% gray
   overlay setup; \`ps.composite_blend\` — place asset + mask + blend mode;

--- a/src/prompts/templates/remove-background.ts
+++ b/src/prompts/templates/remove-background.ts
@@ -8,7 +8,7 @@ import {
 export const removeBackgroundTemplate: PhotoshopPromptTemplate = {
   name: 'ps.remove_background',
   description:
-    'Remove the background from the active layer using Select Subject, with an optional feather radius and an option to keep a soft contact shadow. Users often say: remove background, cut out, isolate subject, transparent background, arka planı sil.',
+    'Remove the background from the active layer using Select Subject, with an optional feather radius. The keep_shadow argument is accepted but does not yet create a shadow layer (recorded in the recipe response only). Users often say: remove background, cut out, isolate subject, transparent background, arka planı sil.',
   arguments: [
     {
       name: 'feather_px',
@@ -19,7 +19,7 @@ export const removeBackgroundTemplate: PhotoshopPromptTemplate = {
     {
       name: 'keep_shadow',
       description:
-        'When true, duplicate the layer first, blur and darken it to simulate a contact shadow. Default false.',
+        'When true, records intent for a contact shadow in the recipe response. Shadow layer creation is not yet implemented. Default false.',
       required: false,
     },
   ],
@@ -34,7 +34,7 @@ export const removeBackgroundTemplate: PhotoshopPromptTemplate = {
       `1. Call \`photoshop_get_state\` to confirm an active document with a non-background active layer that contains a subject.`,
       `2. Call \`photoshop_get_capabilities\` only if you have not yet this session; verify \`select_subject_v2\` is available.`,
       `3. Call \`photoshop_recipe_remove_background\` with { feather_px: ${feather}, keep_shadow: ${keepShadow} }.`,
-      `   - The recipe internally runs Select Subject, inverts the selection, adds a layer mask, applies the feather, and (if keep_shadow) creates a shadow layer underneath.`,
+      `   - The recipe runs Select Subject, inverts the selection, adds a layer mask, and applies the feather. keep_shadow is accepted but does not yet create a shadow layer (value is recorded in the response only).`,
       `4. Call \`photoshop_get_preview\` to show the result against transparency.`,
       `5. If the mask edge needs refinement, ask the user before adding a refine-edge pass — that step is destructive on the mask.`,
       ``,

--- a/src/tools/document-tools.ts
+++ b/src/tools/document-tools.ts
@@ -2,6 +2,13 @@ import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
 import { PhotoshopConnection } from '../platform/connection.js';
 import { PhotoshopAPIFactory } from '../api/photoshop-api.js';
 import { ExtendScriptSnippets } from '../api/extendscript.js';
+import {
+  atomicFailure,
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
 
 export function createDocumentTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
@@ -54,6 +61,53 @@ export function createDocumentTools(connection: PhotoshopConnection): ToolDefini
         },
       },
       handler: async () => getDocumentInfo(connection),
+    },
+    {
+      tool: {
+        name: 'photoshop_list_documents',
+        description:
+          'List every open Photoshop document with id, dimensions, and which tab is active (read-only).\n\n' +
+          'Use when: multiple documents are open and you need document_id before switching tabs or closing a specific file.\n' +
+          'Do NOT use when: you only need the active document — use photoshop_get_document_info or photoshop_get_state.\n\n' +
+          'Returns: JSON { ok, summary, details: { count, documents[], active_document_id, context } }.\n' +
+          'Preconditions: none (safe when zero documents open). Side effects: none.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      handler: async () => listDocuments(connection),
+    },
+    {
+      tool: {
+        name: 'photoshop_set_active_document',
+        description:
+          'Switch the active document tab by document_id (preferred), zero-based index, or name.\n\n' +
+          'Use when: working across multiple open files and mutations must target a specific document.\n' +
+          'Do NOT use when: only one document is open — it is already active.\n' +
+          'Do NOT use document_name when duplicate names exist — use document_id from photoshop_list_documents.\n\n' +
+          'Returns: JSON { ok, summary, details: { activated: { id, name }, context } }.\n' +
+          'Preconditions: target document must be open. Provide exactly one of document_id, index, or document_name. Side effects: changes active tab.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            document_id: {
+              type: 'number',
+              description: 'Unique internal document id from photoshop_list_documents (preferred)',
+            },
+            index: {
+              type: 'number',
+              description: 'Zero-based tab order index (leftmost tab is 0)',
+              minimum: 0,
+            },
+            document_name: {
+              type: 'string',
+              description: 'Document name/title (ambiguous if multiple tabs share the same name)',
+            },
+          },
+        },
+      },
+      handler: async (args) => setActiveDocument(connection, args),
     },
     {
       tool: {
@@ -156,6 +210,119 @@ async function createDocument(
       ],
       isError: true,
     };
+  }
+}
+
+async function listDocuments(connection: PhotoshopConnection): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.listDocuments());
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    if (parsed.ok === false) {
+      return atomicFailure({
+        ok: false,
+        code: 'extendscript_runtime_error',
+        message: String(parsed.message || 'Failed to list documents'),
+        suggested_next_tool: 'photoshop_get_state',
+      });
+    }
+
+    const count = typeof parsed.count === 'number' ? parsed.count : 0;
+    const details: Record<string, unknown> = {
+      count,
+      documents: parsed.documents ?? [],
+      active_document_id: parsed.active_document_id ?? null,
+    };
+    if (parsed.context !== undefined) {
+      details.context = parsed.context;
+    }
+
+    return atomicSuccess(
+      count === 0 ? 'No documents open' : `${count} open document${count === 1 ? '' : 's'}`,
+      details,
+      count === 0 ? 'photoshop_create_document' : 'photoshop_get_document_info'
+    );
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+function countSetActiveIdentifiers(args: Record<string, unknown>): number {
+  let count = 0;
+  if (args.document_id !== undefined && args.document_id !== null) count++;
+  if (args.index !== undefined && args.index !== null) count++;
+  if (typeof args.document_name === 'string' && args.document_name.length > 0) count++;
+  return count;
+}
+
+async function setActiveDocument(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const identifierCount = countSetActiveIdentifiers(args);
+  if (identifierCount !== 1) {
+    return atomicFailure({
+      ok: false,
+      code: 'invalid_arguments',
+      message:
+        'Exactly one of document_id, index, or document_name is required to set the active document',
+      suggested_next_tool: 'photoshop_list_documents',
+    });
+  }
+
+  const params: { documentId?: number; documentName?: string; index?: number } = {};
+  if (args.document_id !== undefined && args.document_id !== null) {
+    params.documentId = args.document_id as number;
+  } else if (args.index !== undefined && args.index !== null) {
+    params.index = args.index as number;
+  } else {
+    params.documentName = args.document_name as string;
+  }
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.setActiveDocument(params));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    if (parsed.ok === false) {
+      const code =
+        parsed.code === 'document_not_found' || parsed.code === 'ambiguous_name'
+          ? parsed.code
+          : 'extendscript_runtime_error';
+      return atomicFailure({
+        ok: false,
+        code,
+        message: String(parsed.message || 'Failed to set active document'),
+        suggested_next_tool: 'photoshop_list_documents',
+        ...(parsed.matching_document_ids
+          ? { suggested_args: { matching_document_ids: parsed.matching_document_ids } }
+          : {}),
+      });
+    }
+
+    const activated = parsed.activated as { id?: number; name?: string } | undefined;
+    const details: Record<string, unknown> = {};
+    if (activated) {
+      details.activated = activated;
+    }
+    if (parsed.context !== undefined) {
+      details.context = parsed.context;
+    }
+
+    return atomicSuccess(
+      activated?.name
+        ? `Active document set to "${activated.name}"`
+        : 'Active document switched',
+      details,
+      'photoshop_get_document_info'
+    );
+  } catch (error) {
+    return atomicFailureFromError(error);
   }
 }
 

--- a/src/tools/filter-tools.ts
+++ b/src/tools/filter-tools.ts
@@ -2,6 +2,17 @@ import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
 import { PhotoshopConnection } from '../platform/connection.js';
 import { PhotoshopAPIFactory } from '../api/photoshop-api.js';
 import { ExtendScriptSnippets } from '../api/extendscript.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+const SMART_BLUR_MODES = ['NORMAL', 'EDGEONLY', 'OVERLAYEDGE'] as const;
+const SMART_BLUR_QUALITIES = ['LOW', 'MEDIUM', 'HIGH'] as const;
+type SmartBlurMode = (typeof SMART_BLUR_MODES)[number];
+type SmartBlurQuality = (typeof SMART_BLUR_QUALITIES)[number];
 
 export function createFilterTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
@@ -111,7 +122,133 @@ export function createFilterTools(connection: PhotoshopConnection): ToolDefiniti
       },
       handler: async (args) => applyMotionBlur(connection, args),
     },
+    {
+      tool: {
+        name: 'photoshop_apply_high_pass',
+        description:
+          'Apply the High Pass filter to the active raster layer — edge/detail extraction for sharpening workflows or frequency separation prep.\n\n' +
+          'Users often say: high pass filter, sharpen edges, extract details, frequency separation high layer.\n\n' +
+          'Use when: sharpening via overlay blend, detail extraction, or prepping a high-frequency layer.\n' +
+          'Do NOT use on text, Smart Objects, or the Background layer — rasterize or convert first (photoshop_rasterize_layer).\n\n' +
+          'Returns: JSON { ok, summary, details: { filter, radius, context } }.\n' +
+          'Preconditions: active document; normal (raster) layer selected. Side effects: one history step.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            radius: {
+              type: 'number',
+              description: 'Edge retention radius in pixels (0.1-250)',
+              minimum: 0.1,
+              maximum: 250,
+            },
+          },
+          required: ['radius'],
+        },
+      },
+      handler: async (args) => applyHighPass(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_apply_smart_blur',
+        description:
+          'Apply the Smart Blur filter to the active raster layer — edge-preserving blur for smoothing skin or simplifying backgrounds.\n\n' +
+          'Users often say: smart blur, edge-preserving blur, smooth skin blur, blur but keep edges.\n\n' +
+          'Use when: subtle smoothing that respects edges (portraits, product cleanup).\n' +
+          'Do NOT use on text, Smart Objects, or the Background layer — rasterize first (photoshop_rasterize_layer).\n' +
+          'Do NOT use when: uniform blur is enough — use photoshop_apply_gaussian_blur.\n\n' +
+          'Returns: JSON { ok, summary, details: { filter, radius, threshold, mode, quality, context } }.\n' +
+          'Preconditions: active document; normal (raster) layer selected. Side effects: one history step.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            radius: {
+              type: 'number',
+              description: 'Blur radius (0.1-100)',
+              minimum: 0.1,
+              maximum: 100,
+            },
+            threshold: {
+              type: 'number',
+              description: 'Blur threshold — higher values restrict blur to stronger edges (0.1-100)',
+              minimum: 0.1,
+              maximum: 100,
+            },
+            mode: {
+              type: 'string',
+              enum: [...SMART_BLUR_MODES],
+              description: 'Smart blur mode (default: NORMAL)',
+              default: 'NORMAL',
+            },
+            quality: {
+              type: 'string',
+              enum: [...SMART_BLUR_QUALITIES],
+              description: 'Blur quality / smoothness (default: MEDIUM)',
+              default: 'MEDIUM',
+            },
+          },
+          required: ['radius', 'threshold'],
+        },
+      },
+      handler: async (args) => applySmartBlur(connection, args),
+    },
   ];
+}
+
+async function runFilterSnippet(
+  connection: PhotoshopConnection,
+  script: string,
+  successSummary: string,
+  detailsKeys: string[]
+): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, script);
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable filter result: ${String(raw)}`));
+    }
+    if (parsed.ok === false) {
+      return atomicFailureFromError(
+        new Error(String(parsed.message || 'Filter operation failed')),
+        parsed.suggested_next_tool
+          ? { suggested_next_tool: String(parsed.suggested_next_tool) }
+          : undefined
+      );
+    }
+    const details: Record<string, unknown> = {};
+    for (const key of detailsKeys) {
+      if (parsed[key] !== undefined) details[key] = parsed[key];
+    }
+    if (parsed.context !== undefined) details.context = parsed.context;
+    return atomicSuccess(successSummary, details);
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+function validateHighPassRadius(radius: unknown): number | ToolResult {
+  if (typeof radius !== 'number' || !Number.isFinite(radius) || radius < 0.1 || radius > 250) {
+    return atomicFailureFromError(new Error('radius must be a number between 0.1 and 250'));
+  }
+  return radius;
+}
+
+function validateSmartBlurRadius(radius: unknown): number | ToolResult {
+  if (typeof radius !== 'number' || !Number.isFinite(radius) || radius < 0.1 || radius > 100) {
+    return atomicFailureFromError(new Error('radius must be a number between 0.1 and 100'));
+  }
+  return radius;
+}
+
+function validateSmartBlurThreshold(threshold: unknown): number | ToolResult {
+  if (
+    typeof threshold !== 'number' ||
+    !Number.isFinite(threshold) ||
+    threshold < 0.1 ||
+    threshold > 100
+  ) {
+    return atomicFailureFromError(new Error('threshold must be a number between 0.1 and 100'));
+  }
+  return threshold;
 }
 
 async function applyGaussianBlur(
@@ -253,4 +390,47 @@ async function applyMotionBlur(
       isError: true,
     };
   }
+}
+
+async function applyHighPass(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const radiusResult = validateHighPassRadius(args.radius);
+  if (typeof radiusResult !== 'number') return radiusResult;
+
+  return runFilterSnippet(
+    connection,
+    ExtendScriptSnippets.applyHighPass(radiusResult),
+    `High Pass filter applied (radius ${radiusResult}px)`,
+    ['filter', 'radius']
+  );
+}
+
+async function applySmartBlur(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const radiusResult = validateSmartBlurRadius(args.radius);
+  if (typeof radiusResult !== 'number') return radiusResult;
+
+  const thresholdResult = validateSmartBlurThreshold(args.threshold);
+  if (typeof thresholdResult !== 'number') return thresholdResult;
+
+  const mode: SmartBlurMode =
+    typeof args.mode === 'string' && (SMART_BLUR_MODES as readonly string[]).includes(args.mode)
+      ? (args.mode as SmartBlurMode)
+      : 'NORMAL';
+  const quality: SmartBlurQuality =
+    typeof args.quality === 'string' &&
+    (SMART_BLUR_QUALITIES as readonly string[]).includes(args.quality)
+      ? (args.quality as SmartBlurQuality)
+      : 'MEDIUM';
+
+  return runFilterSnippet(
+    connection,
+    ExtendScriptSnippets.applySmartBlur(radiusResult, thresholdResult, mode, quality),
+    `Smart Blur applied (radius ${radiusResult}px, threshold ${thresholdResult})`,
+    ['filter', 'radius', 'threshold', 'mode', 'quality']
+  );
 }

--- a/src/tools/mask-tools.ts
+++ b/src/tools/mask-tools.ts
@@ -3,11 +3,68 @@ import { ExtendScriptSnippets, type GradientMaskDirection } from '../api/extends
 import { PhotoshopConnection } from '../platform/connection.js';
 import { clampInt } from './recipes/_shared.js';
 import {
+  atomicFailure,
   atomicFailureFromError,
   atomicSuccess,
   parseSnippetResult,
   runSnippet,
 } from './atomic-shared.js';
+import type { PhotoshopErrorCode } from '../errors/envelope.js';
+
+function mapClippingSnippetFailure(parsed: Record<string, unknown>): ToolResult | null {
+  if (parsed.ok !== false) return null;
+  const rawCode = typeof parsed.code === 'string' ? parsed.code : 'extendscript_runtime_error';
+  const allowed: PhotoshopErrorCode[] = [
+    'no_active_document',
+    'no_active_layer',
+    'layer_not_found',
+    'no_base_layer_below',
+    'not_clipping',
+    'extendscript_runtime_error',
+  ];
+  const code: PhotoshopErrorCode =
+    rawCode === 'no_document'
+      ? 'no_active_document'
+      : allowed.includes(rawCode as PhotoshopErrorCode)
+        ? (rawCode as PhotoshopErrorCode)
+        : 'extendscript_runtime_error';
+  return atomicFailure({
+    ok: false,
+    code,
+    message: String(parsed.message || 'Clipping mask operation failed'),
+    suggested_next_tool:
+      typeof parsed.suggested_next_tool === 'string'
+        ? parsed.suggested_next_tool
+        : code === 'no_base_layer_below' || code === 'not_clipping'
+          ? 'photoshop_get_layers'
+          : 'photoshop_get_state',
+  });
+}
+
+async function runClippingMaskSnippet(
+  connection: PhotoshopConnection,
+  script: string,
+  successSummary: string,
+  detailsKeys: string[]
+): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, script);
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable clipping mask result: ${String(raw)}`));
+    }
+    const failure = mapClippingSnippetFailure(parsed);
+    if (failure) return failure;
+    const details: Record<string, unknown> = {};
+    for (const key of detailsKeys) {
+      if (parsed[key] !== undefined) details[key] = parsed[key];
+    }
+    if (parsed.context !== undefined) details.context = parsed.context;
+    return atomicSuccess(successSummary, details);
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
 
 const GRADIENT_DIRECTIONS: GradientMaskDirection[] = [
   'top_to_bottom',
@@ -69,7 +126,80 @@ export function createMaskTools(connection: PhotoshopConnection): ToolDefinition
       },
       handler: async (args) => applyGradientMask(connection, args),
     },
+    {
+      tool: {
+        name: 'photoshop_create_clipping_mask',
+        description:
+          'Create a clipping mask on the active layer (or a named layer).\n\n' +
+          'Users often say: clip to layer below, clipping mask, clip this layer, mask to shape below.\n\n' +
+          'Use when: the active layer should be visible only where the layer directly below it has opaque pixels.\n' +
+          'Do NOT use when: the layer is already clipped — returns success with already_clipping.\n' +
+          'Do NOT use when: the layer is the bottom-most layer — there is no base layer to clip into.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, is_clipping, already_clipping? } }.\n' +
+          'Preconditions: active document; target layer must sit directly above the base layer below it in the same group/stack.\n' +
+          'Side effects: one history step (groupEvent).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            layer_name: {
+              type: 'string',
+              description: 'Optional exact layer name (recursive search). Default: active layer.',
+            },
+          },
+        },
+      },
+      handler: async (args) => createClippingMask(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_release_clipping_mask',
+        description:
+          'Release (remove) the clipping mask from the active layer (or a named layer).\n\n' +
+          'Users often say: unclip, release clipping mask, remove clipping mask.\n\n' +
+          'Use when: a clipped layer should become independent again.\n' +
+          'Do NOT use when: the layer is not clipped — returns not_clipping error.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, is_clipping: false } }.\n' +
+          'Preconditions: active document; target layer must currently be a clipping mask (grouped).\n' +
+          'Side effects: sets layer.grouped = false; one history step.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            layer_name: {
+              type: 'string',
+              description: 'Optional exact layer name (recursive search). Default: active layer.',
+            },
+          },
+        },
+      },
+      handler: async (args) => releaseClippingMask(connection, args),
+    },
   ];
+}
+
+async function createClippingMask(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const layerName = typeof args.layer_name === 'string' ? args.layer_name.trim() : undefined;
+  return runClippingMaskSnippet(
+    connection,
+    ExtendScriptSnippets.createClippingMask(layerName),
+    layerName ? `Clipping mask created on "${layerName}"` : 'Clipping mask created on active layer',
+    ['layer_name', 'is_clipping', 'already_clipping']
+  );
+}
+
+async function releaseClippingMask(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const layerName = typeof args.layer_name === 'string' ? args.layer_name.trim() : undefined;
+  return runClippingMaskSnippet(
+    connection,
+    ExtendScriptSnippets.releaseClippingMask(layerName),
+    layerName ? `Clipping mask released from "${layerName}"` : 'Clipping mask released from active layer',
+    ['layer_name', 'is_clipping']
+  );
 }
 
 async function applyGradientMask(

--- a/src/tools/recipes/batch-mockup-replace.ts
+++ b/src/tools/recipes/batch-mockup-replace.ts
@@ -7,8 +7,10 @@ import {
   clampInt,
   executeRecipe,
   jsString,
+  RECIPE_ACTION_HELPERS,
   toolFailure,
 } from './_shared.js';
+import { MCP_SMART_OBJECT_HELPERS } from '../../api/extendscript.js';
 
 const TOOL_NAME = 'photoshop_recipe_batch_mockup_replace';
 
@@ -130,6 +132,9 @@ async function runBatchMockupReplace(
     .join(', ');
 
   const body = `
+    ${RECIPE_ACTION_HELPERS}
+    ${MCP_SMART_OBJECT_HELPERS}
+
     var doc = app.activeDocument;
     var targetName = "${jsString(layerName)}";
     var target = null;
@@ -163,10 +168,8 @@ async function runBatchMockupReplace(
         if (!assetFile.exists) {
           return { ok: false, code: 'file_not_found', message: 'Asset missing on disk: ' + spec.asset };
         }
-        var replaceDesc = new ActionDescriptor();
-        replaceDesc.putPath(charIDToTypeID('null'), assetFile);
-        replaceDesc.putInteger(charIDToTypeID('PgNm'), 1);
-        executeAction(stringIDToTypeID('placedLayerReplaceContents'), replaceDesc, DialogModes.NO);
+        var rep = __mcp_replaceSmartObjectContents(spec.asset);
+        if (!rep.ok) return rep;
 
         var outFile = new File(spec.out);
         var jpegOptions = new JPEGSaveOptions();

--- a/src/tools/selection-tools.ts
+++ b/src/tools/selection-tools.ts
@@ -10,9 +10,187 @@ import {
   parseSnippetResult,
   runSnippet,
 } from './atomic-shared.js';
+import type { PhotoshopErrorCode } from '../errors/envelope.js';
+
+function mapSelectionSnippetFailure(parsed: Record<string, unknown>): ToolResult | null {
+  if (parsed.ok !== false) return null;
+  const rawCode = typeof parsed.code === 'string' ? parsed.code : 'extendscript_runtime_error';
+  const code: PhotoshopErrorCode =
+    rawCode === 'no_document'
+      ? 'no_active_document'
+      : rawCode === 'selection_required'
+        ? 'selection_required'
+        : 'extendscript_runtime_error';
+  return atomicFailure({
+    ok: false,
+    code,
+    message: String(parsed.message || 'Selection operation failed'),
+    suggested_next_tool:
+      code === 'selection_required' ? 'photoshop_select_rectangle' : 'photoshop_get_state',
+  });
+}
+
+function parseRequiredPixels(args: Record<string, unknown>): number | null {
+  const value = args.pixels;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return Math.max(1, Math.round(value));
+}
+
+function parseSelectionBounds(
+  parsed: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const details: Record<string, unknown> = {};
+  if (parsed.bounds !== undefined) details.bounds = parsed.bounds;
+  if (parsed.pixels !== undefined) details.pixels = parsed.pixels;
+  if (parsed.operation !== undefined) details.operation = parsed.operation;
+  if (parsed.shape !== undefined) details.shape = parsed.shape;
+  if (parsed.channel_name !== undefined) details.channel_name = parsed.channel_name;
+  if (parsed.context !== undefined) details.context = parsed.context;
+  return Object.keys(details).length > 0 ? details : undefined;
+}
 
 export function createSelectionTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
+    {
+      tool: {
+        name: 'photoshop_get_selection_bounds',
+        description:
+          'Read the active pixel selection bounds in document pixels (read-only).\n\n' +
+          'Use when: verifying selection exists and its size/position before mask, fill, or recipe steps.\n' +
+          'Do NOT use when: creating or modifying a selection — use photoshop_select_rectangle or photoshop_select_subject.\n\n' +
+          'Returns: JSON { ok, summary, details: { has_selection, bounds?, context } }.\n' +
+          'Preconditions: active document. Side effects: none.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      handler: async () => getSelectionBounds(connection),
+    },
+    {
+      tool: {
+        name: 'photoshop_select_ellipse',
+        description:
+          'Create an elliptical pixel selection from a bounding box (anti-aliased).\n\n' +
+          'Use when: circular or oval masks, vignettes, or radial edits inside a region.\n' +
+          'Do NOT use when: a rectangular region is enough — use photoshop_select_rectangle.\n\n' +
+          'Returns: JSON { ok, summary, details: { shape, bounds?, context } }.\n' +
+          'Preconditions: active document; right > left and bottom > top. Side effects: replaces current selection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            left: {
+              type: 'number',
+              description: 'Left edge of bounding box in pixels',
+            },
+            top: {
+              type: 'number',
+              description: 'Top edge of bounding box in pixels',
+            },
+            right: {
+              type: 'number',
+              description: 'Right edge of bounding box in pixels',
+            },
+            bottom: {
+              type: 'number',
+              description: 'Bottom edge of bounding box in pixels',
+            },
+          },
+          required: ['left', 'top', 'right', 'bottom'],
+        },
+      },
+      handler: async (args) => selectEllipse(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_expand_selection',
+        description:
+          'Expand the active pixel selection outward by a pixel amount.\n\n' +
+          'Use when: growing a tight subject selection or adding padding before feather/fill.\n' +
+          'Do NOT use when: no selection exists — create one first.\n\n' +
+          'Returns: JSON { ok, summary, details: { pixels, bounds?, context } }.\n' +
+          'Preconditions: active document and active pixel selection. Side effects: modifies selection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pixels: {
+              type: 'number',
+              description: 'Pixels to expand by (minimum 1)',
+              minimum: 1,
+            },
+          },
+          required: ['pixels'],
+        },
+      },
+      handler: async (args) => expandSelection(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_contract_selection',
+        description:
+          'Contract (shrink) the active pixel selection inward by a pixel amount.\n\n' +
+          'Use when: tightening a loose selection or trimming halo after expand.\n' +
+          'Do NOT use when: no selection exists — create one first.\n\n' +
+          'Returns: JSON { ok, summary, details: { pixels, bounds?, context } }.\n' +
+          'Preconditions: active document and active pixel selection. Side effects: modifies selection.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pixels: {
+              type: 'number',
+              description: 'Pixels to contract by (minimum 1)',
+              minimum: 1,
+            },
+          },
+          required: ['pixels'],
+        },
+      },
+      handler: async (args) => contractSelection(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_feather_selection',
+        description:
+          'Feather (soften) the edges of the active pixel selection.\n\n' +
+          'Use when: soft transitions before fill, mask, or delete operations.\n' +
+          'Do NOT use when: a hard edge is required or no selection exists.\n\n' +
+          'Returns: JSON { ok, summary, details: { pixels, bounds?, context } }.\n' +
+          'Preconditions: active document and active pixel selection. Side effects: modifies selection edges.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pixels: {
+              type: 'number',
+              description: 'Feather radius in pixels (minimum 1)',
+              minimum: 1,
+            },
+          },
+          required: ['pixels'],
+        },
+      },
+      handler: async (args) => featherSelection(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_save_selection',
+        description:
+          'Save the active pixel selection to a new alpha channel.\n\n' +
+          'Use when: preserving a selection for later reload or batch workflows.\n' +
+          'Do NOT use when: no selection exists — create one first.\n\n' +
+          'Returns: JSON { ok, summary, details: { channel_name, context } }.\n' +
+          'Preconditions: active document and active pixel selection. Side effects: adds alpha channel.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            channel_name: {
+              type: 'string',
+              description: 'Optional name for the new alpha channel (auto-generated if omitted)',
+            },
+          },
+        },
+      },
+      handler: async (args) => saveSelection(connection, args),
+    },
     {
       tool: {
         name: 'photoshop_select_rectangle',
@@ -163,6 +341,198 @@ export function createSelectionTools(connection: PhotoshopConnection): ToolDefin
       handler: async () => contentAwareFill(connection),
     },
   ];
+}
+
+async function getSelectionBounds(connection: PhotoshopConnection): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.getSelectionBounds());
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    if (parsed.ok === false) {
+      const code = parsed.code === 'no_document' ? 'no_active_document' : 'extendscript_runtime_error';
+      return atomicFailure({
+        ok: false,
+        code,
+        message: String(parsed.message || 'Failed to read selection bounds'),
+        suggested_next_tool: 'photoshop_get_state',
+      });
+    }
+
+    const hasSelection = parsed.has_selection === true;
+    const details: Record<string, unknown> = {
+      has_selection: hasSelection,
+    };
+    if (hasSelection && parsed.bounds) {
+      details.bounds = parsed.bounds;
+    }
+    if (parsed.context !== undefined) {
+      details.context = parsed.context;
+    }
+
+    return atomicSuccess(
+      hasSelection ? 'Active pixel selection present' : 'No active pixel selection',
+      details,
+      hasSelection ? 'photoshop_get_preview' : 'photoshop_select_rectangle'
+    );
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function selectEllipse(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const left = args.left as number;
+  const top = args.top as number;
+  const right = args.right as number;
+  const bottom = args.bottom as number;
+
+  if (right <= left || bottom <= top) {
+    return atomicFailure({
+      ok: false,
+      code: 'invalid_arguments',
+      message: 'Invalid ellipse bounds: right must be greater than left and bottom greater than top',
+      suggested_next_tool: 'photoshop_get_selection_bounds',
+    });
+  }
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.selectEllipse(left, top, right, bottom));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    const failure = mapSelectionSnippetFailure(parsed);
+    if (failure) return failure;
+
+    return atomicSuccess('Elliptical selection created', parseSelectionBounds(parsed));
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function expandSelection(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const pixels = parseRequiredPixels(args);
+  if (pixels === null) {
+    return atomicFailure({
+      ok: false,
+      code: 'invalid_arguments',
+      message: 'pixels must be a finite number >= 1',
+      suggested_next_tool: 'photoshop_get_selection_bounds',
+    });
+  }
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.expandSelection(pixels));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    const failure = mapSelectionSnippetFailure(parsed);
+    if (failure) return failure;
+
+    return atomicSuccess(`Selection expanded by ${pixels}px`, parseSelectionBounds(parsed));
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function contractSelection(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const pixels = parseRequiredPixels(args);
+  if (pixels === null) {
+    return atomicFailure({
+      ok: false,
+      code: 'invalid_arguments',
+      message: 'pixels must be a finite number >= 1',
+      suggested_next_tool: 'photoshop_get_selection_bounds',
+    });
+  }
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.contractSelection(pixels));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    const failure = mapSelectionSnippetFailure(parsed);
+    if (failure) return failure;
+
+    return atomicSuccess(`Selection contracted by ${pixels}px`, parseSelectionBounds(parsed));
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function featherSelection(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const pixels = parseRequiredPixels(args);
+  if (pixels === null) {
+    return atomicFailure({
+      ok: false,
+      code: 'invalid_arguments',
+      message: 'pixels must be a finite number >= 1',
+      suggested_next_tool: 'photoshop_get_selection_bounds',
+    });
+  }
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.featherSelection(pixels));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    const failure = mapSelectionSnippetFailure(parsed);
+    if (failure) return failure;
+
+    return atomicSuccess(`Selection feathered by ${pixels}px`, parseSelectionBounds(parsed));
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function saveSelection(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const channelName =
+    typeof args.channel_name === 'string' && args.channel_name.length > 0
+      ? args.channel_name
+      : undefined;
+
+  try {
+    const raw = await runSnippet(connection, ExtendScriptSnippets.saveSelection(channelName));
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Snippet returned unparseable payload: ${String(raw)}`));
+    }
+
+    const failure = mapSelectionSnippetFailure(parsed);
+    if (failure) return failure;
+
+    const name = typeof parsed.channel_name === 'string' ? parsed.channel_name : channelName;
+    return atomicSuccess(
+      name ? `Selection saved to channel "${name}"` : 'Selection saved to new alpha channel',
+      parseSelectionBounds(parsed)
+    );
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
 }
 
 async function selectRectangle(

--- a/src/tools/smart-object-tools.ts
+++ b/src/tools/smart-object-tools.ts
@@ -1,0 +1,211 @@
+import { stat } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
+import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
+import { ExtendScriptSnippets } from '../api/extendscript.js';
+import { PhotoshopConnection } from '../platform/connection.js';
+import {
+  atomicFailureFromError,
+  atomicSuccess,
+  parseSnippetResult,
+  runSnippet,
+} from './atomic-shared.js';
+
+export function createSmartObjectTools(connection: PhotoshopConnection): ToolDefinition[] {
+  return [
+    {
+      tool: {
+        name: 'photoshop_convert_to_smart_object',
+        description:
+          'Convert the active layer (or a named layer) to an embedded Smart Object.\n\n' +
+          'Users often say: convert to smart object, make smart layer, embed layer.\n\n' +
+          'Use when: non-destructive transforms/filters are needed on a raster or shape layer.\n' +
+          'Do NOT use when: the layer is already a Smart Object — returns success with already_smart_object.\n' +
+          'Do NOT use on background layers — unlock or duplicate first.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, kind, already_smart_object? } }.\n' +
+          'Preconditions: active document; target layer must be selected or named. Side effects: one history step.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            layer_name: {
+              type: 'string',
+              description: 'Optional exact layer name (recursive search). Default: active layer.',
+            },
+          },
+        },
+      },
+      handler: async (args) => convertToSmartObject(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_replace_smart_object_contents',
+        description:
+          'Replace the embedded contents of a Smart Object layer from an image file. Preserves transforms, warps, and Smart Filters on the layer.\n\n' +
+          'Users often say: replace smart object, swap mockup screen, relink embedded file.\n\n' +
+          'Use when: updating a mockup or template Smart Object with a new asset file.\n' +
+          'Do NOT use when: the target is not a Smart Object — convert first or use photoshop_place_image.\n' +
+          'Do NOT use for linked Smart Objects that need Relink to File — this replaces embedded contents.\n\n' +
+          'Returns: JSON { ok, summary, details: { layer_name, file_path } }.\n' +
+          'Preconditions: Smart Object layer active or named; file_path must exist (absolute). Side effects: replaces embedded pixels.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            file_path: {
+              type: 'string',
+              description: 'Absolute path to the replacement image file (JPEG, PNG, PSD, etc.)',
+            },
+            layer_name: {
+              type: 'string',
+              description: 'Optional exact Smart Object layer name. Default: active layer.',
+            },
+          },
+          required: ['file_path'],
+        },
+      },
+      handler: async (args) => replaceSmartObjectContents(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_edit_smart_object_contents',
+        description:
+          'Open a Smart Object for editing (double-click / Edit Contents). The embedded .psb becomes the active document until you save and close it.\n\n' +
+          'Users often say: edit smart object, open embedded file, double-click smart layer.\n\n' +
+          'Use when: modifying pixels inside an embedded Smart Object non-destructively.\n' +
+          'Do NOT use when: replacing the whole asset — use photoshop_replace_smart_object_contents.\n\n' +
+          'Returns: JSON { ok, summary, details: { parent_document, embedded_document, layer_name } }.\n' +
+          'Preconditions: Smart Object layer active or named.\n' +
+          'Side effects: active document switches to the embedded .psb — save/close it to return to the parent document.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            layer_name: {
+              type: 'string',
+              description: 'Optional exact Smart Object layer name. Default: active layer.',
+            },
+          },
+        },
+      },
+      handler: async (args) => editSmartObjectContents(connection, args),
+    },
+    {
+      tool: {
+        name: 'photoshop_create_smart_object_via_copy',
+        description:
+          'Create an independent Smart Object via Copy — unlinked duplicate with its own embedded contents.\n\n' +
+          'Users often say: new smart object via copy, independent smart copy, duplicate smart object separately.\n\n' +
+          'Use when: you need a second Smart Object that does not share embedded data with the original.\n' +
+          'Do NOT use when: you want linked instances — use photoshop_duplicate_layer (Layer via Copy).\n\n' +
+          'Returns: JSON { ok, summary, details: { source_layer_name, new_layer_name, kind } }.\n' +
+          'Preconditions: Smart Object layer active or named. Side effects: adds a new Smart Object layer.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            layer_name: {
+              type: 'string',
+              description: 'Optional source Smart Object layer name. Default: active layer.',
+            },
+          },
+        },
+      },
+      handler: async (args) => createSmartObjectViaCopy(connection, args),
+    },
+  ];
+}
+
+async function runSmartObjectSnippet(
+  connection: PhotoshopConnection,
+  script: string,
+  successSummary: string,
+  detailsKeys?: string[]
+): Promise<ToolResult> {
+  try {
+    const raw = await runSnippet(connection, script);
+    const parsed = parseSnippetResult(raw);
+    if (!parsed) {
+      return atomicFailureFromError(new Error(`Unparseable Smart Object result: ${String(raw)}`));
+    }
+    if (parsed.ok === false) {
+      return atomicFailureFromError(new Error(String(parsed.message || 'Smart Object operation failed')));
+    }
+    const details: Record<string, unknown> = {};
+    if (detailsKeys) {
+      for (const key of detailsKeys) {
+        if (parsed[key] !== undefined) details[key] = parsed[key];
+      }
+    }
+    if (parsed.context !== undefined) details.context = parsed.context;
+    return atomicSuccess(successSummary, details);
+  } catch (error) {
+    return atomicFailureFromError(error);
+  }
+}
+
+async function convertToSmartObject(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const layerName = typeof args.layer_name === 'string' ? args.layer_name.trim() : undefined;
+  return runSmartObjectSnippet(
+    connection,
+    ExtendScriptSnippets.convertToSmartObject(layerName),
+    layerName ? `Layer "${layerName}" converted to Smart Object` : 'Active layer converted to Smart Object',
+    ['layer_name', 'kind', 'already_smart_object']
+  );
+}
+
+async function replaceSmartObjectContents(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const filePath = typeof args.file_path === 'string' ? args.file_path.trim() : '';
+  const layerName = typeof args.layer_name === 'string' ? args.layer_name.trim() : undefined;
+
+  if (!filePath) {
+    return atomicFailureFromError(new Error('file_path is required.'));
+  }
+  if (!isAbsolute(filePath)) {
+    return atomicFailureFromError(new Error('file_path must be an absolute path.'));
+  }
+
+  try {
+    await stat(filePath);
+  } catch (error) {
+    return atomicFailureFromError(
+      new Error(
+        `Replacement file not found: ${filePath} (${error instanceof Error ? error.message : String(error)})`
+      )
+    );
+  }
+
+  return runSmartObjectSnippet(
+    connection,
+    ExtendScriptSnippets.replaceSmartObjectContents(filePath, layerName),
+    `Smart Object contents replaced from ${filePath}`,
+    ['layer_name', 'file_path']
+  );
+}
+
+async function editSmartObjectContents(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const layerName = typeof args.layer_name === 'string' ? args.layer_name.trim() : undefined;
+  return runSmartObjectSnippet(
+    connection,
+    ExtendScriptSnippets.editSmartObjectContents(layerName),
+    'Smart Object opened for editing — active document is now the embedded contents',
+    ['parent_document', 'embedded_document', 'layer_name']
+  );
+}
+
+async function createSmartObjectViaCopy(
+  connection: PhotoshopConnection,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const layerName = typeof args.layer_name === 'string' ? args.layer_name.trim() : undefined;
+  return runSmartObjectSnippet(
+    connection,
+    ExtendScriptSnippets.createSmartObjectViaCopy(layerName),
+    'New Smart Object created via copy',
+    ['source_layer_name', 'new_layer_name', 'kind']
+  );
+}


### PR DESCRIPTION
## Summary
- Add 16 atomic MCP tools: Smart Object suite (4), selection read/modify (6), document session (2), clipping masks (2), and filters (high pass, smart blur).
- Centralize ExtendScript snippets with shared helpers; refactor `batch-mockup-replace` to reuse Smart Object replace logic.
- Sync agent-facing docs to 118 tools (102 atomic + 16 recipe) and 23 prompts (16 recipe + 7 guide), including `ps.csv_to_cards` and honest `keep_shadow` wording.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run build:server`
- [ ] `npm run verify:photoshop-prompts`
- [ ] With Photoshop running: `npm run test:mcp-all` (new phases 4b, 6a–6c, 7b, 10b)
- [ ] Spot-check Smart Object mockup replace recipe still works on a real PSD