### PR TITLE
Fix #29 and #31: blend/style/place/BG/document_id, generative prompt literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `photoshop_recipe_remove_background` falls back to Color Range on uniform/high-key studio backgrounds (`details.method`).
 - Optional `document_id` on mutating tools pins edits to a document from `get_state` / `list_documents`; `document.id` is included in context.
 - Drop shadow no longer sets a locale-specific "Linear" contour name; Color Range fallback writes both Lab min and max; `place_image` fails instead of silently skipping translate.
+- Wrap generative `prompt` values in ExtendScript string literals (`jsStringLiteral`); non-ASCII is `\uXXXX`-escaped so multi-word prompts no longer break JSX syntax ([#31](https://github.com/alisaitteke/photoshop-mcp/issues/31)).
 
 ## [1.7.3] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixes
+
+- Map `photoshop_set_layer_blend_mode` `COLOR` to ExtendScript `BlendMode.COLORBLEND`; Darker/Lighter Color fall back to Action Manager ([#29](https://github.com/alisaitteke/photoshop-mcp/issues/29)).
+- Fix `photoshop_apply_layer_style` drop shadow (and other styles) `putObject` class-id argument; Use Global Light is off so `angle` applies.
+- Treat `photoshop_place_image` `x`/`y` as absolute canvas top-left, not an offset from centered Place.
+- `photoshop_recipe_remove_background` falls back to Color Range on uniform/high-key studio backgrounds (`details.method`).
+- Optional `document_id` on mutating tools pins edits to a document from `get_state` / `list_documents`; `document.id` is included in context.
+
 ## [1.7.3] - 2026-08-25
 
 [v1.7.2...v1.7.3](https://github.com/alisaitteke/photoshop-mcp/compare/v1.7.2...v1.7.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Treat `photoshop_place_image` `x`/`y` as absolute canvas top-left, not an offset from centered Place.
 - `photoshop_recipe_remove_background` falls back to Color Range on uniform/high-key studio backgrounds (`details.method`).
 - Optional `document_id` on mutating tools pins edits to a document from `get_state` / `list_documents`; `document.id` is included in context.
+- Drop shadow no longer sets a locale-specific "Linear" contour name; Color Range fallback writes both Lab min and max; `place_image` fails instead of silently skipping translate.
 
 ## [1.7.3] - 2026-08-25
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,7 @@ photoshop-mcp/
 ## Design principles
 
 1. **Local-first** — API keys and OAuth tokens stay on disk; Photoshop runs locally.
-2. **State before action** — `photoshop_get_state` / `get_preview` / `get_capabilities` cheapen verification and vision checks.
+2. **State before action** — `photoshop_get_state` / `get_preview` / `get_capabilities` cheapen verification and vision checks. Mutating tools accept optional `document_id` so a Photoshop UI tab switch cannot retarget an edit.
 3. **Recipes over atomic chains** — fewer LLM turns, one undo per outcome.
 4. **Cross-platform parity** — same tool surface on macOS and Windows; platform quirks isolated in `src/platform/`.
 5. **Swappable AI providers** — registry pattern in `src/ui/providers/`; custom OpenAI-compatible endpoints supported.

--- a/docs/available-tools.md
+++ b/docs/available-tools.md
@@ -79,6 +79,8 @@ photoshop_set_active_document({ document_id: 42 })
 photoshop_set_active_document({ index: 0 })
 ```
 
+Mutating tools (and most document-scoped reads) also accept optional `document_id`. Pass the id from `photoshop_get_state` / `photoshop_list_documents` so a Photoshop UI tab switch cannot retarget the edit. Omitted = current active document (previous behavior). Unknown ids fail with `document_not_found`.
+
 #### `photoshop_save_document`
 Save the active document.
 
@@ -189,7 +191,7 @@ photoshop_set_layer_opacity({ opacity: 75 })
 Set the blend mode of the active layer.
 
 **Parameters:**
-- `blendMode` (string, required): Blend mode (NORMAL, MULTIPLY, SCREEN, OVERLAY, etc.)
+- `blendMode` (string, required): Photoshop UI blend-mode name (NORMAL, MULTIPLY, SCREEN, OVERLAY, COLOR, …)
 
 ```javascript
 // Example: Set blend mode to multiply
@@ -197,6 +199,8 @@ photoshop_set_layer_blend_mode({ blendMode: "MULTIPLY" })
 ```
 
 Available blend modes: NORMAL, DISSOLVE, DARKEN, MULTIPLY, COLORBURN, LINEARBURN, DARKERCOLOR, LIGHTEN, SCREEN, COLORDODGE, LINEARDODGE, LIGHTERCOLOR, OVERLAY, SOFTLIGHT, HARDLIGHT, VIVIDLIGHT, LINEARLIGHT, PINLIGHT, HARDMIX, DIFFERENCE, EXCLUSION, SUBTRACT, DIVIDE, HUE, SATURATION, COLOR, LUMINOSITY
+
+`COLOR` is the UI name for Color blend (colorize). The server maps it to ExtendScript `BlendMode.COLORBLEND`. `LUMINOSITY` is already the DOM name. `DARKERCOLOR` / `LIGHTERCOLOR` use Action Manager when the classic `BlendMode` enum does not expose them.
 
 #### `photoshop_set_layer_visibility`
 Show or hide the active layer.
@@ -945,11 +949,13 @@ Place an image file as a layer in the active document.
 
 **Parameters:**
 - `filePath` (string, required): Full path to the image file
-- `x` (number, optional): X position offset in pixels (default: 0)
-- `y` (number, optional): Y position offset in pixels (default: 0)
+- `x` (number, optional): Absolute canvas X of the placed layer **top-left**, in pixels (default: 0 = document left edge)
+- `y` (number, optional): Absolute canvas Y of the placed layer **top-left**, in pixels (default: 0 = document top edge)
+
+`x`/`y` are **not** an offset from Photoshop's default centered Place. After Place, the server translates the layer so `layer.bounds` top-left matches `(x, y)`.
 
 ```javascript
-// Example: Place an image at specific position
+// Example: Place so the layer's top-left sits at (100, 200)
 photoshop_place_image({
   filePath: "/Users/username/Pictures/photo.jpg",
   x: 100,
@@ -1010,7 +1016,7 @@ Apply a layer effect (Action Manager `layerEffects`) to the active layer.
 - `opacity` (number, optional): 0-100 (default 60)
 - `size` (number, optional): Blur/size in px — stroke width for stroke (default 10)
 - `distance` (number, optional): Offset in px, drop shadow only (default 8)
-- `angle` (number, optional): Light angle in degrees (default 120)
+- `angle` (number, optional): Light angle in degrees (default 120). Drop shadow uses this local angle (`Use Global Light` is off).
 
 ```javascript
 // Example: soft drop shadow on the active layer

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ npx -p @alisaitteke/photoshop-mcp photoshop-mcp-ui
 get_capabilities → get_state → (recipe or atomic tool) → get_preview to verify
 ```
 
-Prefer `photoshop_recipe_*` for multi-step outcomes (single undo step). Use atomic `photoshop_*` tools for fine-grained edits. On failure, read structured error envelopes (`code`, `suggested_next_tool`) and call `get_state` before retrying.
+Prefer `photoshop_recipe_*` for multi-step outcomes (single undo step). Use atomic `photoshop_*` tools for fine-grained edits. Capture `document.id` from `get_state` and pass it as `document_id` on mutating calls so a Photoshop UI tab switch cannot retarget the edit. On failure, read structured error envelopes (`code`, `suggested_next_tool`) and call `get_state` before retrying.
 
 ## MCP client configuration
 

--- a/scripts/test-all-mcp-tools.ts
+++ b/scripts/test-all-mcp-tools.ts
@@ -242,6 +242,8 @@ async function main(): Promise<void> {
   });
   await t.run('photoshop_set_layer_opacity', { opacity: 85 });
   await t.run('photoshop_set_layer_blend_mode', { blendMode: 'MULTIPLY' });
+  await t.run('photoshop_set_layer_blend_mode', { blendMode: 'COLOR' });
+  await t.run('photoshop_apply_layer_style', { style: 'drop_shadow' });
   await t.run('photoshop_set_layer_visibility', { visible: true });
   await t.run('photoshop_rename_layer', { name: 'MCP_Paint_Renamed' });
   await t.run('photoshop_duplicate_layer');
@@ -662,7 +664,7 @@ async function main(): Promise<void> {
   await t.run('photoshop_set_text_alignment', { alignment: 'CENTER' });
   await t.run('photoshop_update_text_content', { text: 'MCP Updated' });
 
-  console.log('\n=== Phase 10: Image placement ===');
+  console.log('\n=== Phase 10: Image placement (absolute top-left x/y) ===');
   await t.run('photoshop_place_image', { filePath: testPng, x: 400, y: 200 });
   await t.run('photoshop_open_image', { filePath: testPng });
   await t.run('photoshop_execute_script', {

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -663,12 +663,10 @@ export const ExtendScriptSnippets = {
     executeAction(cTID('Plc '), desc, DialogModes.NO);
 
     var layer = app.activeDocument.activeLayer;
-    try {
-      var placedBounds = layer.bounds;
-      var left = placedBounds[0].as('px');
-      var top = placedBounds[1].as('px');
-      layer.translate(targetX - left, targetY - top);
-    } catch (eMove) {}
+    var placedBounds = layer.bounds;
+    var left = placedBounds[0].as('px');
+    var top = placedBounds[1].as('px');
+    layer.translate(targetX - left, targetY - top);
     
     var result = {
       placed: true,
@@ -3222,9 +3220,6 @@ export const ExtendScriptSnippets = {
       fx.putUnitDouble(cTID('blur'), cTID('#Pxl'), ${size});
       fx.putUnitDouble(cTID('Nose'), cTID('#Prc'), 0);
       fx.putBoolean(cTID('AntA'), false);
-      var contour = new ActionDescriptor();
-      contour.putString(cTID('Nm  '), 'Linear');
-      fx.putObject(cTID('TrnS'), cTID('ShpC'), contour);
       fx.putBoolean(sTID('layerConceals'), true);
       effects.putObject(cTID('DrSh'), cTID('DrSh'), fx);`;
     } else if (style === 'outer_glow') {

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -126,6 +126,7 @@ function getContextInfo() {
 
     if (doc) {
       context.document = {};
+      try { context.document.id = doc.id; } catch (e) {}
       try { context.document.name = doc.name; } catch (e) {}
       try { context.document.width = doc.width.as('px'); } catch (e) {}
       try { context.document.height = doc.height.as('px'); } catch (e) {}
@@ -630,7 +631,9 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
-   * Place an image file as a layer
+   * Place an image file as a layer.
+   * x/y are absolute canvas coordinates for the placed layer's top-left bound
+   * (not an offset from Photoshop's default centered Place).
    */
   placeImage: (filePath: string, x = 0, y = 0) => `
     ${helperFunctions}
@@ -644,30 +647,41 @@ export const ExtendScriptSnippets = {
     if (!imageFile.exists) {
       throw new Error('Image file not found: ${jsString(filePath)}');
     }
+
+    var targetX = ${x};
+    var targetY = ${y};
     
-    // Place image using ActionDescriptor
     var desc = new ActionDescriptor();
     desc.putPath(cTID('null'), imageFile);
     desc.putEnumerated(cTID('FTcs'), cTID('QCSt'), cTID('Qcsa'));
     
     var offsetDesc = new ActionDescriptor();
-    offsetDesc.putUnitDouble(cTID('Hrzn'), cTID('#Pxl'), ${x});
-    offsetDesc.putUnitDouble(cTID('Vrtc'), cTID('#Pxl'), ${y});
+    offsetDesc.putUnitDouble(cTID('Hrzn'), cTID('#Pxl'), 0);
+    offsetDesc.putUnitDouble(cTID('Vrtc'), cTID('#Pxl'), 0);
     desc.putObject(cTID('Ofst'), cTID('Ofst'), offsetDesc);
     
     executeAction(cTID('Plc '), desc, DialogModes.NO);
+
+    var layer = app.activeDocument.activeLayer;
+    try {
+      var placedBounds = layer.bounds;
+      var left = placedBounds[0].as('px');
+      var top = placedBounds[1].as('px');
+      layer.translate(targetX - left, targetY - top);
+    } catch (eMove) {}
     
     var result = {
       placed: true,
       filePath: "${jsString(filePath)}",
-      position: { x: ${x}, y: ${y} },
+      position: { x: targetX, y: targetY, semantics: 'absolute_top_left' },
       context: getContextInfo()
     };
     try {
-      var layer = app.activeDocument.activeLayer;
       result.layerName = layer.name;
       var bounds = layer.bounds;
       result.layerBounds = {
+        left: bounds[0].as('px'),
+        top: bounds[1].as('px'),
         width: bounds[2].as('px') - bounds[0].as('px'),
         height: bounds[3].as('px') - bounds[1].as('px')
       };
@@ -1105,9 +1119,12 @@ export const ExtendScriptSnippets = {
   `,
 
   /**
-   * Set layer blend mode
+   * Set layer blend mode.
+   * `blendMode` is an ExtendScript BlendMode identifier (e.g. COLORBLEND, not COLOR).
+   * Darker Color / Lighter Color fall back to Action Manager when the DOM enum is absent.
    */
   setLayerBlendMode: (blendMode: string) => `
+    ${helperFunctions}
     ${getContextInfo}
     
     if (app.documents.length === 0) {
@@ -1115,8 +1132,31 @@ export const ExtendScriptSnippets = {
     }
     var doc = app.activeDocument;
     var layer = doc.activeLayer;
-    
-    layer.blendMode = BlendMode.${blendMode};
+    var token = "${jsString(blendMode)}";
+    var applied = false;
+    try {
+      if (typeof BlendMode !== 'undefined' && BlendMode[token] !== undefined) {
+        layer.blendMode = BlendMode[token];
+        applied = true;
+      }
+    } catch (eDom) {}
+    if (!applied) {
+      var amKey = {
+        DARKERCOLOR: 'darkerColor',
+        LIGHTERCOLOR: 'lighterColor',
+        COLORBLEND: 'color',
+        COLOR: 'color'
+      }[token];
+      if (!amKey) {
+        throw new Error('Invalid enumeration value: BlendMode.' + token);
+      }
+      var desc = new ActionDescriptor();
+      var ref = new ActionReference();
+      ref.putEnumerated(cTID('Lyr '), cTID('Ordn'), cTID('Trgt'));
+      desc.putReference(cTID('null'), ref);
+      desc.putEnumerated(cTID('Md  '), cTID('BlnM'), sTID(amKey));
+      executeAction(cTID('setd'), desc, DialogModes.NO);
+    }
     
     var result = { 
       updated: true,
@@ -3175,12 +3215,18 @@ export const ExtendScriptSnippets = {
       fx.putEnumerated(cTID('Md  '), cTID('BlnM'), cTID('Mltp'));
       fx.putObject(cTID('Clr '), cTID('RGBC'), rgb);
       fx.putUnitDouble(cTID('Opct'), cTID('#Prc'), ${opacity});
+      fx.putBoolean(cTID('uglg'), false);
       fx.putUnitDouble(cTID('lagl'), cTID('#Ang'), ${angle});
       fx.putUnitDouble(cTID('Dstn'), cTID('#Pxl'), ${distance});
       fx.putUnitDouble(cTID('Ckmt'), cTID('#Pxl'), 0);
       fx.putUnitDouble(cTID('blur'), cTID('#Pxl'), ${size});
-      fx.putBoolean(cTID('uglg'), true);
-      effects.putObject(cTID('DrSh'), fx);`;
+      fx.putUnitDouble(cTID('Nose'), cTID('#Prc'), 0);
+      fx.putBoolean(cTID('AntA'), false);
+      var contour = new ActionDescriptor();
+      contour.putString(cTID('Nm  '), 'Linear');
+      fx.putObject(cTID('TrnS'), cTID('ShpC'), contour);
+      fx.putBoolean(sTID('layerConceals'), true);
+      effects.putObject(cTID('DrSh'), cTID('DrSh'), fx);`;
     } else if (style === 'outer_glow') {
       styleDescriptor = `
       var fx = new ActionDescriptor();
@@ -3193,7 +3239,7 @@ export const ExtendScriptSnippets = {
       fx.putUnitDouble(cTID('Nose'), cTID('#Prc'), 0);
       fx.putUnitDouble(cTID('ShdN'), cTID('#Prc'), 0);
       fx.putBoolean(cTID('AntA'), true);
-      effects.putObject(cTID('OrGl'), fx);`;
+      effects.putObject(cTID('OrGl'), cTID('OrGl'), fx);`;
     } else if (style === 'stroke') {
       styleDescriptor = `
       var fx = new ActionDescriptor();
@@ -3205,7 +3251,7 @@ export const ExtendScriptSnippets = {
       fx.putUnitDouble(cTID('Sz  '), cTID('#Pxl'), ${size});
       fx.putObject(cTID('Clr '), cTID('RGBC'), rgb);
       fx.putBoolean(sTID('overprint'), false);
-      effects.putObject(sTID('frameFX'), fx);`;
+      effects.putObject(sTID('frameFX'), sTID('frameFX'), fx);`;
     } else {
       styleDescriptor = `
       var fx = new ActionDescriptor();
@@ -3226,7 +3272,7 @@ export const ExtendScriptSnippets = {
       fx.putEnumerated(cTID('sdwM'), cTID('BlnM'), cTID('Mltp'));
       fx.putObject(cTID('sdwC'), cTID('RGBC'), rgb);
       fx.putUnitDouble(cTID('sdwO'), cTID('#Prc'), ${opacity});
-      effects.putObject(cTID('ebbl'), fx);`;
+      effects.putObject(cTID('ebbl'), cTID('ebbl'), fx);`;
     }
     return `
     ${helperFunctions}

--- a/src/api/extendscript.ts
+++ b/src/api/extendscript.ts
@@ -3,7 +3,7 @@
  * ExtendScript is the legacy scripting API for Photoshop
  */
 
-import { jsString } from '../utils/js-string.js';
+import { jsString, jsStringLiteral } from '../utils/js-string.js';
 
 /**
  * Helper functions for character/string ID conversion
@@ -2026,7 +2026,7 @@ export const ExtendScriptSnippets = {
    * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/Selection/store.html
    */
   saveSelection: (channelName?: string) => {
-    const channelNameLiteral = channelName ? jsString(channelName) : 'null';
+    const channelNameLiteral = channelName ? jsStringLiteral(channelName) : 'null';
     return `
     ${helperFunctions}
     ${getContextInfo}
@@ -2940,7 +2940,7 @@ export const ExtendScriptSnippets = {
   `,
 
   generativeFill: (prompt: string) => {
-    const escaped = jsString(prompt);
+    const escaped = jsStringLiteral(prompt);
     return `
       ${helperFunctions}
       ${ExtendScriptSnippets.generativeHelpers()}
@@ -3036,8 +3036,8 @@ export const ExtendScriptSnippets = {
   `,
 
   generativeExpand: (direction: string, prompt: string) => {
-    const escaped = jsString(prompt);
-    const dir = jsString(direction);
+    const escaped = jsStringLiteral(prompt);
+    const dir = jsStringLiteral(direction);
     return `
       ${helperFunctions}
       ${ExtendScriptSnippets.generativeHelpers()}
@@ -3105,7 +3105,7 @@ export const ExtendScriptSnippets = {
   `,
 
   skyReplacement: (skyImagePath: string) => {
-    const escaped = jsString(skyImagePath);
+    const escaped = jsStringLiteral(skyImagePath);
     return `
       ${helperFunctions}
       ${ExtendScriptSnippets.generativeHelpers()}
@@ -3144,7 +3144,7 @@ export const ExtendScriptSnippets = {
   },
 
   generateImage: (prompt: string, width: number, height: number) => {
-    const escaped = jsString(prompt);
+    const escaped = jsStringLiteral(prompt);
     return `
       ${helperFunctions}
       ${ExtendScriptSnippets.generativeHelpers()}

--- a/src/api/photoshop-api.ts
+++ b/src/api/photoshop-api.ts
@@ -1,5 +1,6 @@
 import { Logger } from '../utils/logger.js';
 import { PhotoshopConnection } from '../platform/connection.js';
+import { documentGuardScript, getTargetDocumentId } from '../core/document-target.js';
 
 export type APIType = 'UXP' | 'ExtendScript';
 
@@ -102,6 +103,9 @@ class ExtendScriptPhotoshopAPI implements PhotoshopAPI {
     // textItem.position, doc.crop bounds, etc.) behaves consistently
     // regardless of the user's Photoshop preferences. The user's original
     // preferences are restored in the finally block.
+    const targetId = getTargetDocumentId();
+    const documentGuard =
+      typeof targetId === 'number' ? documentGuardScript(targetId) : '';
     return `
 (function() {
   var __originalRulerUnits = null;
@@ -133,6 +137,8 @@ class ExtendScriptPhotoshopAPI implements PhotoshopAPI {
   try {
     try { app.preferences.rulerUnits = Units.PIXELS; } catch (e) {}
     try { app.preferences.typeUnits = TypeUnits.POINTS; } catch (e) {}
+
+    ${documentGuard}
 
     var result = (function() {
       ${script}

--- a/src/core/document-target.ts
+++ b/src/core/document-target.ts
@@ -1,0 +1,90 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolHandler } from './tool-registry.js';
+
+const targetDocumentId = new AsyncLocalStorage<number | undefined>();
+
+/** Tools that already manage documents themselves, or never target a document. */
+export const DOCUMENT_ID_SCHEMA_EXCLUDES = new Set([
+  'photoshop_ping',
+  'photoshop_get_version',
+  'photoshop_get_capabilities',
+  'photoshop_list_documents',
+  'photoshop_set_active_document',
+]);
+
+export const DOCUMENT_ID_PROPERTY = {
+  type: 'number',
+  description:
+    'Optional Photoshop document id from photoshop_get_state / photoshop_list_documents. ' +
+    'When set, the tool activates that document before running so a UI tab switch cannot retarget the edit.',
+} as const;
+
+export function runWithDocumentId<T>(documentId: number | undefined, fn: () => T): T {
+  return targetDocumentId.run(documentId, fn);
+}
+
+export function getTargetDocumentId(): number | undefined {
+  return targetDocumentId.getStore();
+}
+
+export function parseDocumentIdArg(args: Record<string, unknown> | undefined): number | undefined {
+  const raw = args?.document_id;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return undefined;
+  return Math.trunc(raw);
+}
+
+export function wrapDocumentIdHandler(handler: ToolHandler): ToolHandler {
+  return async (args) => {
+    const documentId = parseDocumentIdArg(args);
+    return runWithDocumentId(documentId, () => handler(args));
+  };
+}
+
+type ObjectSchema = {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: string[];
+  [key: string]: unknown;
+};
+
+/** Inject optional `document_id` on tools that operate against the active document. */
+export function withOptionalDocumentId(tool: Tool): Tool {
+  if (DOCUMENT_ID_SCHEMA_EXCLUDES.has(tool.name)) return tool;
+  const schema = tool.inputSchema as ObjectSchema | undefined;
+  if (!schema || schema.type !== 'object') return tool;
+  const properties = schema.properties ?? {};
+  if (properties.document_id) return tool;
+  return {
+    ...tool,
+    inputSchema: {
+      ...schema,
+      type: 'object',
+      properties: {
+        ...properties,
+        document_id: { ...DOCUMENT_ID_PROPERTY },
+      },
+    },
+  };
+}
+
+/** ExtendScript prepended inside the execute wrapper when a target id is set. */
+export function documentGuardScript(documentId: number): string {
+  const id = Math.trunc(documentId);
+  return `
+    (function() {
+      var __mcp_targetDocId = ${id};
+      var __mcp_found = false;
+      for (var __mcp_di = 0; __mcp_di < app.documents.length; __mcp_di++) {
+        if (app.documents[__mcp_di].id === __mcp_targetDocId) {
+          app.activeDocument = app.documents[__mcp_di];
+          __mcp_found = true;
+          break;
+        }
+      }
+      if (!__mcp_found) {
+        throw new Error('document_not_found: no open document with id ' + __mcp_targetDocId);
+      }
+    })();
+  `;
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -12,6 +12,7 @@ import { ToolRegistry, ToolDefinition } from './tool-registry.js';
 import { PromptRegistry } from './prompt-registry.js';
 import { Session } from './session.js';
 import { wrapToolHandler } from '../errors/envelope.js';
+import { withOptionalDocumentId, wrapDocumentIdHandler } from './document-target.js';
 import { buildPhotoshopInstructions } from '../prompts/instructions.js';
 import { registerPhotoshopPrompts } from '../prompts/registry.js';
 import { createDocumentTools } from '../tools/document-tools.js';
@@ -77,9 +78,10 @@ export class PhotoshopMCPServer {
   }
 
   private registerToolDefinition(definition: ToolDefinition): void {
-    this.toolRegistry.register(definition.tool.name, {
-      tool: definition.tool,
-      handler: wrapToolHandler(definition.tool.name, definition.handler),
+    const tool = withOptionalDocumentId(definition.tool);
+    this.toolRegistry.register(tool.name, {
+      tool,
+      handler: wrapToolHandler(tool.name, wrapDocumentIdHandler(definition.handler)),
     });
   }
 

--- a/src/errors/envelope.ts
+++ b/src/errors/envelope.ts
@@ -37,6 +37,7 @@ const ERROR_PATTERNS: Array<{
   code: PhotoshopErrorCode;
   suggested_next_tool?: string;
 }> = [
+  { pattern: /document_not_found/i, code: 'document_not_found', suggested_next_tool: 'photoshop_list_documents' },
   { pattern: /no active document/i, code: 'no_active_document', suggested_next_tool: 'photoshop_get_state' },
   { pattern: /no documents/i, code: 'no_active_document', suggested_next_tool: 'photoshop_get_state' },
   { pattern: /no active layer/i, code: 'no_active_layer', suggested_next_tool: 'photoshop_get_layers' },

--- a/src/prompts/instructions.ts
+++ b/src/prompts/instructions.ts
@@ -18,6 +18,9 @@ State before action
   \`photoshop_get_state\` to confirm what is currently open. Treat its output as
   the source of truth for document dimensions, activeLayer, selection bounds and color
   mode.
+- Capture \`document.id\` from \`photoshop_get_state\` (or \`photoshop_list_documents\`)
+  and pass it as optional \`document_id\` on mutating tools. Photoshop's active tab
+  can change outside this integration; \`document_id\` pins the edit to that file.
 - For visual confirmation after meaningful edits, call
   \`photoshop_get_preview\` (cheap, side-effect free JPEG snapshot). Use it
   sparingly — once per major step, not per atomic tool.
@@ -52,6 +55,8 @@ Error recovery contract
   along with MCP's \`isError: true\`. When you see this, follow the
   \`suggested_next_tool\` hint instead of guessing or retrying blindly.
 - Common codes you should be ready to handle without asking the user:
+  - \`document_not_found\` — the \`document_id\` you passed is not open;
+    call \`photoshop_list_documents\` and retry with a current id.
   - \`no_active_document\` — call \`photoshop_open_image\` or
     \`photoshop_create_document\` first.
   - \`no_active_layer\` / \`layer_not_found\` — list layers with

--- a/src/prompts/templates/composite-blend.ts
+++ b/src/prompts/templates/composite-blend.ts
@@ -46,7 +46,7 @@ export const compositeBlendTemplate: PhotoshopPromptTemplate = {
     const pathWarning =
       imagePath === ''
         ? `   - WARNING: no image_path provided — ask the user for an absolute file path before placing.`
-        : `   - Place with { filePath: "${imagePath}" } at the correct offset (adjust x/y after preview).`;
+        : `   - Place with { filePath: "${imagePath}", x, y } where x/y are absolute canvas top-left pixels (0,0 = document corner).`;
 
     const text = [
       `Goal: Composite an external image into the active document with optional masking and blend mode.`,

--- a/src/prompts/templates/remove-background.ts
+++ b/src/prompts/templates/remove-background.ts
@@ -8,7 +8,7 @@ import {
 export const removeBackgroundTemplate: PhotoshopPromptTemplate = {
   name: 'ps.remove_background',
   description:
-    'Remove the background from the active layer using Select Subject, with an optional feather radius. The keep_shadow argument is accepted but does not yet create a shadow layer (recorded in the recipe response only). Users often say: remove background, cut out, isolate subject, transparent background, arka planı sil.',
+    'Remove the background from the active layer. Default path is Select Subject; uniform/high-key studio shots automatically fall back to Color Range. The keep_shadow argument is accepted but does not yet create a shadow layer (recorded in the recipe response only). Users often say: remove background, cut out, isolate subject, transparent background, arka planı sil.',
   arguments: [
     {
       name: 'feather_px',
@@ -28,13 +28,14 @@ export const removeBackgroundTemplate: PhotoshopPromptTemplate = {
     const keepShadow = argBool(args, 'keep_shadow', false);
 
     const text = [
-      `Goal: Remove the background from the subject on the active layer using Select Subject.`,
+      `Goal: Remove the background from the subject on the active layer (Select Subject, with Color Range fallback on uniform studio backgrounds).`,
       ``,
       `Plan:`,
       `1. Call \`photoshop_get_state\` to confirm an active document with a non-background active layer that contains a subject.`,
       `2. Call \`photoshop_get_capabilities\` only if you have not yet this session; verify \`select_subject_v2\` is available.`,
       `3. Call \`photoshop_recipe_remove_background\` with { feather_px: ${feather}, keep_shadow: ${keepShadow} }.`,
-      `   - The recipe runs Select Subject, inverts the selection, adds a layer mask, and applies the feather. keep_shadow is accepted but does not yet create a shadow layer (value is recorded in the response only).`,
+      `   - Default: Select Subject + layer mask. On uniform/high-key (product-on-white) backgrounds the recipe may switch to Color Range; check details.method.`,
+      `   - keep_shadow is accepted but does not yet create a shadow layer (value is recorded in the response only).`,
       `4. Call \`photoshop_get_preview\` to show the result against transparency.`,
       `5. If the mask edge needs refinement, ask the user before adding a refine-edge pass — that step is destructive on the mask.`,
       ``,

--- a/src/tools/blend-mode.ts
+++ b/src/tools/blend-mode.ts
@@ -1,0 +1,82 @@
+/**
+ * MCP blend-mode names (Photoshop UI) → ExtendScript BlendMode enum members.
+ *
+ * `COLOR` is the UI name; the DOM enum is `BlendMode.COLORBLEND`.
+ * @see https://theiviaxx.github.io/photoshop-docs/Photoshop/BlendMode/COLORBLEND.html
+ */
+
+export const LAYER_BLEND_MODE_ENUM = [
+  'NORMAL',
+  'DISSOLVE',
+  'DARKEN',
+  'MULTIPLY',
+  'COLORBURN',
+  'LINEARBURN',
+  'DARKERCOLOR',
+  'LIGHTEN',
+  'SCREEN',
+  'COLORDODGE',
+  'LINEARDODGE',
+  'LIGHTERCOLOR',
+  'OVERLAY',
+  'SOFTLIGHT',
+  'HARDLIGHT',
+  'VIVIDLIGHT',
+  'LINEARLIGHT',
+  'PINLIGHT',
+  'HARDMIX',
+  'DIFFERENCE',
+  'EXCLUSION',
+  'SUBTRACT',
+  'DIVIDE',
+  'HUE',
+  'SATURATION',
+  'COLOR',
+  'LUMINOSITY',
+] as const;
+
+export type LayerBlendMode = (typeof LAYER_BLEND_MODE_ENUM)[number];
+
+/** UI / schema token → ExtendScript `BlendMode.*` identifier (or AM fallback token). */
+const TO_EXTENDSCRIPT: Record<string, string> = {
+  NORMAL: 'NORMAL',
+  DISSOLVE: 'DISSOLVE',
+  DARKEN: 'DARKEN',
+  MULTIPLY: 'MULTIPLY',
+  COLORBURN: 'COLORBURN',
+  LINEARBURN: 'LINEARBURN',
+  DARKERCOLOR: 'DARKERCOLOR',
+  LIGHTEN: 'LIGHTEN',
+  SCREEN: 'SCREEN',
+  COLORDODGE: 'COLORDODGE',
+  LINEARDODGE: 'LINEARDODGE',
+  LIGHTERCOLOR: 'LIGHTERCOLOR',
+  OVERLAY: 'OVERLAY',
+  SOFTLIGHT: 'SOFTLIGHT',
+  HARDLIGHT: 'HARDLIGHT',
+  VIVIDLIGHT: 'VIVIDLIGHT',
+  LINEARLIGHT: 'LINEARLIGHT',
+  PINLIGHT: 'PINLIGHT',
+  HARDMIX: 'HARDMIX',
+  DIFFERENCE: 'DIFFERENCE',
+  EXCLUSION: 'EXCLUSION',
+  SUBTRACT: 'SUBTRACT',
+  DIVIDE: 'DIVIDE',
+  HUE: 'HUE',
+  SATURATION: 'SATURATION',
+  COLOR: 'COLORBLEND',
+  COLORBLEND: 'COLORBLEND',
+  LUMINOSITY: 'LUMINOSITY',
+  PASSTHROUGH: 'PASSTHROUGH',
+};
+
+/**
+ * Resolve a caller blend-mode token to a safe ExtendScript identifier.
+ * Returns null for unknown or non-alphabetic values (never interpolate those).
+ */
+export function resolveLayerBlendMode(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const key = raw.trim().toUpperCase();
+  if (!/^[A-Z]+$/.test(key)) return null;
+  return TO_EXTENDSCRIPT[key] ?? null;
+}

--- a/src/tools/image-placement-tools.ts
+++ b/src/tools/image-placement-tools.ts
@@ -10,9 +10,11 @@ export function createImagePlacementTools(connection: PhotoshopConnection): Tool
         name: 'photoshop_place_image',
         description:
           'Place an external image file as a new layer in the active document.\n\n' +
-          'Use when: compositing assets into an open document at a specific offset.\n' +
+          'x/y are absolute canvas coordinates for the placed layer\'s top-left bound in pixels ' +
+          '(0,0 = document top-left). They are NOT an offset from Photoshop\'s default centered Place.\n\n' +
+          'Use when: compositing assets into an open document at a known position.\n' +
           'Do NOT use when: opening a file as a new document — use photoshop_open_image.\n\n' +
-          'Returns: placed layer name, bounds, and context.\n' +
+          'Returns: placed layer name, bounds, and position.semantics = absolute_top_left.\n' +
           'Preconditions: active document; file must exist. Side effects: adds a new layer.',
         inputSchema: {
           type: 'object',
@@ -23,12 +25,12 @@ export function createImagePlacementTools(connection: PhotoshopConnection): Tool
             },
             x: {
               type: 'number',
-              description: 'X position offset in pixels (default: 0)',
+              description: 'Absolute canvas X of the placed layer top-left, in pixels (default: 0)',
               default: 0,
             },
             y: {
               type: 'number',
-              description: 'Y position offset in pixels (default: 0)',
+              description: 'Absolute canvas Y of the placed layer top-left, in pixels (default: 0)',
               default: 0,
             },
           },
@@ -67,8 +69,8 @@ async function placeImage(
   args: Record<string, unknown>
 ): Promise<ToolResult> {
   const filePath = args.filePath as string;
-  const x = (args.x as number) || 0;
-  const y = (args.y as number) || 0;
+  const x = typeof args.x === 'number' && Number.isFinite(args.x) ? args.x : 0;
+  const y = typeof args.y === 'number' && Number.isFinite(args.y) ? args.y : 0;
 
   try {
     const apiFactory = new PhotoshopAPIFactory(connection);
@@ -81,7 +83,7 @@ async function placeImage(
       content: [
         {
           type: 'text' as const,
-          text: `Image placed successfully: ${filePath}\nPosition: (${x}, ${y})\nResult: ${JSON.stringify(result)}`,
+          text: `Image placed successfully: ${filePath}\nPosition (absolute top-left): (${x}, ${y})\nResult: ${JSON.stringify(result)}`,
         },
       ],
     };

--- a/src/tools/layer-properties-tools.ts
+++ b/src/tools/layer-properties-tools.ts
@@ -2,6 +2,7 @@ import { ToolDefinition, ToolResult } from '../core/tool-registry.js';
 import { PhotoshopConnection } from '../platform/connection.js';
 import { PhotoshopAPIFactory } from '../api/photoshop-api.js';
 import { ExtendScriptSnippets } from '../api/extendscript.js';
+import { LAYER_BLEND_MODE_ENUM, resolveLayerBlendMode } from './blend-mode.js';
 
 export function createLayerPropertiesTools(connection: PhotoshopConnection): ToolDefinition[] {
   return [
@@ -38,42 +39,18 @@ export function createLayerPropertiesTools(connection: PhotoshopConnection): Too
     {
       tool: {
         name: 'photoshop_set_layer_blend_mode',
-        description: 'Set the blend mode of the active layer',
+        description:
+          'Set the blend mode of the active layer.\n\n' +
+          '`COLOR` is the Photoshop UI name (Colorize); it is mapped to ExtendScript `BlendMode.COLORBLEND`.',
         inputSchema: {
           type: 'object',
           properties: {
             blendMode: {
               type: 'string',
-              description: 'Blend mode name',
-              enum: [
-                'NORMAL',
-                'DISSOLVE',
-                'DARKEN',
-                'MULTIPLY',
-                'COLORBURN',
-                'LINEARBURN',
-                'DARKERCOLOR',
-                'LIGHTEN',
-                'SCREEN',
-                'COLORDODGE',
-                'LINEARDODGE',
-                'LIGHTERCOLOR',
-                'OVERLAY',
-                'SOFTLIGHT',
-                'HARDLIGHT',
-                'VIVIDLIGHT',
-                'LINEARLIGHT',
-                'PINLIGHT',
-                'HARDMIX',
-                'DIFFERENCE',
-                'EXCLUSION',
-                'SUBTRACT',
-                'DIVIDE',
-                'HUE',
-                'SATURATION',
-                'COLOR',
-                'LUMINOSITY',
-              ],
+              description:
+                'Blend mode (Photoshop UI name). COLOR maps to BlendMode.COLORBLEND. ' +
+                'DARKERCOLOR / LIGHTERCOLOR use Action Manager if the DOM enum is missing.',
+              enum: [...LAYER_BLEND_MODE_ENUM],
             },
           },
           required: ['blendMode'],
@@ -213,20 +190,32 @@ async function setLayerBlendMode(
   connection: PhotoshopConnection,
   args: Record<string, unknown>
 ): Promise<ToolResult> {
-  const blendMode = args.blendMode as string;
+  const requested = typeof args.blendMode === 'string' ? args.blendMode : '';
+  const extendScriptToken = resolveLayerBlendMode(requested);
+  if (!extendScriptToken) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Error setting blend mode: unknown blendMode "${requested}"`,
+        },
+      ],
+      isError: true,
+    };
+  }
 
   try {
     const apiFactory = new PhotoshopAPIFactory(connection);
     const api = await apiFactory.createAPI();
 
-    const script = ExtendScriptSnippets.setLayerBlendMode(blendMode);
+    const script = ExtendScriptSnippets.setLayerBlendMode(extendScriptToken);
     await api.executeScript(script);
 
     return {
       content: [
         {
           type: 'text' as const,
-          text: `Layer blend mode set to ${blendMode}`,
+          text: `Layer blend mode set to ${requested}`,
         },
       ],
     };

--- a/src/tools/recipes/remove-background.ts
+++ b/src/tools/recipes/remove-background.ts
@@ -144,6 +144,14 @@ async function runRemoveBackground(
       }
     }
 
+    function __mcp_labColorDesc(sc) {
+      var cDesc = new ActionDescriptor();
+      cDesc.putDouble(charIDToTypeID('Lmnc'), sc.lab.l);
+      cDesc.putDouble(charIDToTypeID('A   '), sc.lab.a);
+      cDesc.putDouble(charIDToTypeID('B   '), sc.lab.b);
+      return cDesc;
+    }
+
     function __mcp_colorRangeFromRgb(r, g, b, fuzziness) {
       var sc = new SolidColor();
       sc.rgb.red = r;
@@ -151,11 +159,9 @@ async function runRemoveBackground(
       sc.rgb.blue = b;
       var desc = new ActionDescriptor();
       desc.putInteger(charIDToTypeID('Fzns'), fuzziness);
-      var cDesc = new ActionDescriptor();
-      cDesc.putDouble(charIDToTypeID('Lmnc'), sc.lab.l);
-      cDesc.putDouble(charIDToTypeID('A   '), sc.lab.a);
-      cDesc.putDouble(charIDToTypeID('B   '), sc.lab.b);
-      desc.putObject(charIDToTypeID('Mnm '), charIDToTypeID('LbCl'), cDesc);
+      var lab = __mcp_labColorDesc(sc);
+      desc.putObject(charIDToTypeID('Mnm '), charIDToTypeID('LbCl'), lab);
+      desc.putObject(charIDToTypeID('Mxm '), charIDToTypeID('LbCl'), __mcp_labColorDesc(sc));
       desc.putInteger(stringIDToTypeID('colorModel'), 0);
       executeAction(charIDToTypeID('ClrR'), desc, DialogModes.NO);
     }

--- a/src/tools/recipes/remove-background.ts
+++ b/src/tools/recipes/remove-background.ts
@@ -10,16 +10,16 @@ export function bindRemoveBackground(connection: PhotoshopConnection): ToolDefin
     tool: {
       name: TOOL_NAME,
       description:
-        'One-shot background removal: runs Select Subject on the active layer, inverts the selection, attaches a layer mask, and applies an optional feather. Wrapped in a single undoable history step.\n' +
+        'One-shot background removal: Select Subject by default, with an automatic Color Range fallback for uniform/high-key studio backgrounds (product-on-white). Attaches a layer mask (source pixels kept). Wrapped in a single undoable history step.\n' +
         '\n' +
         'Users often say: cut out, isolate subject, remove background, transparent background, arka planı sil.\n' +
         '\n' +
-        'Use when: the user wants the subject isolated from the background non-destructively. The source pixels are preserved behind the mask.\n' +
+        'Use when: the user wants the subject isolated from the background non-destructively.\n' +
         'Do NOT use when: the subject is extremely fine-edged (hair against a busy background) — propose a manual Refine Edge pass afterwards.\n' +
         '\n' +
-        'Returns: { ok, summary, undo_history_states_consumed, details }. On failure, an error envelope with code and suggested_next_tool.\n' +
+        'Returns: { ok, summary, undo_history_states_consumed, details.method = select_subject | color_range_fallback }.\n' +
         '\n' +
-        'Preconditions: PS ≥ 23 (Select Subject v2). Active document with a non-background active layer that contains a subject.\n' +
+        'Preconditions: PS ≥ 23 (Select Subject v2) for the default path; Color Range fallback still runs on uniform studio shots if Select Subject is loose or empty.\n' +
         'Side effects: attaches a pixel mask to the active layer; no pixels destroyed; one undo reverts everything.',
       inputSchema: {
         type: 'object',
@@ -80,26 +80,143 @@ async function runRemoveBackground(
     }
 
     app.displayDialogs = DialogModes.NO;
-    var subjectSelected = false;
-    try {
-      doc.selection.selectSubject();
-      subjectSelected = true;
-    } catch (eDomSubject) {}
-    if (!subjectSelected) {
+
+    function __mcp_sampleRgb(x, y) {
+      var sampler = doc.colorSamplers.add([UnitValue(x, 'px'), UnitValue(y, 'px')]);
+      try {
+        var c = sampler.color.rgb;
+        return { r: c.red, g: c.green, b: c.blue };
+      } finally {
+        sampler.remove();
+      }
+    }
+
+    function __mcp_detectStudio() {
+      var w = doc.width.as('px');
+      var h = doc.height.as('px');
+      var inset = 5;
+      if (w < inset * 2 || h < inset * 2) {
+        return { uniform: false, highKey: false, samples: [] };
+      }
+      var pts = [[inset, inset], [w - inset, inset], [inset, h - inset], [w - inset, h - inset]];
+      var samples = [];
+      try {
+        for (var i = 0; i < pts.length; i++) {
+          samples.push(__mcp_sampleRgb(pts[i][0], pts[i][1]));
+        }
+      } catch (eSample) {
+        return { uniform: false, highKey: false, samples: samples };
+      }
+      var maxDelta = 0;
+      var avgL = 0;
+      var chroma = 0;
+      for (var s = 0; s < samples.length; s++) {
+        var lum = 0.2126 * samples[s].r + 0.7152 * samples[s].g + 0.0722 * samples[s].b;
+        avgL += lum;
+        var mean = (samples[s].r + samples[s].g + samples[s].b) / 3;
+        chroma = Math.max(chroma, Math.abs(samples[s].r - mean), Math.abs(samples[s].g - mean), Math.abs(samples[s].b - mean));
+        for (var t = s + 1; t < samples.length; t++) {
+          maxDelta = Math.max(maxDelta, Math.abs(samples[s].r - samples[t].r), Math.abs(samples[s].g - samples[t].g), Math.abs(samples[s].b - samples[t].b));
+        }
+      }
+      avgL = avgL / samples.length;
+      return { uniform: maxDelta <= 18 && chroma <= 12, highKey: avgL >= 230, samples: samples };
+    }
+
+    function __mcp_hasSel() {
+      try { return doc.selection.bounds != null; } catch (e) { return false; }
+    }
+
+    function __mcp_selectionLooksLoose() {
+      try {
+        var b = doc.selection.bounds;
+        var left = b[0].as('px');
+        var top = b[1].as('px');
+        var right = b[2].as('px');
+        var bottom = b[3].as('px');
+        var w = doc.width.as('px');
+        var h = doc.height.as('px');
+        var coverage = ((right - left) * (bottom - top)) / (w * h);
+        var touchesEdge = left <= 8 || top <= 8 || right >= w - 8 || bottom >= h - 8;
+        return coverage >= 0.55 || touchesEdge;
+      } catch (eLoose) {
+        return true;
+      }
+    }
+
+    function __mcp_colorRangeFromRgb(r, g, b, fuzziness) {
+      var sc = new SolidColor();
+      sc.rgb.red = r;
+      sc.rgb.green = g;
+      sc.rgb.blue = b;
+      var desc = new ActionDescriptor();
+      desc.putInteger(charIDToTypeID('Fzns'), fuzziness);
+      var cDesc = new ActionDescriptor();
+      cDesc.putDouble(charIDToTypeID('Lmnc'), sc.lab.l);
+      cDesc.putDouble(charIDToTypeID('A   '), sc.lab.a);
+      cDesc.putDouble(charIDToTypeID('B   '), sc.lab.b);
+      desc.putObject(charIDToTypeID('Mnm '), charIDToTypeID('LbCl'), cDesc);
+      desc.putInteger(stringIDToTypeID('colorModel'), 0);
+      executeAction(charIDToTypeID('ClrR'), desc, DialogModes.NO);
+    }
+
+    function __mcp_tryColorRange(samples) {
+      if (!samples || samples.length === 0) return false;
+      var r = 0, g = 0, b = 0;
+      for (var i = 0; i < samples.length; i++) {
+        r += samples[i].r; g += samples[i].g; b += samples[i].b;
+      }
+      r = r / samples.length; g = g / samples.length; b = b / samples.length;
+      try { doc.selection.deselect(); } catch (eD) {}
+      __mcp_colorRangeFromRgb(r, g, b, 48);
+      doc.selection.invert();
+      return __mcp_hasSel();
+    }
+
+    function __mcp_trySelectSubject() {
+      try {
+        doc.selection.selectSubject();
+        return true;
+      } catch (eDomSubject) {}
       try {
         var cutoutDesc = new ActionDescriptor();
         cutoutDesc.putBoolean(stringIDToTypeID('sampleAllLayers'), false);
         executeAction(stringIDToTypeID('autoCutout'), cutoutDesc, DialogModes.NO);
-        subjectSelected = true;
+        return true;
       } catch (eSelectSubject) {
-        return { ok: false, code: 'generative_unavailable', message: 'Select Subject is not available: ' + (eSelectSubject.message || eSelectSubject), suggested_next_tool: 'photoshop_get_capabilities' };
+        return false;
       }
     }
 
-    var hasSel = false;
-    try { hasSel = doc.selection.bounds != null; } catch (e) { hasSel = false; }
+    var studio = __mcp_detectStudio();
+    var method = 'select_subject';
+    var subjectOk = __mcp_trySelectSubject();
+    var hasSel = subjectOk && __mcp_hasSel();
+
+    var preferColorRange = studio.uniform && (studio.highKey || !hasSel || __mcp_selectionLooksLoose());
+    if (preferColorRange) {
+      var crOk = false;
+      try {
+        crOk = __mcp_tryColorRange(studio.samples);
+      } catch (eCR) {
+        crOk = false;
+      }
+      if (crOk) {
+        method = 'color_range_fallback';
+        hasSel = true;
+      } else if (!hasSel) {
+        subjectOk = __mcp_trySelectSubject();
+        hasSel = subjectOk && __mcp_hasSel();
+        method = 'select_subject';
+      } else {
+        try { __mcp_trySelectSubject(); } catch (eRe) {}
+        hasSel = __mcp_hasSel();
+        method = 'select_subject';
+      }
+    }
+
     if (!hasSel) {
-      return { ok: false, code: 'selection_required', message: 'Select Subject produced no selection — the layer may not contain a recognizable subject.' };
+      return { ok: false, code: 'selection_required', message: 'Could not isolate the subject (Select Subject empty; Color Range fallback did not produce a selection).', suggested_next_tool: 'photoshop_get_preview' };
     }
 
     if (${feather} > 0) {
@@ -108,15 +225,17 @@ async function runRemoveBackground(
 
     __mcp_makeLayerMaskRevealSelection();
 
+    var methodLabel = method === 'color_range_fallback' ? 'Color Range (uniform studio fallback)' : 'Select Subject';
     return {
       ok: true,
-      summary: 'Background removed via Select Subject + layer mask' + (${feather} > 0 ? ' (feather ' + ${feather} + 'px)' : ''),
+      summary: 'Background removed via ' + methodLabel + ' + layer mask' + (${feather} > 0 ? ' (feather ' + ${feather} + 'px)' : ''),
       undo_history_states_consumed: 1,
       next_suggested_tool: 'photoshop_get_preview',
       details: {
         feather_px: ${feather},
         keep_shadow: ${keepShadow ? 'true' : 'false'},
-        layer_name: layer.name
+        layer_name: layer.name,
+        method: method
       }
     };
   `;

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -24,7 +24,7 @@ export function createStateTools(connection: PhotoshopConnection): ToolDefinitio
           'Return a cheap read-only snapshot of Photoshop session state (active document, layer, selection).\n\n' +
           'Use when: before any tool that needs an active document/layer, or after an error to recover context.\n' +
           'Do NOT use when: you only need a visual preview — use photoshop_get_preview instead.\n\n' +
-          'Returns: JSON with hasDocument, document dimensions/colorMode, activeLayer kind/name, hasSelection.\n' +
+          'Returns: JSON with hasDocument, document.id/name/dimensions/colorMode, activeLayer kind/name, hasSelection. Capture document.id and pass it as document_id on later mutating calls.\n' +
           'Preconditions: none (safe on empty session). Side effects: none.',
         inputSchema: { type: 'object', properties: {} },
       },

--- a/src/tools/style-tools.ts
+++ b/src/tools/style-tools.ts
@@ -34,7 +34,7 @@ export function createStyleTools(connection: PhotoshopConnection): ToolDefinitio
           'Use when: quick presentational effects on the active layer (cards, buttons, mockups, text pop).\n' +
           'Do NOT use when: you need full custom layer-effects control — use photoshop_execute_script with a custom layerEffects descriptor.\n\n' +
           'Returns: JSON { ok, summary, details: { style, layer_name } }.\n' +
-          'Preconditions: active document with an active pixel/text layer. Side effects: sets the chosen effect on the active layer.',
+          'Preconditions: active document with an active pixel/text layer. Side effects: sets the chosen effect on the active layer. Drop shadow uses the given `angle` (Use Global Light is off).',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/utils/js-string.ts
+++ b/src/utils/js-string.ts
@@ -4,10 +4,15 @@ export function jsString(value: string): string {
     .replace(/"/g, '\\"')
     .replace(/\n/g, '\\n')
     .replace(/\r/g, '\\r')
-    // Remaining C0 controls plus U+2028/U+2029: ExtendScript (ES3) treats the
-    // latter as line terminators, so raw occurrences break the string literal.
-    // eslint-disable-next-line no-control-regex -- stripping control chars is the point
-    .replace(/[\u0000-\u001f\u2028\u2029]/g, (ch) => {
+    // Remaining non-ASCII-printable: C0/DEL, U+2028/U+2029 (ES3 line
+    // terminators), and any other non-ASCII so Windows cscript/ANSI codepages
+    // cannot mangle prompts when the generated JSX is echoed or re-read.
+    .replace(/[^\x20-\x7e]/g, (ch) => {
       return '\\u' + ch.charCodeAt(0).toString(16).padStart(4, '0');
     });
+}
+
+/** Complete double-quoted ExtendScript string literal. Prefer this over interpolating `jsString` raw. */
+export function jsStringLiteral(value: string): string {
+  return `"${jsString(value)}"`;
 }

--- a/tests/blend-mode.test.ts
+++ b/tests/blend-mode.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { LAYER_BLEND_MODE_ENUM, resolveLayerBlendMode } from '../src/tools/blend-mode.js';
+
+describe('resolveLayerBlendMode', () => {
+  it('maps COLOR to COLORBLEND (ExtendScript DOM name)', () => {
+    expect(resolveLayerBlendMode('COLOR')).toBe('COLORBLEND');
+  });
+
+  it('accepts COLORBLEND as an alias', () => {
+    expect(resolveLayerBlendMode('COLORBLEND')).toBe('COLORBLEND');
+  });
+
+  it('passes LUMINOSITY through unchanged', () => {
+    expect(resolveLayerBlendMode('LUMINOSITY')).toBe('LUMINOSITY');
+  });
+
+  it('keeps DARKERCOLOR / LIGHTERCOLOR as Action Manager fallback tokens', () => {
+    expect(resolveLayerBlendMode('DARKERCOLOR')).toBe('DARKERCOLOR');
+    expect(resolveLayerBlendMode('LIGHTERCOLOR')).toBe('LIGHTERCOLOR');
+  });
+
+  it('rejects unknown or unsafe tokens', () => {
+    expect(resolveLayerBlendMode('NOTAMODE')).toBeNull();
+    expect(resolveLayerBlendMode('NORMAL;hack')).toBeNull();
+    expect(resolveLayerBlendMode(12)).toBeNull();
+  });
+
+  it('covers every schema enum value', () => {
+    for (const name of LAYER_BLEND_MODE_ENUM) {
+      expect(resolveLayerBlendMode(name)).toBeTruthy();
+    }
+  });
+});

--- a/tests/document-target.test.ts
+++ b/tests/document-target.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import {
+  DOCUMENT_ID_SCHEMA_EXCLUDES,
+  documentGuardScript,
+  parseDocumentIdArg,
+  withOptionalDocumentId,
+} from '../src/core/document-target.js';
+
+function fakeTool(name: string, properties: Record<string, unknown> = {}): Tool {
+  return {
+    name,
+    description: 'test',
+    inputSchema: { type: 'object', properties },
+  };
+}
+
+describe('withOptionalDocumentId', () => {
+  it('injects document_id on mutating tools', () => {
+    const next = withOptionalDocumentId(fakeTool('photoshop_delete_layer'));
+    const schema = next.inputSchema as { properties: Record<string, { type: string }> };
+    expect(schema.properties.document_id.type).toBe('number');
+  });
+
+  it('does not inject on excluded tools', () => {
+    for (const name of DOCUMENT_ID_SCHEMA_EXCLUDES) {
+      const next = withOptionalDocumentId(fakeTool(name));
+      const schema = next.inputSchema as { properties: Record<string, unknown> };
+      expect(schema.properties.document_id).toBeUndefined();
+    }
+  });
+
+  it('does not overwrite an existing document_id property', () => {
+    const next = withOptionalDocumentId(
+      fakeTool('photoshop_export_layers', {
+        document_id: { type: 'string', description: 'already there' },
+      })
+    );
+    const schema = next.inputSchema as { properties: Record<string, { type: string }> };
+    expect(schema.properties.document_id.type).toBe('string');
+  });
+});
+
+describe('parseDocumentIdArg', () => {
+  it('truncates finite numbers', () => {
+    expect(parseDocumentIdArg({ document_id: 12.9 })).toBe(12);
+  });
+
+  it('rejects non-numbers', () => {
+    expect(parseDocumentIdArg({})).toBeUndefined();
+    expect(parseDocumentIdArg({ document_id: '1' })).toBeUndefined();
+  });
+});
+
+describe('documentGuardScript', () => {
+  it('embeds the numeric id and document_not_found error', () => {
+    const script = documentGuardScript(42);
+    expect(script).toContain('var __mcp_targetDocId = 42;');
+    expect(script).toContain('document_not_found');
+  });
+});

--- a/tests/generative-prompt-literal.test.ts
+++ b/tests/generative-prompt-literal.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { ExtendScriptSnippets } from '../src/api/extendscript.js';
+
+const MULTI_WORD = 'Photorealistic, highly detailed São Paulo city skyline';
+const QUOTED_PROMPT = '"Photorealistic, highly detailed S\\u00e3o Paulo city skyline"';
+
+describe('generative prompt string literals', () => {
+  it('wraps generativeFill prompt in a real JS string (issue #31)', () => {
+    const jsx = ExtendScriptSnippets.generativeFill(MULTI_WORD);
+    expect(jsx).toContain(`desc.putString(sTID('prompt'), ${QUOTED_PROMPT})`);
+    expect(jsx).not.toMatch(/putString\(sTID\('prompt'\), Photorealistic/);
+  });
+
+  it('escapes caller-supplied quotes instead of treating them as delimiters', () => {
+    const jsx = ExtendScriptSnippets.generativeFill('say "hi"');
+    expect(jsx).toContain(`desc.putString(sTID('prompt'), "say \\"hi\\"")`);
+  });
+
+  it('wraps generativeExpand prompt and direction', () => {
+    const jsx = ExtendScriptSnippets.generativeExpand('all', MULTI_WORD);
+    expect(jsx).toContain(`desc.putString(sTID('prompt'), ${QUOTED_PROMPT})`);
+    expect(jsx).toContain(`desc.putString(sTID('direction'), "all")`);
+  });
+
+  it('wraps generateImage prompt', () => {
+    const jsx = ExtendScriptSnippets.generateImage(MULTI_WORD, 1024, 1024);
+    expect(jsx).toContain(`desc.putString(sTID('prompt'), ${QUOTED_PROMPT})`);
+  });
+
+  it('wraps skyReplacement path for File()', () => {
+    const jsx = ExtendScriptSnippets.skyReplacement('C:\\Skies\\blue sky.psd');
+    expect(jsx).toContain('var skyFile = new File("C:\\\\Skies\\\\blue sky.psd")');
+  });
+});

--- a/tests/js-string.test.ts
+++ b/tests/js-string.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { jsString } from '../src/utils/js-string.js';
+import { jsString, jsStringLiteral } from '../src/utils/js-string.js';
 
 // Characters built via fromCharCode so no raw control/line-terminator bytes
 // end up in this source file.
@@ -46,5 +46,20 @@ describe('jsString', () => {
     // ...and must evaluate back to the exact original string.
     // eslint-disable-next-line no-eval
     expect(eval(`"${literal}"`)).toBe(nasty);
+  });
+
+  it('escapes non-ASCII as \\uXXXX so Windows codepages cannot mangle prompts', () => {
+    expect(jsString('São Paulo')).toBe('S\\u00e3o Paulo');
+    expect(jsString('não')).toBe('n\\u00e3o');
+  });
+
+  it('jsStringLiteral wraps the escaped value in double quotes', () => {
+    expect(jsStringLiteral('Photorealistic, highly detailed skyline')).toBe(
+      '"Photorealistic, highly detailed skyline"'
+    );
+    expect(jsStringLiteral('say "hi"')).toBe('"say \\"hi\\""');
+    expect(jsStringLiteral('São')).toBe('"S\\u00e3o"');
+    // eslint-disable-next-line no-eval
+    expect(eval(jsStringLiteral('São Paulo — "skyline"'))).toBe('São Paulo — "skyline"');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #29 — addresses all five bugs/friction points reported from real-world compositing use.

- Map `photoshop_set_layer_blend_mode` `COLOR` to ExtendScript `BlendMode.COLORBLEND`; Darker/Lighter Color fall back to Action Manager
- Fix `photoshop_apply_layer_style` drop shadow (and other styles) `putObject` class-id argument; drop shadow no longer sets locale-specific "Linear" contour name
- Treat `photoshop_place_image` `x`/`y` as absolute canvas top-left; fail instead of silently skipping translate on error
- `photoshop_recipe_remove_background` falls back to Color Range on uniform/high-key studio backgrounds (`details.method`); writes both Lab min and max
- Optional `document_id` on mutating tools pins edits to a document from `get_state` / `list_documents`

Fixes #31 — generative free-text prompts were spliced into JSX without string delimiters.

- Wrap `photoshop_generative_fill` / `expand` / `generate_image` (and sky path) prompts via `jsStringLiteral`
- `\uXXXX`-escape non-ASCII so Windows `cscript`/ANSI codepages cannot mangle characters like `São`

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build:server` passes
- [x] `npm run test:unit` passes
- [ ] `COLOR` blend mode works in Photoshop
- [ ] Drop shadow applies without error
- [ ] `place_image` places at expected absolute coordinates
- [ ] Studio BG remove background uses Color Range fallback
- [ ] `document_id` prevents edits to wrong document after active-doc switch
- [ ] Multi-word `photoshop_generative_fill` prompt (commas, spaces, non-ASCII) succeeds instead of `Expected: )`