### PR TITLE
fix(macos): apply detected app name before the first script runs

### DIFF
--- a/src/platform/connection.ts
+++ b/src/platform/connection.ts
@@ -80,12 +80,8 @@ export class PhotoshopConnection {
         this.photoshopInfo = await this.detector.detect();
       }
 
-      // Set app name for macOS executor
-      if (this.macosExecutor && this.photoshopInfo.appName) {
-        this.macosExecutor.setAppName(this.photoshopInfo.appName);
-      }
-
       const executor = this.getExecutor();
+      this.applyMacOSAppName();
 
       // Check if Photoshop is running, launch if needed
       const isRunning = await executor.isPhotoshopRunning();
@@ -113,10 +109,25 @@ export class PhotoshopConnection {
     }
 
     const executor = this.getExecutor();
+    this.applyMacOSAppName();
     const isRunning = await executor.isPhotoshopRunning();
     if (!isRunning) {
       this.logger.info('Launching Photoshop...');
       await executor.launchPhotoshop(this.photoshopInfo.path);
+    }
+  }
+
+  /**
+   * Point the macOS executor at the detected app bundle name. Must run after
+   * getExecutor(): the executor is created lazily, and before this ordering fix
+   * the first script of every session ran against the hard-coded default
+   * ("Adobe Photoshop 2025"), so on any other version pgrep reported Photoshop
+   * as not running, launchPhotoshop() stole focus for 5s, and osascript failed
+   * to compile `do javascript` (-2741) because the app name did not resolve.
+   */
+  private applyMacOSAppName(): void {
+    if (this.macosExecutor && this.photoshopInfo?.appName) {
+      this.macosExecutor.setAppName(this.photoshopInfo.appName);
     }
   }
 }

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, platform: () => 'darwin' };
+});
+
+vi.mock('../src/platform/detector.js', () => ({
+  PhotoshopDetector: class {
+    async detect() {
+      return {
+        version: '27.9.1',
+        path: '/Applications/Adobe Photoshop 2026/Adobe Photoshop 2026.app',
+        isRunning: true,
+        appName: 'Adobe Photoshop 2026',
+      };
+    }
+  },
+}));
+
+import { MacOSExecutor } from '../src/platform/macos-executor.js';
+import { PhotoshopConnection } from '../src/platform/connection.js';
+
+const appNameOf = (executor: MacOSExecutor) =>
+  (executor as unknown as { appName: string }).appName;
+
+describe('PhotoshopConnection on macOS', () => {
+  const seenAppNames: string[] = [];
+
+  beforeEach(() => {
+    seenAppNames.length = 0;
+    vi.spyOn(MacOSExecutor.prototype, 'isPhotoshopRunning').mockImplementation(async function (
+      this: MacOSExecutor
+    ) {
+      seenAppNames.push(appNameOf(this));
+      return true;
+    });
+    vi.spyOn(MacOSExecutor.prototype, 'execute').mockImplementation(async function (
+      this: MacOSExecutor
+    ) {
+      seenAppNames.push(appNameOf(this));
+      return 'ok';
+    });
+  });
+
+  it('applies the detected app name before the very first script runs', async () => {
+    // Regression: the executor is created lazily, and setAppName used to run
+    // before getExecutor(), so the first call of every session targeted the
+    // hard-coded "Adobe Photoshop 2025" and failed on any other version.
+    const connection = new PhotoshopConnection();
+    await connection.executeScript('app.version');
+    expect(seenAppNames).toEqual(['Adobe Photoshop 2026', 'Adobe Photoshop 2026']);
+  });
+
+  it('applies the detected app name in ensurePhotoshopRunning', async () => {
+    const connection = new PhotoshopConnection();
+    await connection.ensurePhotoshopRunning();
+    expect(seenAppNames).toEqual(['Adobe Photoshop 2026']);
+  });
+});


### PR DESCRIPTION
## Summary

On macOS, the first script of every server session fails when the installed Photoshop is not exactly "Adobe Photoshop 2025".

`PhotoshopConnection.executeScript()` (and `ensurePhotoshopRunning()`) called `this.macosExecutor.setAppName(...)` **before** `getExecutor()`, but the executor is created lazily inside `getExecutor()`. So on the first call `this.macosExecutor` is still `undefined`, the name is never applied, and the executor runs with its hard-coded default `'Adobe Photoshop 2025'`. From the second call on, the executor exists and the name is applied, which made the bug look like flakiness.

With Photoshop 2026 (27.9.1) this is what every new session did on its first `photoshop_*` tool call:

1. `isPhotoshopRunning()` ran `pgrep -f "Adobe Photoshop 2025"` → no match → `Photoshop not running, launching...`
2. `launchPhotoshop()` ran `open -a` on the (already running) app, stole focus, and waited 5 s.
3. `osascript` compiled `tell application "Adobe Photoshop 2025"` → no such app → Photoshop terminology not loaded → `do javascript` failed with `script error: Expected end of line but found identifier. (-2741)` (localized on non-English systems, e.g. `Esperava-se final de linha, encontrou-se identificador`).

The MCP client only sees `{ "ok": false, "code": "unknown", "message": "Command failed: osascript ..." }`, so agents retry and the second call works.

## Fix

Create the executor first, then apply the detected app name, in both code paths (`applyMacOSAppName()` helper).

## Test plan

- [x] `npm run lint`, `npm run build:server`, `npm run verify:photoshop-prompts`, `npm run test:unit`
- [x] New `tests/connection.test.ts` fails on `master` (`expected [ 'Adobe Photoshop 2025', … ] to deeply equal [ 'Adobe Photoshop 2026', … ]`) and passes with this change
- [x] macOS 26 / Photoshop 2026 (27.9.1), pt-BR system: first `photoshop_get_state` of a fresh server now returns in ~250 ms with no launch/focus steal, previously failed after ~5 s with -2741
- [x] End-to-end on the same setup: `create_document` → `fill_layer` → `create_text_layer` → `get_layers` → `get_preview` → `export_as` → `close_document`
